### PR TITLE
fix: run deployment preflight through protected helper

### DIFF
--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -40,6 +40,7 @@ jobs:
       DEPLOY_APP_ROOT: ${{ vars.DEPLOY_APP_ROOT }}
       DEPLOY_RUN_USER: ${{ vars.DEPLOY_RUN_USER || 'arkinfra' }}
       DEPLOY_INTERNAL_PORT: ${{ vars.DEPLOY_INTERNAL_PORT }}
+      DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
       PREFLIGHT_MODE: ${{ inputs.mode }}
       DEPLOY_PREPARE_HELPER_CONTRACT: "2"
       DEPLOY_RELEASE_HELPER_CONTRACT: "2"
@@ -115,11 +116,11 @@ jobs:
 
           timeout --kill-after=10s 60s ssh "${ssh_options[@]}" \
             "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
-            bash -s -- "$DEPLOY_APP_ROOT" "$DEPLOY_RUN_USER" "$PREFLIGHT_MODE" <<'REMOTE'
+            bash -s -- "$DEPLOY_APP_ROOT" "$PREFLIGHT_MODE" "$DEPLOY_ENVIRONMENT" <<'REMOTE'
           set -euo pipefail
           app_root="$1"
-          run_user="$2"
-          preflight_mode="$3"
+          preflight_mode="$2"
+          deployment_environment="$3"
           cache_repository="/var/cache/arknights-infra-deploy/repository.git"
           expected_origin="https://github.com/KnightCodeSquareMatrix/RIIC-Web.git"
           cutover_ready=0
@@ -143,88 +144,18 @@ jobs:
             test "$public_cache_ready" = "1"
           fi
 
-          current_release="$(readlink -f "$app_root/current")"
-          case "$current_release" in
-            "$app_root"/releases/*) ;;
-            *) exit 1 ;;
-          esac
-          current_solver="$current_release/bin/infra-cli"
-          test -f "$current_solver"
-          test ! -L "$current_solver"
-
-          trusted_solver="$app_root/shared/bin/infra-cli"
-          expected_digest_file="$app_root/shared/bin/infra-cli.sha256"
-          solver="$current_solver"
-          solver_source="current-release"
           if [[ "$cutover_ready" == "1" ]]; then
-            test -d "$app_root/shared/bin"
-            test ! -L "$app_root/shared/bin"
-            test "$(stat -c '%U:%G:%a' -- "$app_root/shared/bin")" = "root:root:755"
-            test -f "$trusted_solver"
-            test ! -L "$trusted_solver"
-            test "$(stat -c '%U:%G:%a' -- "$trusted_solver")" = "root:root:755"
-            test -f "$expected_digest_file"
-            test ! -L "$expected_digest_file"
-            test "$(stat -c '%U:%G:%a' -- "$expected_digest_file")" = "root:root:644"
-            expected_solver_sha256="$(awk 'NR == 1 { value = $0 } END { if (NR != 1) exit 1; print value }' "$expected_digest_file")"
-            [[ "$expected_solver_sha256" =~ ^[0-9a-f]{64}$ ]]
-            solver="$trusted_solver"
-            solver_source="shared"
-          fi
-          solver_owner="$(stat -c '%U' -- "$solver")"
-          solver_mode="$(stat -c '%a' -- "$solver")"
-          (( (8#$solver_mode & 0111) != 0 ))
-          solver_sha256="$(sha256sum -- "$solver" | cut -d ' ' -f 1)"
-          if [[ "$cutover_ready" == "1" ]]; then
-            test "$solver_sha256" = "$expected_solver_sha256"
-            test -f "$current_release/.env.production.local"
-            test ! -L "$current_release/.env.production.local"
-            configured_solver_sha256="$(awk -F= '$1 == "INFRA_CLI_EXPECTED_SHA256" { count += 1; value = $2 } END { if (count != 1) exit 1; print value }' "$current_release/.env.production.local")"
-            test "$configured_solver_sha256" = "$expected_solver_sha256"
+            sudo -n /usr/local/sbin/arknights-infra-deploy \
+              --preflight "$deployment_environment" "$app_root"
           else
-            expected_solver_sha256="$solver_sha256"
+            available_kib="$(df -Pk "$app_root" | awk 'NR == 2 { print $4 }')"
+            [[ "$available_kib" =~ ^[0-9]+$ ]]
+            (( available_kib >= 2097152 ))
+            printf 'solver_source=not-inspected-root-only\n'
+            printf 'available_kib=%s\n' "$available_kib"
           fi
-
-          worker_ping="$(printf '%s\n' '{"id":"deployment-preflight","method":"ping"}' \
-            | timeout --kill-after=2s 10s "$solver" serve)"
-          worker_metadata="$(printf '%s' "$worker_ping" | node -e '
-            let input = "";
-            process.stdin.on("data", (chunk) => input += chunk);
-            process.stdin.on("end", () => {
-              const lines = input.split(/\r?\n/u).filter((line) => line.trim());
-              if (lines.length !== 1) process.exit(1);
-              const response = JSON.parse(lines[0]);
-              const result = response?.result;
-              const schemaReady = Array.isArray(result?.supported_plan_schema_versions)
-                && result.supported_plan_schema_versions.includes(3);
-              const contract = result?.plan_contract_sha256 ?? "none";
-              process.stdout.write([
-                response?.ok === true ? "ok" : "invalid",
-                String(result?.protocol_version ?? ""),
-                schemaReady ? "schema-ready" : "schema-invalid",
-                String(result?.solver_executable_sha256 ?? ""),
-                String(contract),
-              ].join(" "));
-            });
-          ')"
-          read -r worker_ok worker_protocol worker_schema worker_sha256 worker_contract_sha256 <<<"$worker_metadata"
-          test "$worker_ok" = "ok"
-          test "$worker_protocol" = "1"
-          test "$worker_schema" = "schema-ready"
-          test "$worker_sha256" = "$expected_solver_sha256"
-          if [[ "$worker_contract_sha256" != "none" ]]; then
-            [[ "$worker_contract_sha256" =~ ^[0-9a-f]{64}$ ]]
-          fi
-
-          available_kib="$(df -Pk "$app_root" | awk 'NR == 2 { print $4 }')"
-          [[ "$available_kib" =~ ^[0-9]+$ ]]
-          (( available_kib >= 2097152 ))
-
-          printf 'preflight_mode=%s cache_public_origin_ready=%s\n' "$preflight_mode" "$public_cache_ready"
-          printf 'solver_source=%s\n' "$solver_source"
-          printf 'solver_owner=%s solver_mode=%s solver_sha256=%s worker_protocol=%s worker_schema=%s worker_contract_sha256=%s\n' \
-            "$solver_owner" "$solver_mode" "$solver_sha256" "$worker_protocol" "$worker_schema" "$worker_contract_sha256"
-          printf 'available_kib=%s\n' "$available_kib"
+          printf 'preflight_mode=%s cache_public_origin_ready=%s\n' \
+            "$preflight_mode" "$public_cache_ready"
           REMOTE
 
           {

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -105,10 +105,11 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(preflightWorkflow, /Preflight is read-only: no archive, release directory, symlink switch, or service restart was requested/);
   assert.match(preflightWorkflow, /mode:[\s\S]+baseline[\s\S]+cutover-ready/);
   assert.match(preflightWorkflow, /PREFLIGHT_MODE: \$\{\{ inputs\.mode \}\}/);
+  assert.match(preflightWorkflow, /DEPLOY_ENVIRONMENT: \$\{\{ inputs\.environment \}\}/);
   assert.match(preflightWorkflow, /if \[\[ "\$PREFLIGHT_MODE" == "cutover-ready" \]\][\s\S]+test "\$actual_contract" = "\$expected_contract"/);
-  assert.match(preflightWorkflow, /expected_digest_file="\$app_root\/shared\/bin\/infra-cli\.sha256"/);
-  assert.match(preflightWorkflow, /test "\$solver_sha256" = "\$expected_solver_sha256"/);
-  assert.match(preflightWorkflow, /supported_plan_schema_versions[\s\S]+worker_sha256[\s\S]+expected_solver_sha256/);
+  assert.match(preflightWorkflow, /sudo -n \/usr\/local\/sbin\/arknights-infra-deploy[\s\S]+--preflight "\$deployment_environment" "\$app_root"/);
+  assert.match(preflightWorkflow, /solver_source=not-inspected-root-only/);
+  assert.doesNotMatch(preflightWorkflow, /current_release\/\.env\.production\.local|current_release="\$\(readlink/);
   assert.match(deployWorkflow, /printf '%s\\n' "\$DEPLOY_PUBLIC_HEALTH_URL" \| ssh[\s\S]+'\$public_health_argument'/);
   assert.doesNotMatch(deployWorkflow, /'\$DEPLOY_PUBLIC_HEALTH_URL'/);
   assert.match(deployWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);


### PR DESCRIPTION
Moves root-only release, environment snapshot, and solver inspection behind the existing restricted deployment helper. Baseline mode remains read-only and does not inspect protected runtime files. Local repository hygiene, lint, unit/API tests, scope tests, and security audit passed. Deployment automation remains disabled.