### PR TITLE
chore: activate public deployment source marker

### DIFF
--- a/deploy/PUBLIC_DEPLOYMENT_SOURCE
+++ b/deploy/PUBLIC_DEPLOYMENT_SOURCE
@@ -1,1 +1,1 @@
-pending-public-cutover
+public-automation-v1


### PR DESCRIPTION
## Summary

- mark the public repository as the sole intended deployment source
- keep both repository automation switches disabled during the cutover
- trigger the deploy-required quality path without deploying

## Verification

- development helper v4 cutover-ready preflight passed
- change-scope tests 7/7
- public repository hygiene passed
- git diff --check