### PR TITLE
fix(deploy): keep runtime cache out of release archive

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -49,7 +49,7 @@ test("production builds prepare a solver-free standalone runtime with static ass
   assert.match(stageStandalone, /\["bin\/infra-cli", "infra-cli"\]/);
   assert.match(stageStandalone, /\["\.env\.production\.local", "\.env\.production\.local"\]/);
   assert.match(stageStandalone, /dereference: true/);
-  assert.match(stageStandalone, /outputRoot, "\.next", "cache"/);
+  assert.doesNotMatch(stageStandalone, /outputRoot, "\.next", "cache"/);
 });
 
 test("Next.js owns graceful shutdown while systemd accepts its signal exit statuses", async () => {

--- a/scripts/stage-standalone-release.mjs
+++ b/scripts/stage-standalone-release.mjs
@@ -65,7 +65,7 @@ for (const [relativePath, displayName] of forbiddenBuildEntries) {
 }
 
 await mkdir(path.join(outputRoot, "scripts"), { recursive: true });
-await mkdir(path.join(outputRoot, ".next", "cache"), { recursive: true });
+await mkdir(path.join(outputRoot, ".next"), { recursive: true });
 await copyFile(path.join(repoRoot, "package.json"), path.join(outputRoot, "package.json"));
 await copyFile(
   path.join(repoRoot, "scripts", "start-standalone.mjs"),
@@ -85,7 +85,6 @@ await writeFile(path.join(outputRoot, ".release-artifact.json"), `${JSON.stringi
 }, null, 2)}\n`, "utf8");
 
 assert.equal(await lstat(path.join(outputRoot, ".next", "standalone", "server.js")).then((entry) => entry.isFile()), true);
-assert.equal(await lstat(path.join(outputRoot, ".next", "cache")).then((entry) => entry.isDirectory()), true);
 for (const forbiddenRootEntry of ["node_modules", "bin"]) {
   try {
     await lstat(path.join(outputRoot, forbiddenRootEntry));


### PR DESCRIPTION
## P0 production deployment fix

- keep the server-owned `.next/cache` directory out of the standalone release archive
- restore staging of the `.next` parent only
- add a regression assertion for the helper contract

The production deploy helper creates both runtime cache directories with the service account permissions during atomic activation. Including the directory in the archive is rejected by contract v4.

Validation: `node --test scripts/build-tooling.test.mjs` (16/16 passed).