### PR TITLE
feat: 管理端折叠展示完整求解器指纹

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -17,7 +17,7 @@ export default async function AdminUsersPage() {
   return (
     <AdminUsers
       plannerReady={Boolean(health.ok && health.cliReady)}
-      solverFingerprint={health.serve?.planCompute?.solverExecutableSha256 ?? null}
+      solverFingerprint={health.serve?.fingerprint ?? null}
     />
   );
 }

--- a/src/app/admin/users/users-client.tsx
+++ b/src/app/admin/users/users-client.tsx
@@ -1,22 +1,34 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogBody, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import type { AdminSessionData, AdminUserAction, AdminUserData } from "@/types";
+import type { AdminSessionData, AdminUserAction, AdminUserData, SolverPingFingerprint } from "@/types";
 
 const CLIENT_SKLAND_ENABLED = process.env.APP_CLIENT_SKLAND_ENABLED === "1";
 
 type RoleChange = { userId: string; name: string; email: string; action: "grantAdmin" | "revokeAdmin" };
+
+function FingerprintValue({ value, dataAttribute }: { value: string | number | null; dataAttribute?: string }) {
+  return (
+    <code
+      className="mt-1 block break-all font-mono text-xs leading-5 text-foreground"
+      {...(dataAttribute ? { [dataAttribute]: value ?? "unavailable" } : {})}
+    >
+      {value ?? "未返回"}
+    </code>
+  );
+}
 
 export function AdminUsers({
   plannerReady,
   solverFingerprint,
 }: {
   plannerReady: boolean;
-  solverFingerprint: string | null;
+  solverFingerprint: SolverPingFingerprint | null;
 }) {
   const [users, setUsers] = useState<AdminUserData[]>([]);
   const [canManageAdminRoles, setCanManageAdminRoles] = useState<boolean | null>(null);
@@ -26,6 +38,7 @@ export function AdminUsers({
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [roleChange, setRoleChange] = useState<RoleChange | null>(null);
   const [sessionsByUser, setSessionsByUser] = useState<Record<string, AdminSessionData[] | undefined>>({});
+  const executableSha256 = solverFingerprint?.solverExecutableSha256 ?? null;
 
   const load = useCallback(async (search: string) => {
     setLoading(true);
@@ -116,10 +129,98 @@ export function AdminUsers({
         <p className="mt-4 text-xs text-muted-foreground">Linux ELF SHA-256</p>
         <code
           className="mt-1 block break-all rounded-lg bg-muted/50 px-3 py-2 font-mono text-xs leading-5"
-          data-solver-fingerprint={solverFingerprint ?? "unavailable"}
+          data-solver-fingerprint={executableSha256 ?? "unavailable"}
         >
-          {solverFingerprint ?? "Worker 未返回有效指纹"}
+          {executableSha256 ?? "Worker 未返回有效指纹"}
         </code>
+
+        <details className="group mt-3 border-t pt-2" data-solver-fingerprint-details>
+          <summary className="flex min-h-11 cursor-pointer list-none items-center justify-between gap-4 rounded-lg px-2 text-sm outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring [&::-webkit-details-marker]:hidden">
+            <span>
+              <span className="block font-medium">完整 Worker 指纹</span>
+              <span className="mt-0.5 block text-xs text-muted-foreground">构建身份、协议能力与各版本契约</span>
+            </span>
+            <span className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+              <span className="group-open:hidden">展开</span>
+              <span className="hidden group-open:inline">收起</span>
+              <ChevronDown aria-hidden="true" className="size-4 transition-transform duration-200 group-open:rotate-180" />
+            </span>
+          </summary>
+
+          <div className="grid gap-5 px-2 pb-2 pt-4">
+            <div>
+              <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">构建身份</h3>
+              <dl className="mt-2 grid gap-x-6 gap-y-3 sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs text-muted-foreground">solver.git_commit</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.envelopeSolverGitCommit ?? null} dataAttribute="data-solver-envelope-git-commit" /></dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">solver.built_at</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.envelopeSolverBuiltAt ?? null} /></dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">result.solver_git_commit</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.solverGitCommit ?? null} dataAttribute="data-solver-git-commit" /></dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">result.solver_built_at</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.solverBuiltAt ?? null} /></dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="border-t pt-4">
+              <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">协议能力</h3>
+              <dl className="mt-2 grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
+                <div>
+                  <dt className="text-xs text-muted-foreground">pong</dt>
+                  <dd className="mt-1 text-sm font-medium">{solverFingerprint ? String(solverFingerprint.pong) : "未返回"}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">elapsed_ms</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.elapsedMs ?? null} /></dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">protocol_version</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.protocolVersion ?? null} /></dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-muted-foreground">plan_schema_version</dt>
+                  <dd><FingerprintValue value={solverFingerprint?.planSchemaVersion ?? null} /></dd>
+                </div>
+              </dl>
+              <p className="mt-3 text-xs text-muted-foreground">supported_plan_schema_versions</p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {solverFingerprint?.supportedPlanSchemaVersions.length
+                  ? solverFingerprint.supportedPlanSchemaVersions.map((version) => (
+                    <code key={version} className="rounded-md bg-muted px-2 py-1 font-mono text-xs">v{version}</code>
+                  ))
+                  : <span className="text-xs text-muted-foreground">未返回</span>}
+              </div>
+            </div>
+
+            <div className="border-t pt-4">
+              <h3 className="text-xs font-medium uppercase tracking-wider text-muted-foreground">计划契约</h3>
+              <p className="mt-2 text-xs text-muted-foreground">plan_contract_sha256</p>
+              <FingerprintValue value={solverFingerprint?.planContractSha256 ?? null} dataAttribute="data-plan-contract-sha256" />
+              <div className="mt-3 overflow-hidden rounded-lg border">
+                {solverFingerprint?.planContractSha256ByVersion.length
+                  ? solverFingerprint.planContractSha256ByVersion.map(({ version, sha256 }, index) => (
+                    <div
+                      key={version}
+                      className={`grid grid-cols-[auto_1fr] gap-3 px-3 py-2.5 ${index ? "border-t" : ""}`}
+                      data-plan-contract-version={version}
+                    >
+                      <span className="text-xs font-medium text-muted-foreground">v{version}</span>
+                      <code className="min-w-0 break-all text-right font-mono text-xs leading-5">{sha256}</code>
+                    </div>
+                  ))
+                  : <p className="px-3 py-2.5 text-xs text-muted-foreground">Worker 未返回按版本划分的契约指纹。</p>}
+              </div>
+            </div>
+          </div>
+        </details>
       </section>
 
       <form

--- a/src/server/infra.ts
+++ b/src/server/infra.ts
@@ -23,6 +23,7 @@ import {
   createPlanComputeParams,
   createSolverObservation,
   inspectPlanComputeCapability,
+  inspectSolverPingFingerprint,
   inspectSolverDeploymentReadiness,
   parsePlanComputePayload,
   solverObservationFromPlanRecord,
@@ -569,6 +570,7 @@ export async function getHealth(): Promise<HealthApiResponse> {
       try {
         const pingResult = await healthServeClient.ping();
         const planCompute = inspectPlanComputeCapability(pingResult.response);
+        const fingerprint = inspectSolverPingFingerprint(pingResult.response);
         const deploymentReadiness = inspectSolverDeploymentReadiness(
           planCompute,
           process.env.INFRA_CLI_EXPECTED_SHA256
@@ -577,6 +579,7 @@ export async function getHealth(): Promise<HealthApiResponse> {
           ...healthServeClient.info(),
           protocolMode: planCompute.supported ? "plan.compute" : "legacy",
           planCompute,
+          fingerprint,
         };
         if (!deploymentReadiness.ready) {
           serveError = deploymentReadiness.reason;

--- a/src/server/plan-protocol.test.ts
+++ b/src/server/plan-protocol.test.ts
@@ -6,10 +6,58 @@ import {
   createPlanComputeParams,
   createSolverObservation,
   inspectPlanComputeCapability,
+  inspectSolverPingFingerprint,
   inspectSolverDeploymentReadiness,
   parsePlanComputePayload,
   solverObservationFromPlanRecord,
 } from "./plan-protocol.ts";
+
+test("normalizes the complete allowlisted Worker ping fingerprint", () => {
+  const contracts = {
+    "1": "a".repeat(64),
+    "2": "b".repeat(64),
+    "4": "d".repeat(64),
+  };
+  const fingerprint = inspectSolverPingFingerprint({
+    id: 1,
+    ok: true,
+    elapsed_ms: 7,
+    solver: {
+      git_commit: "1".repeat(40),
+      built_at: "2026-08-31T04:34:00Z",
+    },
+    result: {
+      pong: true,
+      protocol_version: 1,
+      plan_schema_version: 1,
+      supported_plan_schema_versions: [1, 2, 3, 4],
+      plan_contract_sha256: contracts["1"],
+      plan_contract_sha256_by_version: { ...contracts, invalid: "e".repeat(64), "3": "invalid" },
+      solver_executable_sha256: "f".repeat(64),
+      solver_git_commit: "2".repeat(40),
+      solver_built_at: "2026-08-31T04:34:00Z",
+    },
+  });
+
+  assert.deepEqual(fingerprint, {
+    elapsedMs: 7,
+    envelopeSolverGitCommit: "1".repeat(40),
+    envelopeSolverBuiltAt: "2026-08-31T04:34:00Z",
+    pong: true,
+    protocolVersion: 1,
+    planSchemaVersion: 1,
+    supportedPlanSchemaVersions: [1, 2, 3, 4],
+    planContractSha256: contracts["1"],
+    planContractSha256ByVersion: [
+      { version: 1, sha256: contracts["1"] },
+      { version: 2, sha256: contracts["2"] },
+      { version: 4, sha256: contracts["4"] },
+    ],
+    solverExecutableSha256: "f".repeat(64),
+    solverGitCommit: "2".repeat(40),
+    solverBuiltAt: "2026-08-31T04:34:00Z",
+  });
+});
 
 test("uses plan.compute for matching versions regardless of schema byte hash", () => {
   const contractHashes = [

--- a/src/server/plan-protocol.ts
+++ b/src/server/plan-protocol.ts
@@ -5,6 +5,7 @@ import type {
   PlanComputeParams,
   RotationProfile,
   SolverObservation,
+  SolverPingFingerprint,
   TrainingAdviceReport,
   TrainingRoomSchedule,
 } from "../types";
@@ -17,6 +18,7 @@ export const PLAN_PROTOCOL_VERSION = 1;
 export const PLAN_SCHEMA_VERSION = 3;
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+const GIT_COMMIT_PATTERN = /^[0-9a-f]{40}$/;
 
 export type PlanComputeCapability = {
   supported: boolean;
@@ -74,16 +76,61 @@ export function normalizeSha256(value: unknown): string | null {
   return typeof value === "string" && SHA256_PATTERN.test(value) ? value : null;
 }
 
+function normalizeGitCommit(value: unknown): string | null {
+  return typeof value === "string" && GIT_COMMIT_PATTERN.test(value) ? value : null;
+}
+
+function normalizeTimestamp(value: unknown): string | null {
+  return typeof value === "string" && Number.isFinite(Date.parse(value)) ? value : null;
+}
+
+function inspectContractSha256ByVersion(value: unknown): SolverPingFingerprint["planContractSha256ByVersion"] {
+  if (!isProtocolRecord(value)) return [];
+
+  return Object.entries(value)
+    .flatMap(([rawVersion, rawSha256]) => {
+      const version = Number(rawVersion);
+      const sha256 = normalizeSha256(rawSha256);
+      return Number.isSafeInteger(version) && version > 0 && String(version) === rawVersion && sha256
+        ? [{ version, sha256 }]
+        : [];
+    })
+    .sort((left, right) => left.version - right.version);
+}
+
+export function inspectSolverPingFingerprint(response: unknown): SolverPingFingerprint {
+  const envelope = isProtocolRecord(response) ? response : {};
+  const solver = isProtocolRecord(envelope.solver) ? envelope.solver : {};
+  const result = isProtocolRecord(envelope.result) ? envelope.result : {};
+
+  return {
+    elapsedMs: typeof envelope.elapsed_ms === "number" && Number.isFinite(envelope.elapsed_ms) && envelope.elapsed_ms >= 0
+      ? envelope.elapsed_ms
+      : null,
+    envelopeSolverGitCommit: normalizeGitCommit(solver.git_commit),
+    envelopeSolverBuiltAt: normalizeTimestamp(solver.built_at),
+    pong: result.pong === true,
+    protocolVersion: Number.isInteger(result.protocol_version) ? result.protocol_version as number : null,
+    planSchemaVersion: Number.isInteger(result.plan_schema_version) ? result.plan_schema_version as number : null,
+    supportedPlanSchemaVersions: Array.isArray(result.supported_plan_schema_versions)
+      ? result.supported_plan_schema_versions.filter((version): version is number => Number.isInteger(version))
+      : [],
+    planContractSha256: normalizeSha256(result.plan_contract_sha256),
+    planContractSha256ByVersion: inspectContractSha256ByVersion(result.plan_contract_sha256_by_version),
+    solverExecutableSha256: normalizeSha256(result.solver_executable_sha256),
+    solverGitCommit: normalizeGitCommit(result.solver_git_commit),
+    solverBuiltAt: normalizeTimestamp(result.solver_built_at),
+  };
+}
+
 export function inspectPlanComputeCapability(response: unknown): PlanComputeCapability {
   const envelope = isProtocolRecord(response) ? response : {};
-  const result = isProtocolRecord(envelope.result) ? envelope.result : {};
-  const protocolVersion = typeof result.protocol_version === "number" ? result.protocol_version : null;
-  const schemaVersion = typeof result.plan_schema_version === "number" ? result.plan_schema_version : null;
-  const supportedSchemaVersions = Array.isArray(result.supported_plan_schema_versions)
-    ? result.supported_plan_schema_versions.filter((value): value is number => Number.isInteger(value))
-    : [];
-  const contractSha256 = normalizeSha256(result.plan_contract_sha256);
-  const solverExecutableSha256 = normalizeSha256(result.solver_executable_sha256);
+  const fingerprint = inspectSolverPingFingerprint(response);
+  const protocolVersion = fingerprint.protocolVersion;
+  const schemaVersion = fingerprint.planSchemaVersion;
+  const supportedSchemaVersions = fingerprint.supportedPlanSchemaVersions;
+  const contractSha256 = fingerprint.planContractSha256;
+  const solverExecutableSha256 = fingerprint.solverExecutableSha256;
   const base = {
     protocolVersion,
     schemaVersion,

--- a/src/types.ts
+++ b/src/types.ts
@@ -370,6 +370,24 @@ export interface CliCandidate {
   reason: string | null;
 }
 
+export interface SolverPingFingerprint {
+  elapsedMs: number | null;
+  envelopeSolverGitCommit: string | null;
+  envelopeSolverBuiltAt: string | null;
+  pong: boolean;
+  protocolVersion: number | null;
+  planSchemaVersion: number | null;
+  supportedPlanSchemaVersions: number[];
+  planContractSha256: string | null;
+  planContractSha256ByVersion: Array<{
+    version: number;
+    sha256: string;
+  }>;
+  solverExecutableSha256: string | null;
+  solverGitCommit: string | null;
+  solverBuiltAt: string | null;
+}
+
 export interface HealthApiResponse {
   ok: boolean;
   apiReady?: boolean;
@@ -389,6 +407,7 @@ export interface HealthApiResponse {
       solverExecutableSha256: string | null;
       reason: string | null;
     };
+    fingerprint?: SolverPingFingerprint;
   };
   serveError?: string | null;
   candidates?: CliCandidate[];


### PR DESCRIPTION
## 变更

- 管理员用户页保留当前 Linux ELF SHA-256 摘要
- 增加默认收起的“完整 Worker 指纹”详情
- 展示构建提交/时间、ping 状态、协议与 Schema 能力、当前及按版本契约哈希
- 仅向通过服务端管理员鉴权的页面传递严格白名单字段

## 验证

- [x] PR 的 base branch 是 `main`，分支为维护者 `release/**`，并使用 `direct-main-release` 特批标签
- [x] 解析单测通过：`node --test --experimental-strip-types src/server/plan-protocol.test.ts`
- [x] 相关文件 ESLint 通过
- [x] `npm run check:public-repository` 通过
- [x] `npm run build` 通过
- [x] 未包含数据库改动
- [x] 未包含凭据、用户数据、内部文档、服务器 helper、solver 或真实部署信息

## 许可

- [x] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布
- [x] 未引入第三方代码或素材