### PR TITLE
fix: 刷新森空岛登录入口缓存

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -309,6 +309,12 @@ test("workbench views use five prefetched route entries under one persistent lay
   assert.doesNotMatch(sidebar, /\?beta|betaRequested/);
 });
 
+test("the Skland entry is request-rendered so releases cannot retain stale login chunks", async () => {
+  const sklandPage = await readRepoFile("src/app/(workbench)/skland/page.tsx");
+
+  assert.match(sklandPage, /export const dynamic = "force-dynamic"/);
+});
+
 test("the critical calculator board stays initial while the compact view loads on demand", async () => {
   const calculator = await readRepoFile("src/components/pages/InfraCalculator.tsx");
   const calculatorRoute = await readRepoFile("src/components/workbench/CalculatorRoute.tsx");

--- a/src/app/(workbench)/skland/page.tsx
+++ b/src/app/(workbench)/skland/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from "next/navigation";
 
 import { SklandRoute } from "workbench-skland-route";
 
+export const dynamic = "force-dynamic";
+
 export default function Page() {
   if (process.env.APP_CLIENT_SKLAND_ENABLED !== "1") notFound();
   return <SklandRoute />;


### PR DESCRIPTION
## Summary
- 将 `/skland` 改为按请求渲染，避免跨发布复用旧预渲染 HTML 和旧客户端 chunk。
- 增加构建工具回归断言，锁定该入口必须保持动态路由。

## Root cause
线上凭证导入 API 与新静态 chunk 已发布，但裸 `/skland` 仍命中旧的 Next 全路由缓存；带发布版本查询参数的页面会正确加载新客户端。

## Test coverage
- `node --test scripts/build-tooling.test.mjs`：17/17 通过。
- production `npm run build`：通过，路由清单确认 `/skland` 为 `ƒ Dynamic`。

## Pre-landing review
No issues found. No SQL, authentication, data-model, or visual-layout behavior changed.

## Release path
直接合入 `main`，不经过 `develop`；使用 `direct-main-release` 受控标签，其余质量与生产部署门禁保持不变。
## Documentation
已逐一审计仓库内全部 17 个 Markdown 文档与本次 8 行缓存热修；现有 README、森空岛能力说明和运维文档均仍然准确，因此无需修改文档文件。