### PR TITLE
Polish Skland credential login layout

### DIFF
--- a/e2e/production-readiness-skland.spec.ts
+++ b/e2e/production-readiness-skland.spec.ts
@@ -65,6 +65,9 @@ test("Skland login exposes both methods and starts QR only after explicit consen
   await expect(page.getByText("登录凭证只保存在当前浏览器，7 天后失效。")).toBeVisible();
   await expect(page.getByRole("tab", { name: "扫码登录" })).toBeVisible();
   await expect(page.getByRole("tab", { name: "凭证导入" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "登录森空岛账号" })).toHaveCount(0);
+  await expect(page.getByText("登录信息经加密写入 HttpOnly Cookie，并在授权成功 7 天后固定失效。")).toHaveCount(0);
+  await expect(page.locator("[data-skland-auth-copy]")).toHaveCount(0);
   expect(qrStartRequests).toBe(0);
 
   const consentCheckboxes = page.getByRole("checkbox");
@@ -153,16 +156,19 @@ test("credential import explains the risk, gates consent, recovers from errors, 
 
   const credentialPanel = page.locator("[data-skland-credential-panel]");
   await expect(credentialPanel).toBeVisible();
+  const credentialForm = credentialPanel.locator("[data-skland-credential-form]");
+  await expect(credentialForm).toBeVisible();
+  await expect.poll(() => credentialForm.evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   await expect(credentialPanel.getByText("手机端优先使用扫码")).toBeVisible();
   await expect(credentialPanel.locator("ol > li")).toHaveCount(3);
+  await expect(credentialPanel.getByText(/allow pasting.*允许粘贴/)).toBeVisible();
   await expect(credentialPanel.getByText("仓库物资数量", { exact: true })).toBeVisible();
   await expect(credentialPanel.getByText(/本站实际不读取、不保存、不展示仓库数据/)).toBeVisible();
 
   await credentialPanel.getByRole("button", { name: "复制命令" }).click();
   await expect(credentialPanel.getByRole("button", { name: "已复制" })).toBeVisible();
   const copiedCommand = await page.evaluate(() => navigator.clipboard.readText());
-  expect(copiedCommand).toContain('localStorage.getItem("SK_OAUTH_CRED_KEY")');
-  expect(copiedCommand).toContain('localStorage.getItem("SK_TOKEN_CACHE_KEY")');
+  expect(copiedCommand).toBe("copy(localStorage.getItem('SK_OAUTH_CRED_KEY')+','+localStorage.getItem('SK_TOKEN_CACHE_KEY')),console.log('已复制到粘贴板，回到网页粘贴')");
 
   const input = credentialPanel.locator("[data-skland-credential-input]");
   const submit = credentialPanel.locator("[data-skland-credential-submit]");
@@ -279,6 +285,20 @@ test("credential import can add a second Skland account from the account dialog"
 
   const dialog = page.getByRole("dialog", { name: "添加森空岛账号" });
   await dialog.getByRole("tab", { name: "凭证导入" }).click();
+  await expect(dialog).toHaveCSS("width", "960px");
+  const credentialPanel = dialog.locator("[data-skland-credential-panel]");
+  const credentialForm = credentialPanel.locator("[data-skland-credential-form]");
+  const riskNotice = credentialPanel.locator("[data-skland-credential-risk]");
+  const [panelBox, formBox, riskBox] = await Promise.all([
+    credentialPanel.boundingBox(),
+    credentialForm.boundingBox(),
+    riskNotice.boundingBox(),
+  ]);
+  expect(panelBox).not.toBeNull();
+  expect(formBox?.width).toBeCloseTo(768, 0);
+  expect(riskBox?.width).toBeCloseTo(672, 0);
+  expect(Math.abs((formBox?.x ?? 0) + (formBox?.width ?? 0) / 2 - ((panelBox?.x ?? 0) + (panelBox?.width ?? 0) / 2))).toBeLessThanOrEqual(2);
+  expect(Math.abs((riskBox?.x ?? 0) + (riskBox?.width ?? 0) / 2 - ((formBox?.x ?? 0) + (formBox?.width ?? 0) / 2))).toBeLessThanOrEqual(2);
   await dialog.locator("[data-skland-credential-input]").fill(submittedCredential);
   await dialog.getByRole("checkbox").nth(0).check();
   await dialog.getByRole("checkbox").nth(1).check();
@@ -1078,7 +1098,7 @@ test("Skland supports adding, switching, and individually logging out multiple a
   const addAccountDialog = page.getByRole("dialog", { name: "添加森空岛账号" });
   await expect(addAccountDialog).toBeVisible();
   await expectUnifiedDialogTypography(addAccountDialog);
-  await expect(addAccountDialog).toHaveCSS("width", "880px");
+  await expect(addAccountDialog).toHaveCSS("width", "960px");
   await expect(addAccountDialog.locator("[data-skland-login-panel]")).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
   const generateLoginQr = addAccountDialog.getByRole("button", { name: "生成登录二维码" });
   await expectUnifiedDialogAction(generateLoginQr, { width: "196px", height: "46px" });

--- a/src/components/pages/SklandStatus.tsx
+++ b/src/components/pages/SklandStatus.tsx
@@ -1444,7 +1444,7 @@ export function SklandStatus({
         className="min-h-[calc(100dvh-7rem)] place-items-center py-8 sm:py-12"
         data-skland-page
       >
-        <div className="grid w-full max-w-3xl justify-items-center gap-7 text-center">
+        <div className="grid w-full max-w-4xl justify-items-center gap-7 text-center">
           <header className="grid max-w-lg gap-3" data-skland-login-copy>
             <p className="text-xs font-medium tracking-wide text-primary">森空岛状态中心</p>
             <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">{loginTitle}</h2>
@@ -1459,7 +1459,7 @@ export function SklandStatus({
             </Alert>
           ) : null}
           <SklandLoginPanel
-            className="max-w-3xl"
+            className="max-w-4xl"
             configured={configured}
             disabledReason={disabledReason}
             onAuthenticated={onAuthenticated}
@@ -1646,7 +1646,7 @@ export function SklandStatus({
       />
 
       <Dialog open={addAccountOpen} onOpenChange={setAddAccountOpen}>
-        <DialogContent className="max-h-[calc(100dvh-1rem)] grid-rows-[auto_minmax(0,1fr)] sm:max-w-[min(880px,calc(100vw-2rem))]">
+        <DialogContent className="max-h-[calc(100dvh-1rem)] grid-rows-[auto_minmax(0,1fr)] sm:max-w-[min(960px,calc(100vw-2rem))]">
           <DialogHeader>
             <DialogTitle>添加森空岛账号</DialogTitle>
             <DialogDescription>

--- a/src/skland-components.tsx
+++ b/src/skland-components.tsx
@@ -15,7 +15,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { pollSklandQr, startSklandQr, toDisplayError } from "@/api";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Card, CardDescription, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { buildSklandAppOpenUrl } from "@/skland-auth-url";
 import {
@@ -228,26 +228,14 @@ export function SklandLoginPanel({
       )}
       data-skland-login-panel
     >
-      <div className="grid gap-5 px-5 pb-6 pt-5 sm:px-7 sm:pb-7">
-        <div className="flex items-start gap-3" data-skland-auth-copy>
-          <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-            {authMethod === "qr" ? <ScanLine className="size-5" aria-hidden="true" /> : <KeyRound className="size-5" aria-hidden="true" />}
-          </div>
-          <div className="min-w-0">
-            <CardTitle className={dialogPresentation ? "text-lg" : "text-xl"}>登录森空岛账号</CardTitle>
-            <CardDescription className="mt-1 text-pretty leading-6">
-              登录信息经加密写入 HttpOnly Cookie，并在授权成功 7 天后固定失效。
-            </CardDescription>
-          </div>
-        </div>
-
+      <div className="grid gap-6 px-5 py-6 sm:px-8 sm:py-8">
         {!configured ? (
           <Alert>
             <AlertDescription>{disabledReason ?? "当前未开放森空岛登录，可继续使用 MAA 导入。"}</AlertDescription>
           </Alert>
         ) : (
           <div>
-            <div className="grid min-h-11 w-full grid-cols-2 rounded-lg bg-muted p-1 text-muted-foreground" role="tablist" aria-label="森空岛登录方式">
+            <div className="mx-auto grid min-h-11 w-full max-w-xl grid-cols-2 rounded-lg bg-muted p-1 text-muted-foreground" role="tablist" aria-label="森空岛登录方式">
               {(["qr", "credential"] as const).map((method) => (
                 <button
                   key={method}
@@ -333,7 +321,7 @@ export function SklandLoginPanel({
             ) : null}
 
             {authMethod === "credential" ? (
-            <div id={`${authTabsId}-credential-panel`} role="tabpanel" aria-labelledby={`${authTabsId}-credential-tab`} className="mt-4" data-skland-credential-panel>
+            <div id={`${authTabsId}-credential-panel`} role="tabpanel" aria-labelledby={`${authTabsId}-credential-tab`} className="mx-auto mt-5 w-full max-w-3xl" data-skland-credential-panel>
               <SklandCredentialPanel
                 dialogPresentation={dialogPresentation}
                 onAuthenticated={onAuthenticated}

--- a/src/skland-credential-panel.tsx
+++ b/src/skland-credential-panel.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/skland-policy-consent";
 import type { SklandSessionData } from "@/types";
 
-const SKLAND_CREDENTIAL_COPY_COMMAND = 'copy([localStorage.getItem("SK_OAUTH_CRED_KEY"), localStorage.getItem("SK_TOKEN_CACHE_KEY")].join(","))';
+const SKLAND_CREDENTIAL_COPY_COMMAND = "copy(localStorage.getItem('SK_OAUTH_CRED_KEY')+','+localStorage.getItem('SK_TOKEN_CACHE_KEY')),console.log('已复制到粘贴板，回到网页粘贴')";
 
 export function SklandCredentialPanel({
   dialogPresentation,
@@ -79,29 +79,36 @@ export function SklandCredentialPanel({
   }
 
   return (
-    <form className="grid gap-5" onSubmit={(event) => void submitCredential(event)}>
-      <Alert className="md:hidden">
+    <form
+      className="mx-auto grid w-full max-w-3xl justify-items-center gap-7"
+      onSubmit={(event) => void submitCredential(event)}
+      data-skland-credential-form
+    >
+      <Alert className="w-full text-start md:hidden">
         <ScanLine />
         <AlertTitle>手机端优先使用扫码</AlertTitle>
         <AlertDescription>凭证导入需要桌面浏览器的开发者工具，手机上建议切回“扫码登录”。</AlertDescription>
       </Alert>
 
-      <ol className="grid gap-4 text-sm leading-6">
-        <li className="grid grid-cols-[1.75rem_minmax(0,1fr)] gap-3">
-          <span className="font-number grid size-7 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">1</span>
-          <div>
+      <ol className="grid w-full gap-6 text-sm leading-6" data-skland-credential-workflow>
+        <li className="grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-4 text-start">
+          <span className="font-number grid size-8 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">1</span>
+          <div className="min-w-0">
             <p className="font-medium text-foreground">登录森空岛网页版</p>
             <p className="text-muted-foreground">打开 <a className="font-medium text-foreground underline underline-offset-4" href="https://www.skland.com/index" target="_blank" rel="noreferrer">www.skland.com/index</a> 并完成登录。</p>
           </div>
         </li>
-        <li className="grid grid-cols-[1.75rem_minmax(0,1fr)] gap-3">
-          <span className="font-number grid size-7 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">2</span>
+        <li className="grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-4 text-start">
+          <span className="font-number grid size-8 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">2</span>
           <div className="min-w-0">
             <p className="font-medium text-foreground">在 F12 Console 执行命令</p>
             <p className="text-muted-foreground">打开开发者工具的 Console，将下方命令粘贴并执行。它只读取森空岛页面已有的 cred 与 token，并复制为一行。</p>
-            <div className="mt-2 flex min-w-0 items-stretch gap-2">
-              <code className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap rounded-lg bg-muted px-3 py-2 font-number text-xs text-foreground" title={SKLAND_CREDENTIAL_COPY_COMMAND}>{SKLAND_CREDENTIAL_COPY_COMMAND}</code>
-              <Button type="button" variant="outline" size="sm" onClick={() => void copyCredentialCommand()} data-skland-copy-command>
+            <p className="mt-2 text-xs leading-5 text-amber-700 dark:text-amber-400">
+              如果 Console 阻止粘贴，请先输入 <span className="font-number font-medium">allow pasting</span> 或 <span className="font-medium">允许粘贴</span>，按回车后再粘贴命令。
+            </p>
+            <div className="mt-3 flex min-w-0 flex-col items-stretch gap-2 sm:flex-row">
+              <code className="flex min-h-10 min-w-0 flex-1 items-center overflow-hidden text-ellipsis whitespace-nowrap rounded-lg bg-muted px-3 py-2 font-number text-xs text-foreground" title={SKLAND_CREDENTIAL_COPY_COMMAND}>{SKLAND_CREDENTIAL_COPY_COMMAND}</code>
+              <Button className="sm:shrink-0" type="button" variant="outline" size="sm" onClick={() => void copyCredentialCommand()} data-skland-copy-command>
                 {copyState === "copied" ? <Check /> : <Clipboard />}
                 {copyState === "copied" ? "已复制" : "复制命令"}
               </Button>
@@ -109,9 +116,9 @@ export function SklandCredentialPanel({
             {copyState === "error" ? <p className="mt-1 text-xs text-destructive">复制失败，请手动选择命令复制。</p> : null}
           </div>
         </li>
-        <li className="grid grid-cols-[1.75rem_minmax(0,1fr)] gap-3">
-          <span className="font-number grid size-7 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">3</span>
-          <div>
+        <li className="grid grid-cols-[2rem_minmax(0,1fr)] items-start gap-4 text-start">
+          <span className="font-number grid size-8 place-items-center rounded-full bg-foreground text-xs font-semibold text-background">3</span>
+          <div className="min-w-0">
             <label className="font-medium text-foreground" htmlFor={credentialInputId}>粘贴生成的单行凭证</label>
             <p className="text-muted-foreground">内容应为 <span className="font-number">cred,token</span>，仅在本次请求和当前组件内存中短暂存在。</p>
             <Input
@@ -125,7 +132,7 @@ export function SklandCredentialPanel({
               autoCorrect="off"
               spellCheck={false}
               maxLength={12 * 1024}
-              className="mt-2 h-11 font-number"
+              className="mt-3 h-12 font-number"
               aria-invalid={Boolean(importError)}
               data-skland-credential-input
             />
@@ -133,7 +140,7 @@ export function SklandCredentialPanel({
         </li>
       </ol>
 
-      <div className="grid gap-3 border-y py-4">
+      <div className="grid w-full max-w-2xl gap-4 border-y py-5 text-start" data-skland-credential-risk>
         <div className="flex items-start gap-2">
           <TriangleAlert className="mt-0.5 size-4 shrink-0 text-amber-600" aria-hidden="true" />
           <div>
@@ -150,19 +157,21 @@ export function SklandCredentialPanel({
         <p className="text-xs font-medium leading-5 text-foreground">本站实际不读取、不保存、不展示仓库数据，也不签到、不发布或操作任何社区内容。</p>
       </div>
 
-      <SklandPolicyConsent
-        termsAccepted={termsAccepted}
-        privacyAccepted={privacyAccepted}
-        onTermsChange={setTermsAccepted}
-        onPrivacyChange={setPrivacyAccepted}
-      />
+      <div className="w-full max-w-2xl text-start">
+        <SklandPolicyConsent
+          termsAccepted={termsAccepted}
+          privacyAccepted={privacyAccepted}
+          onTermsChange={setTermsAccepted}
+          onPrivacyChange={setPrivacyAccepted}
+        />
+      </div>
 
-      {importError ? <Alert variant="destructive"><AlertDescription>{importError}</AlertDescription></Alert> : null}
+      {importError ? <Alert className="w-full max-w-2xl text-start" variant="destructive"><AlertDescription>{importError}</AlertDescription></Alert> : null}
 
       <Button
         type="submit"
         size={dialogPresentation ? "dialog" : "default"}
-        className={cn("w-full sm:w-fit", dialogPresentation && "sm:w-[196px]")}
+        className={cn("w-full max-w-sm", dialogPresentation && "sm:w-[240px]")}
         disabled={!consentReady || !credential.trim() || submitting}
         data-skland-credential-submit
       >


### PR DESCRIPTION
## Summary
- remove the duplicate Skland login panel heading, icon, and HttpOnly Cookie expiry sentence
- give credential import a wider, centered layout with more breathing room on desktop and safe stacking on mobile
- update the console copy command and explain how to allow pasting when DevTools blocks it

## Verification
- npm run check
- targeted Chromium Skland login, credential import, add-account, and multi-account flows
- production npm run build with Skland and cloud sync enabled
- git diff --check