### PR TITLE
fix: 补全练卡建议提示（替代 #5）

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -79,7 +79,7 @@ test("CI enforces route and document preload JavaScript budgets after building",
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 395_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 405_000/);
   assert.match(budgetCheck, /const sklandEnabled = sklandRoute\.firstLoadChunkPaths\.some/);
-  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_525_000/);
+  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_527_000/);
   assert.match(budgetCheck, /MAX_DOCUMENT_INITIAL_JS_FILES = 18/);
   assert.match(budgetCheck, /WORKBENCH_ROUTES = \["\/", "\/training", "\/skills", "\/skland", "\/account"\]/);
   assert.match(budgetCheck, /firstLoadUncompressedJsBytes/);

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -8,7 +8,9 @@ import { gzipSync } from "node:zlib";
 // views have independent route chunks and may carry their own datasets without joining `/`.
 const MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_130_000;
 const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_150_000;
-const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_525_000;
+// Training tooltips add profession labels and icons to the existing route chunk. Preserve a
+// narrow secondary-route ceiling instead of treating a sub-kilobyte intentional delta as drift.
+const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_527_000;
 const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_590_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_240_000;
 const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_270_000;

--- a/src/components/training-advice/TrainingAdviceActionCard.tsx
+++ b/src/components/training-advice/TrainingAdviceActionCard.tsx
@@ -63,6 +63,7 @@ export function TrainingAdviceActionCard({
               profession: operatorProfessionFor(action.operator),
             }}
             portraitSize={80}
+            showSkillTooltip
           />
           <div className="grid min-w-0 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
             <div className="min-w-0">

--- a/src/components/training-advice/TrainingCombinationCard.tsx
+++ b/src/components/training-advice/TrainingCombinationCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
+
 import { InfraTechnicalCard } from "@/components/InfraTechnicalCard";
-import { TapAwareTooltip } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { operatorProfessionPresentationForCode } from "@/operator-presentation";
 import { operatorPortraitFor, operatorProfessionFor } from "@/operatorPortraits";
 import { cn } from "@/lib/utils";
@@ -27,6 +29,7 @@ const STATE_CLASSES: Record<string, string> = {
 };
 
 function MemberRow({ member }: { member: TrainingAdviceMember }) {
+  const [professionOpen, setProfessionOpen] = useState(false);
   const isReady = member.progress === "ready";
   const isMissing = member.progress === "missing";
   // 就绪：浅灰背景；需培养（需精2 等）：琥珀色边框与状态字同色；缺失保持原样。
@@ -54,8 +57,8 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
       ? "border-white/20 bg-white/10 text-white"
       : "border-white/10 bg-white/5 text-white/65";
   const profession = operatorProfessionPresentationForCode(operatorProfessionFor(member.operator));
-  const card = (
-    <div className={cn("flex min-w-0 items-center gap-1.5 border px-2 py-1", cardClass)}>
+  const content = (
+    <>
       <span className="size-8 shrink-0 overflow-hidden border border-white/10 bg-[#272A2B]">
         <img src={operatorPortraitFor(member.operator)} alt="" className="size-full object-cover" loading="lazy" />
       </span>
@@ -66,14 +69,30 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
       <span className={cn("shrink-0 text-xs tabular-nums", statusClass)}>
         {statusText}
       </span>
-    </div>
+    </>
   );
-  if (!profession) return card;
+  const cardClassName = cn("flex min-w-0 items-center gap-1.5 border px-2 py-1", cardClass);
+  if (!profession) return <div className={cardClassName}>{content}</div>;
   return (
-    <TapAwareTooltip trigger={card} side="top" align="center" className="gap-2 whitespace-nowrap px-3.5 py-2">
-      <img src={profession.icon} alt="" aria-hidden="true" className="size-6 shrink-0 object-contain" />
-      <span className="text-sm font-semibold">{profession.label}</span>
-    </TapAwareTooltip>
+    <Tooltip open={professionOpen} onOpenChange={setProfessionOpen}>
+      <TooltipTrigger
+        closeOnClick={false}
+        render={(
+        <button
+          type="button"
+          className={cardClassName}
+          aria-label={`${member.operator}，职业：${profession.label}`}
+          onClick={() => setProfessionOpen((value) => !value)}
+        >
+          {content}
+        </button>
+      )}
+      />
+      <TooltipContent side="top" align="center" className="gap-2 whitespace-nowrap px-3.5 py-2">
+        <img src={profession.icon} alt="" aria-hidden="true" className="size-6 shrink-0 object-contain" />
+        <span className="text-sm font-semibold">{profession.label}</span>
+      </TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/src/components/training-advice/TrainingCombinationCard.tsx
+++ b/src/components/training-advice/TrainingCombinationCard.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { InfraTechnicalCard } from "@/components/InfraTechnicalCard";
-import { operatorPortraitFor } from "@/operatorPortraits";
+import { TapAwareTooltip } from "@/components/ui/tooltip";
+import { operatorProfessionPresentationForCode } from "@/operator-presentation";
+import { operatorPortraitFor, operatorProfessionFor } from "@/operatorPortraits";
 import { cn } from "@/lib/utils";
 import type { TrainingCombination, TrainingAdviceMember } from "@/types";
 
@@ -51,7 +53,8 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
     member.role === "core"
       ? "border-white/20 bg-white/10 text-white"
       : "border-white/10 bg-white/5 text-white/65";
-  return (
+  const profession = operatorProfessionPresentationForCode(operatorProfessionFor(member.operator));
+  const card = (
     <div className={cn("flex min-w-0 items-center gap-1.5 border px-2 py-1", cardClass)}>
       <span className="size-8 shrink-0 overflow-hidden border border-white/10 bg-[#272A2B]">
         <img src={operatorPortraitFor(member.operator)} alt="" className="size-full object-cover" loading="lazy" />
@@ -64,6 +67,13 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
         {statusText}
       </span>
     </div>
+  );
+  if (!profession) return card;
+  return (
+    <TapAwareTooltip trigger={card} side="top" align="center" className="gap-2 whitespace-nowrap px-3.5 py-2">
+      <img src={profession.icon} alt="" aria-hidden="true" className="size-6 shrink-0 object-contain" />
+      <span className="text-sm font-semibold">{profession.label}</span>
+    </TapAwareTooltip>
   );
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,14 +1,6 @@
 "use client"
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
-import {
-  cloneElement,
-  useEffect,
-  useRef,
-  useState,
-  type ReactElement,
-  type ReactNode,
-} from "react"
 import { motion, type HTMLMotionProps } from "motion/react"
 
 import { cn } from "@/lib/utils"
@@ -87,76 +79,6 @@ function TooltipContent({
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
-  )
-}
-
-function useCoarsePointer() {
-  const [coarse, setCoarse] = useState(false)
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return
-    const query = window.matchMedia("(pointer: coarse)")
-    const apply = (matches: boolean) => setCoarse(matches)
-    apply(query.matches)
-    const onChange = (event: MediaQueryListEvent) => apply(event.matches)
-    query.addEventListener("change", onChange)
-    return () => query.removeEventListener("change", onChange)
-  }, [])
-  return coarse
-}
-
-function withClick(trigger: ReactElement, onClick: (event: React.MouseEvent) => void): ReactElement {
-  return cloneElement(trigger, {
-    onClick,
-  } as Record<string, unknown>)
-}
-
-/**
- * 桌面（细指针）悬浮显示；触屏/平板（粗指针）改为点击切换气泡，点击外部自动收起。
- */
-export function TapAwareTooltip({
-  trigger,
-  children,
-  side = "top",
-  align = "center",
-  className,
-}: {
-  trigger: ReactElement
-  children: ReactNode
-  side?: TooltipPrimitive.Positioner.Props["side"]
-  align?: TooltipPrimitive.Positioner.Props["align"]
-  className?: string
-}) {
-  const coarse = useCoarsePointer()
-  const [open, setOpen] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement | null>(null)
-
-  useEffect(() => {
-    if (!coarse) return
-    const onPointerDown = (event: PointerEvent) => {
-      const element = triggerRef.current
-      if (element && event.target instanceof Node && !element.contains(event.target)) {
-        setOpen(false)
-      }
-    }
-    document.addEventListener("pointerdown", onPointerDown, true)
-    return () => document.removeEventListener("pointerdown", onPointerDown, true)
-  }, [coarse])
-
-  // 始终使用受控 open，避免同一组件在受控/非受控之间切换触发 React 警告。
-  return (
-    <Tooltip open={open} onOpenChange={setOpen}>
-      <TooltipTrigger
-        ref={triggerRef}
-        closeOnClick={!coarse}
-        render={coarse
-          ? withClick(trigger, (event) => {
-              event.preventDefault()
-              setOpen((value) => !value)
-            })
-          : trigger}
-      />
-      <TooltipContent side={side} align={align} className={className}>{children}</TooltipContent>
-    </Tooltip>
   )
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,14 @@
 "use client"
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+import {
+  cloneElement,
+  useEffect,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 import { motion, type HTMLMotionProps } from "motion/react"
 
 import { cn } from "@/lib/utils"
@@ -79,6 +87,76 @@ function TooltipContent({
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
+  )
+}
+
+function useCoarsePointer() {
+  const [coarse, setCoarse] = useState(false)
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const query = window.matchMedia("(pointer: coarse)")
+    const apply = (matches: boolean) => setCoarse(matches)
+    apply(query.matches)
+    const onChange = (event: MediaQueryListEvent) => apply(event.matches)
+    query.addEventListener("change", onChange)
+    return () => query.removeEventListener("change", onChange)
+  }, [])
+  return coarse
+}
+
+function withClick(trigger: ReactElement, onClick: (event: React.MouseEvent) => void): ReactElement {
+  return cloneElement(trigger, {
+    onClick,
+  } as Record<string, unknown>)
+}
+
+/**
+ * 桌面（细指针）悬浮显示；触屏/平板（粗指针）改为点击切换气泡，点击外部自动收起。
+ */
+export function TapAwareTooltip({
+  trigger,
+  children,
+  side = "top",
+  align = "center",
+  className,
+}: {
+  trigger: ReactElement
+  children: ReactNode
+  side?: TooltipPrimitive.Positioner.Props["side"]
+  align?: TooltipPrimitive.Positioner.Props["align"]
+  className?: string
+}) {
+  const coarse = useCoarsePointer()
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!coarse) return
+    const onPointerDown = (event: PointerEvent) => {
+      const element = triggerRef.current
+      if (element && event.target instanceof Node && !element.contains(event.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown, true)
+    return () => document.removeEventListener("pointerdown", onPointerDown, true)
+  }, [coarse])
+
+  // 始终使用受控 open，避免同一组件在受控/非受控之间切换触发 React 警告。
+  return (
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger
+        ref={triggerRef}
+        closeOnClick={!coarse}
+        render={coarse
+          ? withClick(trigger, (event) => {
+              event.preventDefault()
+              setOpen((value) => !value)
+            })
+          : trigger}
+      />
+      <TooltipContent side={side} align={align} className={className}>{children}</TooltipContent>
+    </Tooltip>
   )
 }
 


### PR DESCRIPTION
保留 #5 的作者提交与署名，并在最新 develop 上重建干净分支。原 #5 的 fork 分支误合并了与本功能无关的 main 历史，因此不直接合并。\n\n审查修正：\n- 职业提示触发器改为可键盘聚焦的语义按钮\n- 保留桌面悬浮、键盘聚焦和移动端点击行为\n- 将次级路由预算仅上调 2 KB，继续保留严格门禁\n\n本地验证：npm run check、production build、bundle/build-trace/production-client 均通过。\n\nSupersedes #5.