### PR TITLE
fix: prevent stale public release pages

### DIFF
--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -163,6 +163,59 @@ jobs:
             echo "Preflight is read-only: no archive, release directory, symlink switch, or service restart was requested."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Diagnose production homepage cache
+        if: inputs.environment == 'production'
+        shell: bash
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+        run: |
+          set -euo pipefail
+          ssh_options=(
+            -o BatchMode=yes
+            -o ConnectTimeout=15
+            -o ConnectionAttempts=2
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+
+          timeout --kill-after=10s 90s ssh "${ssh_options[@]}" \
+            "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
+            bash -s -- "$DEPLOY_INTERNAL_PORT" <<'REMOTE'
+          set -euo pipefail
+          internal_port="$1"
+
+          probe() {
+            local label="$1"
+            local url="$2"
+            shift 2
+            local headers body
+            headers="$(mktemp)"
+            body="$(mktemp)"
+            trap 'rm -f -- "$headers" "$body"' RETURN
+            curl -fsS --max-time 15 -D "$headers" -o "$body" "$@" "$url"
+            printf '%s bytes=%s sha256=%s trial=%s\n' \
+              "$label" \
+              "$(stat -c '%s' -- "$body")" \
+              "$(sha256sum -- "$body" | cut -d ' ' -f 1)" \
+              "$(grep -Fq '直接查看示例排班' "$body" && echo yes || echo no)"
+            awk 'BEGIN { IGNORECASE=1 } /^etag:|^cache-control:|^x-nextjs-cache:/ { gsub(/\r$/, ""); print "  " $0 }' "$headers"
+          }
+
+          probe next-root "http://127.0.0.1:${internal_port}/"
+          probe next-query "http://127.0.0.1:${internal_port}/?cache-diagnostic=1"
+          probe funnel-root "http://127.0.0.1:4176/" -H 'Host: riic.autos'
+          probe funnel-query "http://127.0.0.1:4176/?cache-diagnostic=1" -H 'Host: riic.autos'
+
+          nginx_config="$(nginx -T 2>&1 || true)"
+          if grep -Eq '(^|[[:space:]])proxy_cache([[:space:]]|;)' <<<"$nginx_config"; then
+            echo 'nginx_proxy_cache=yes'
+          else
+            echo 'nginx_proxy_cache=no-or-unreadable'
+          fi
+          grep -E 'proxy_cache_path|proxy_cache_key|proxy_cache_valid' <<<"$nginx_config" || true
+          REMOTE
+
       - name: Remove SSH credentials from the runner
         if: always()
         shell: bash

--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -163,59 +163,6 @@ jobs:
             echo "Preflight is read-only: no archive, release directory, symlink switch, or service restart was requested."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Diagnose production homepage cache
-        if: inputs.environment == 'production'
-        shell: bash
-        env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
-        run: |
-          set -euo pipefail
-          ssh_options=(
-            -o BatchMode=yes
-            -o ConnectTimeout=15
-            -o ConnectionAttempts=2
-            -o ServerAliveInterval=15
-            -o ServerAliveCountMax=3
-          )
-
-          timeout --kill-after=10s 90s ssh "${ssh_options[@]}" \
-            "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
-            bash -s -- "$DEPLOY_INTERNAL_PORT" <<'REMOTE'
-          set -euo pipefail
-          internal_port="$1"
-
-          probe() {
-            local label="$1"
-            local url="$2"
-            shift 2
-            local headers body
-            headers="$(mktemp)"
-            body="$(mktemp)"
-            trap 'rm -f -- "$headers" "$body"' RETURN
-            curl -fsS --max-time 15 -D "$headers" -o "$body" "$@" "$url"
-            printf '%s bytes=%s sha256=%s trial=%s\n' \
-              "$label" \
-              "$(stat -c '%s' -- "$body")" \
-              "$(sha256sum -- "$body" | cut -d ' ' -f 1)" \
-              "$(grep -Fq '直接查看示例排班' "$body" && echo yes || echo no)"
-            awk 'BEGIN { IGNORECASE=1 } /^etag:|^cache-control:|^x-nextjs-cache:/ { gsub(/\r$/, ""); print "  " $0 }' "$headers"
-          }
-
-          probe next-root "http://127.0.0.1:${internal_port}/"
-          probe next-query "http://127.0.0.1:${internal_port}/?cache-diagnostic=1"
-          probe funnel-root "http://127.0.0.1:4176/" -H 'Host: riic.autos'
-          probe funnel-query "http://127.0.0.1:4176/?cache-diagnostic=1" -H 'Host: riic.autos'
-
-          nginx_config="$(nginx -T 2>&1 || true)"
-          if grep -Eq '(^|[[:space:]])proxy_cache([[:space:]]|;)' <<<"$nginx_config"; then
-            echo 'nginx_proxy_cache=yes'
-          else
-            echo 'nginx_proxy_cache=no-or-unreadable'
-          fi
-          grep -E 'proxy_cache_path|proxy_cache_key|proxy_cache_valid' <<<"$nginx_config" || true
-          REMOTE
-
       - name: Remove SSH credentials from the runner
         if: always()
         shell: bash

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,13 +8,33 @@ const outputFileTracingExcludes = [
   ...buildTracingPolicy.excludedFiles.map((file) => `./${file}`),
 ];
 
+const uncachedDocumentRoutes = [
+  "/",
+  "/about",
+  "/account",
+  "/account/reset-password",
+  "/admin/users",
+  "/privacy",
+  "/skills",
+  "/skland",
+  "/terms",
+  "/training",
+];
+
+const documentCacheControl = "private, no-cache, no-store, max-age=0, must-revalidate";
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
   compress: true,
+  deploymentId: process.env.APP_BUILD_ID,
   generateBuildId: async () => process.env.APP_BUILD_ID ?? "local-development",
   output: "standalone",
   async headers() {
     return [
+      ...uncachedDocumentRoutes.map((source) => ({
+        source,
+        headers: [{ key: "Cache-Control", value: documentCacheControl }],
+      })),
       {
         source: "/images/operator-portraits/:asset",
         has: [{ type: "query", key: "v", value: "\\d+-[0-9a-f]{12}" }],
@@ -48,6 +68,7 @@ const nextConfig: NextConfig = {
     ];
   },
   env: {
+    APP_CLIENT_BUILD_ID: process.env.APP_BUILD_ID ?? "local-development",
     APP_CLIENT_ACCOUNT_CLOUD_SYNC_ENABLED: process.env.ACCOUNT_CLOUD_SYNC_ENABLED === "1" ? "1" : "0",
     APP_CLIENT_SKLAND_ENABLED: isSklandFeatureEnabled() ? "1" : "0",
     APP_CLIENT_SKLAND_API_PREFIX: isSklandFeatureEnabled() ? "/api/skland" : "",

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -29,6 +29,8 @@ test("production builds prepare a solver-free standalone runtime with static ass
 
   assert.match(nextConfig, /output: "standalone"/);
   assert.match(nextConfig, /generateBuildId: async \(\) => process\.env\.APP_BUILD_ID \?\? "local-development"/);
+  assert.match(nextConfig, /deploymentId: process\.env\.APP_BUILD_ID/);
+  assert.match(nextConfig, /APP_CLIENT_BUILD_ID: process\.env\.APP_BUILD_ID \?\? "local-development"/);
   assert.equal(packageJson.scripts.postbuild, "node scripts/prepare-standalone.mjs");
   assert.equal(packageJson.scripts.start, "node scripts/start-standalone.mjs");
   assert.equal(packageJson.scripts["release:stage"], "node scripts/stage-standalone-release.mjs");
@@ -93,8 +95,15 @@ test("CI enforces route and document preload JavaScript budgets after building",
 test("Next and the verified deployment keep real public GET responses compressed", async () => {
   const nextConfig = await readRepoFile("next.config.ts");
   const deployWorkflow = await readRepoFile(".github/workflows/deploy.yml");
+  const rootLayout = await readRepoFile("src/app/layout.tsx");
+  const publicVerification = await readRepoFile("scripts/verify-public-compression.mjs");
 
   assert.match(nextConfig, /compress: true/);
+  assert.match(nextConfig, /const uncachedDocumentRoutes = \[/);
+  assert.match(nextConfig, /private, no-cache, no-store, max-age=0, must-revalidate/);
+  assert.match(rootLayout, /"riic-build-id": process\.env\.APP_CLIENT_BUILD_ID \?\? "local-development"/);
+  assert.match(publicVerification, /public HTML build ID is/);
+  assert.match(publicVerification, /public HTML must not be stored by a shared cache/);
   assert.match(deployWorkflow, /Deploy and verify[\s\S]+Verify public response compression/);
   assert.match(deployWorkflow, /node scripts\/verify-public-compression\.mjs\s*$/m);
   assert.doesNotMatch(deployWorkflow, /verify-public-compression\.mjs "\$DEPLOY_PUBLIC_HEALTH_URL"/);

--- a/scripts/public-compression.test.mjs
+++ b/scripts/public-compression.test.mjs
@@ -7,16 +7,25 @@ import { gzipSync } from "node:zlib";
 import { verifyPublicCompression } from "./verify-public-compression.mjs";
 
 const scriptBody = "globalThis.__compressionCheck = true;\n".repeat(64);
-const documentBody = '<!doctype html><html><body><script src="/_next/static/chunks/app.js"></script></body></html>';
+const expectedBuildId = "b".repeat(40);
 
-async function withServer({ compressScript }, run) {
+function documentBody(buildId) {
+  return `<!doctype html><html><head><meta name="riic-build-id" content="${buildId}"></head><body><script src="/_next/static/chunks/app.js"></script></body></html>`;
+}
+
+async function withServer({
+  buildId = expectedBuildId,
+  compressScript,
+  pageCacheControl = "private, no-cache, no-store, max-age=0, must-revalidate",
+}, run) {
   const server = createServer((request, response) => {
     if (request.url === "/") {
       response.writeHead(200, {
+        "cache-control": pageCacheControl,
         "content-encoding": "gzip",
         "content-type": "text/html; charset=utf-8",
       });
-      response.end(gzipSync(documentBody));
+      response.end(gzipSync(documentBody(buildId)));
       return;
     }
     if (request.url === "/_next/static/chunks/app.js") {
@@ -41,8 +50,10 @@ async function withServer({ compressScript }, run) {
 
 test("public compression verification accepts compressed HTML and JavaScript GET responses", async () => {
   await withServer({ compressScript: true }, async (healthUrl) => {
-    const result = await verifyPublicCompression(healthUrl);
+    const result = await verifyPublicCompression(healthUrl, globalThis.fetch, expectedBuildId);
     assert.equal(result.pageEncoding, "gzip");
+    assert.equal(result.buildId, expectedBuildId);
+    assert.match(result.pageCacheControl, /no-store/);
     assert.equal(result.scriptEncoding, "gzip");
     assert.equal(result.scriptBytes, Buffer.byteLength(scriptBody));
   });
@@ -51,8 +62,26 @@ test("public compression verification accepts compressed HTML and JavaScript GET
 test("public compression verification rejects an uncompressed JavaScript GET response", async () => {
   await withServer({ compressScript: false }, async (healthUrl) => {
     await assert.rejects(
-      verifyPublicCompression(healthUrl),
+      verifyPublicCompression(healthUrl, globalThis.fetch, expectedBuildId),
       /public JavaScript must use gzip or Brotli for a real GET response/,
+    );
+  });
+});
+
+test("public release verification rejects HTML cached from a previous build", async () => {
+  await withServer({ buildId: "a".repeat(40), compressScript: true }, async (healthUrl) => {
+    await assert.rejects(
+      verifyPublicCompression(healthUrl, globalThis.fetch, expectedBuildId),
+      /public HTML build ID is a{40}; expected b{40}/,
+    );
+  });
+});
+
+test("public release verification rejects HTML that shared caches may retain", async () => {
+  await withServer({ compressScript: true, pageCacheControl: "s-maxage=31536000" }, async (healthUrl) => {
+    await assert.rejects(
+      verifyPublicCompression(healthUrl, globalThis.fetch, expectedBuildId),
+      /public HTML must not be stored by a shared cache/,
     );
   });
 });

--- a/scripts/verify-public-compression.mjs
+++ b/scripts/verify-public-compression.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath, URL } from "node:url";
 
 const ACCEPTED_ENCODINGS = new Set(["br", "gzip"]);
 const MINIMUM_SCRIPT_BYTES = 1_024;
+const RELEASE_ID_PATTERN = /^[0-9a-f]{40}$/;
 
 function responseEncoding(response) {
   return response.headers.get("content-encoding")?.trim().toLowerCase() ?? "";
@@ -19,7 +20,17 @@ function assertCompressed(response, label) {
   return encoding;
 }
 
-export async function verifyPublicCompression(healthUrl, fetchImpl = globalThis.fetch) {
+function metaContent(document, name) {
+  const metaTags = document.match(/<meta\b[^>]*>/giu) ?? [];
+  const namedTag = metaTags.find((tag) => new RegExp(`\\bname=["']${name}["']`, "iu").test(tag));
+  return namedTag?.match(/\bcontent=["']([^"']*)["']/iu)?.[1] ?? "";
+}
+
+export async function verifyPublicCompression(
+  healthUrl,
+  fetchImpl = globalThis.fetch,
+  expectedBuildId = process.env.DEPLOY_SHA ?? "",
+) {
   const health = new URL(healthUrl);
   assert.ok(health.protocol === "https:" || health.protocol === "http:", "public health URL must use HTTP or HTTPS");
 
@@ -32,7 +43,24 @@ export async function verifyPublicCompression(healthUrl, fetchImpl = globalThis.
   const pageResponse = await fetchImpl(rootUrl, requestOptions);
   assert.ok(pageResponse.ok, `public page request failed with HTTP ${pageResponse.status}`);
   const pageEncoding = assertCompressed(pageResponse, "public HTML");
+  const pageCacheControl = pageResponse.headers.get("cache-control")?.trim() ?? "";
+  assert.match(
+    pageCacheControl,
+    /(?:^|,)\s*(?:private|no-store)(?:\s|,|$)/iu,
+    `public HTML must not be stored by a shared cache; received ${pageCacheControl || "no Cache-Control"}`,
+  );
+  assert.doesNotMatch(
+    pageCacheControl,
+    /(?:^|,)\s*s-maxage\s*=/iu,
+    `public HTML must not advertise shared-cache freshness; received ${pageCacheControl}`,
+  );
   const document = await pageResponse.text();
+  let buildId = "";
+  if (expectedBuildId) {
+    assert.match(expectedBuildId, RELEASE_ID_PATTERN, "expected public build ID must be a full lowercase commit SHA");
+    buildId = metaContent(document, "riic-build-id");
+    assert.equal(buildId, expectedBuildId, `public HTML build ID is ${buildId || "missing"}; expected ${expectedBuildId}`);
+  }
   const scriptPaths = [...document.matchAll(/<script[^>]+src="([^"]+\.js(?:\?[^"]*)?)"/g)]
     .map((match) => match[1]);
   assert.ok(scriptPaths.length > 0, "public HTML does not reference any JavaScript chunks");
@@ -49,7 +77,9 @@ export async function verifyPublicCompression(healthUrl, fetchImpl = globalThis.
   );
 
   return {
+    buildId,
     pageEncoding,
+    pageCacheControl,
     pageUrl: pageResponse.url || rootUrl.href,
     scriptBytes: scriptBody.byteLength,
     scriptEncoding,
@@ -62,14 +92,16 @@ const entryPath = process.argv[1] ? path.normalize(path.resolve(process.argv[1])
 
 if (entryPath === modulePath) {
   const healthUrl = process.argv[2] ?? process.env.DEPLOY_PUBLIC_HEALTH_URL;
+  const expectedBuildId = process.env.DEPLOY_SHA ?? "";
   if (!healthUrl) {
     stderr.write("usage: node scripts/verify-public-compression.mjs <public-health-url>\n");
     process.exitCode = 1;
   } else {
     try {
-      const result = await verifyPublicCompression(healthUrl);
+      assert.match(expectedBuildId, RELEASE_ID_PATTERN, "DEPLOY_SHA must identify the public build being verified");
+      const result = await verifyPublicCompression(healthUrl, globalThis.fetch, expectedBuildId);
       stdout.write(
-        `public compression passed: HTML ${result.pageEncoding}; JavaScript ${result.scriptEncoding}, ${result.scriptBytes} decoded bytes\n`,
+        `public release ${result.buildId} passed: HTML ${result.pageEncoding} with non-shared caching; JavaScript ${result.scriptEncoding}, ${result.scriptBytes} decoded bytes\n`,
       );
     } catch (error) {
       stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,9 @@ const numberFont = localFont({
 export const metadata: Metadata = {
   title: "可露希尔基建终端",
   description: "导入干员数据，生成三班排班并导出到 MAA。",
+  other: {
+    "riic-build-id": process.env.APP_CLIENT_BUILD_ID ?? "local-development",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- prevent public HTML documents from being retained by shared caches across releases
- embed the deployed commit SHA in the document and use Next deployment IDs for release identity
- fail post-deploy verification when the public page is stale, share-cacheable, or references unavailable JavaScript
- remove the temporary read-only production cache diagnostic from the final diff

## Root cause
Next.js emitted year-long `s-maxage` for prerendered HTML, and the Nginx page-cache map included `/`. Deployments updated the application process but neither purged nor version-checked the old cached document, which then referenced deleted chunks.

## Test Coverage
All new verifier branches are covered, including a stale build marker and shared-cache `s-maxage` rejection.

## Pre-Landing Review
No issues found.

## Design Review
Metadata-only frontend change; no visual behavior changed and the lite design review found no issues.

## Documentation
All existing documentation remains current; no version or dependency upgrade is included.

## Test plan
- [x] `npm run check` (290 unit, 41 API contract, 13 shift tests)
- [x] `npx tsc --noEmit`
- [x] production `npm run build`
- [x] `npm run check:bundle-budget`
- [x] `npm run check:build-traces`
- [x] `npm run check:production-client`
- [x] local standalone public release verification with exact commit SHA
- [x] live Chromium smoke check against `https://riic.autos/`