### PR TITLE
fix: stop plan worker solver clients on shutdown

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -55,6 +55,13 @@ test("production builds prepare a solver-free standalone runtime with static ass
   assert.doesNotMatch(stageStandalone, /outputRoot, "\.next", "cache"/);
 });
 
+test("the plan worker closes persistent solver clients before exiting", async () => {
+  const workerRuntime = await readRepoFile("scripts/plan-worker-runtime.mts");
+
+  assert.match(workerRuntime, /stopInfraServeClients\("计划任务 Worker 正在退出。"\)/);
+  assert.match(workerRuntime, /stopInfraServeClients[\s\S]+getDatabase\(\)\.\$client[\s\S]+\[plan-worker\] stopped/);
+});
+
 test("Next.js owns graceful shutdown while systemd accepts its signal exit statuses", async () => {
   const processCleanup = await readRepoFile("src/server/process-cleanup.ts");
   const systemdDropIn = await readRepoFile("deploy/next-graceful-exit.conf");

--- a/scripts/plan-worker-runtime.mts
+++ b/scripts/plan-worker-runtime.mts
@@ -6,6 +6,7 @@ import {
   describePlanArtifact,
   getPlanCacheSolverIdentity,
   runPlan,
+  stopInfraServeClients,
 } from "../src/server/infra.ts";
 import {
   completePlanCache,
@@ -224,5 +225,7 @@ export async function runPlanWorker(): Promise<void> {
   clearInterval(heartbeatTimer);
   clearInterval(cleanupTimer);
   console.log("[plan-worker] shutting down");
+  stopInfraServeClients("计划任务 Worker 正在退出。");
   await (getDatabase().$client as { end: () => Promise<void> }).end().catch(() => undefined);
+  console.log("[plan-worker] stopped");
 }

--- a/src/server/infra.ts
+++ b/src/server/infra.ts
@@ -533,7 +533,7 @@ function getPlanServeClient() {
   return globalForInfra.__infraCliPlanServeClient;
 }
 
-function stopServeClient(reason: string) {
+export function stopInfraServeClients(reason: string) {
   globalForInfra.__infraCliHealthServeClient?.stop(reason);
   globalForInfra.__infraCliPlanServeClient?.stop(reason);
 }
@@ -541,7 +541,7 @@ function stopServeClient(reason: string) {
 function registerServeClientCleanup() {
   if (globalForInfra.__infraCliCleanupRegistered) return;
   globalForInfra.__infraCliCleanupRegistered = true;
-  registerProcessCleanup(process, stopServeClient);
+  registerProcessCleanup(process, stopInfraServeClients);
 }
 
 registerServeClientCleanup();
@@ -1114,7 +1114,7 @@ export async function activateCliRelease(id: string) {
   const temp = `${activeCliPath}.${randomUUID()}.tmp`;
   await writeJson(temp, { releaseId: id, path: metadata.path, activatedAt: new Date().toISOString() });
   await rename(temp, activeCliPath);
-  stopServeClient("CLI 版本已切换，等待下次请求重启。");
+  stopInfraServeClients("CLI 版本已切换，等待下次请求重启。");
   return { releaseId: id, path: metadata.path };
 }
 


### PR DESCRIPTION
## Summary
- close persistent infra-cli serve processes when the plan worker finishes its graceful drain
- keep the existing process-exit cleanup for the Next.js web runtime
- add a regression assertion for shutdown ordering

## Production evidence
- the 1ef9572 deployment logged worker shutdown at 01:47:03 but systemd killed the lingering Node and infra-cli processes after TimeoutStopSec=30s
- the task loop had already drained; the lingering solver children were the remaining handles

## Verification
- npm run check (295 unit, 48 API contract, 13 shift comparison tests)
- production Next.js build and TypeScript checks
- worker build and node syntax check
- bundle budget, output tracing, and production client boundary checks