### PR TITLE
fix: disable feedback for sample operator box

### DIFF
--- a/e2e/production-readiness-planning.spec.ts
+++ b/e2e/production-readiness-planning.spec.ts
@@ -770,7 +770,7 @@ test("tooltips wait once and then open adjacent help instantly within the provid
   )))).toBe(true);
 });
 
-test("a stored sample BOX completes generation, shifts, MAA export, and feedback", async ({ page }) => {
+test("a stored sample BOX completes generation, shifts, MAA export, and disables feedback", async ({ page }) => {
   await mockApis(page);
   await seedV4Session(page, null);
   await page.goto("/");
@@ -798,19 +798,10 @@ test("a stored sample BOX completes generation, shifts, MAA export, and feedback
   };
   expect(downloadedMaa.plans?.every((plan) => !("training" in (plan.rooms ?? {})))).toBe(true);
 
-  await page.getByRole("button", { name: "加工站 反馈排班问题" }).click();
-  const feedbackDialog = page.getByRole("dialog");
-  await expectUnifiedDialogTypography(feedbackDialog);
-  const feedbackFooter = feedbackDialog.locator('[data-slot="dialog-footer"]');
-  await expect(feedbackFooter).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
-  await expect(feedbackFooter).toHaveCSS("border-top-width", "0px");
-  await expect(feedbackFooter).toHaveCSS("box-shadow", "none");
-  await expectUnifiedDialogAction(feedbackDialog.getByRole("button", { name: "取消" }), { height: "46px" });
-  await expectUnifiedDialogAction(feedbackDialog.getByRole("button", { name: "提交反馈" }), { width: "196px", height: "46px" });
-  await page.getByPlaceholder(/这组应该换成/).fill("加工站排班与预期不一致");
-  await page.getByRole("checkbox").check();
-  await page.getByRole("button", { name: "提交反馈" }).click();
-  await expect(page.getByText("反馈已提交，编号：feedback-001")).toBeVisible();
+  const feedbackButton = page.getByRole("button", { name: "加工站 反馈排班问题" });
+  await expect(feedbackButton).toBeDisabled();
+  await feedbackButton.hover();
+  await expect(page.getByText("全角色导入为体验数据，不能提交反馈")).toBeVisible();
 });
 
 test("plan timing stays passive and performance feedback waits for result details to close", async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -395,6 +395,7 @@ function WorkbenchApp({ children }: { children: ReactNode }) {
   const accountCanUseCurrentBox = boxSource === "sample" || Boolean(websiteSession);
   const hasBox = Boolean(operbox?.length);
   const hasPersonalBox = hasBox && boxSource !== "sample";
+  const feedbackDisabledForSampleBox = boxSource === "sample";
   const canRun = Boolean(operbox && operbox.length > 0 && cliReady && accountCanUseCurrentBox);
   const sklandBindingCount = sklandBindingSummary.totalCount;
   const websiteUserId = websiteSession?.user.id ?? null;
@@ -997,6 +998,7 @@ function WorkbenchApp({ children }: { children: ReactNode }) {
   }
 
   function handleMarkIssue(row: RoomRow) {
+    if (feedbackDisabledForSampleBox) return;
     setIssueDraftKind("room_issue");
     setIssueDraftRow(row);
     setIssueDraftNote("");
@@ -1005,6 +1007,7 @@ function WorkbenchApp({ children }: { children: ReactNode }) {
   }
 
   function handlePerformanceIssue() {
+    if (feedbackDisabledForSampleBox) return;
     if (!result?.diagnosticId) return;
     setIssueDraftKind("performance_issue");
     setIssueDraftRow(null);
@@ -1531,6 +1534,7 @@ function WorkbenchApp({ children }: { children: ReactNode }) {
       canRun,
       hasBox,
       hasPersonalBox,
+      feedbackDisabledForSampleBox,
       plannerReady: cliReady,
       websiteAuthenticated: Boolean(websiteSession),
       showOnboarding: onboardingPreference === "active" && !result,

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1330,6 +1330,7 @@ export function ScheduleBoard({
   searchQuery = "",
   animateInitialView = false,
   onIssue,
+  feedbackDisabled = false,
   onFactoryRecipeChange,
   onTradeOrderChange,
   onViewModeChange,
@@ -1347,6 +1348,7 @@ export function ScheduleBoard({
   searchQuery?: string;
   animateInitialView?: boolean;
   onIssue: (row: RoomRow) => void;
+  feedbackDisabled?: boolean;
   onFactoryRecipeChange: (roomId: string, recipe: FactoryRecipe) => void;
   onTradeOrderChange: (roomId: string, order: TradeOrder) => void;
   onViewModeChange?: (viewMode: "list" | "compact") => void;
@@ -1699,20 +1701,23 @@ export function ScheduleBoard({
                     <Tooltip>
                       <TooltipTrigger
                         render={
+                          <span className="absolute right-2 top-2 z-10">
                           <Button
                             id={scheduleIssueTriggerId(row)}
                             type="button"
                             variant="ghost"
                             size="icon-sm"
-                            className="absolute right-2 top-2 z-10 border border-white/10 bg-[#3C3C3C]/55 text-white/70 hover:bg-[#4B4B4B] hover:text-white max-sm:size-11"
+                            className="border border-white/10 bg-[#3C3C3C]/55 text-white/70 hover:bg-[#4B4B4B] hover:text-white disabled:cursor-not-allowed disabled:opacity-45 max-sm:size-11"
                             aria-label={`${row.title} 反馈排班问题`}
+                            disabled={feedbackDisabled}
                             onClick={() => onIssue(row)}
                           >
                             <FileWarning />
                           </Button>
+                          </span>
                         }
                       />
-                      <TooltipContent side="left">反馈排班问题</TooltipContent>
+                      <TooltipContent side="left">{feedbackDisabled ? "全角色导入为体验数据，不能提交反馈" : "反馈排班问题"}</TooltipContent>
                     </Tooltip>
                   </div>
                 );

--- a/src/components/PlanResultSummary.tsx
+++ b/src/components/PlanResultSummary.tsx
@@ -87,6 +87,7 @@ export function PlanResultSummary({
   animateEntrance = true,
   onEntranceConsumed,
   onPerformanceIssue,
+  feedbackDisabled = false,
 }: {
   profile?: UserProfile;
   rotation?: RotationJson;
@@ -99,6 +100,7 @@ export function PlanResultSummary({
   animateEntrance?: boolean;
   onEntranceConsumed?: (revision: string) => void;
   onPerformanceIssue: () => void;
+  feedbackDisabled?: boolean;
 }) {
   const shouldReduceMotion = useReducedMotion();
   const [animateOnMount] = useState(animateEntrance);
@@ -262,10 +264,13 @@ export function PlanResultSummary({
               variant="link"
               className="h-11 justify-start px-0 text-xs font-medium text-[#313131]/58 hover:text-[#313131]"
               data-plan-performance-feedback
+              disabled={feedbackDisabled}
+              title={feedbackDisabled ? "全角色导入为体验数据，不能提交反馈" : undefined}
               onClick={requestPerformanceFeedback}
             >
               反馈本次求解速度
             </Button>
+            {feedbackDisabled ? <p className="mt-1 text-xs text-[#313131]/55">全角色导入为体验数据，不能提交反馈。</p> : null}
           </div>
         </div>
       </Drawer>

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -307,6 +307,7 @@ export interface InfraCalculatorProps {
   canRun: boolean;
   hasBox: boolean;
   hasPersonalBox: boolean;
+  feedbackDisabledForSampleBox: boolean;
   plannerReady: boolean;
   websiteAuthenticated: boolean;
   showOnboarding: boolean;
@@ -347,7 +348,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
     activePlan, closestComparison,
     resultClearNotice,
     feedbackResult,
-    sampleLoading, loading, canRun, hasBox, hasPersonalBox, plannerReady, websiteAuthenticated, showOnboarding, taskQueue, animatePlanEntrance, animateEmptyScheduleEntrance, onPlanEntranceConsumed, requiresAccount = false, accountControl,
+    sampleLoading, loading, canRun, hasBox, hasPersonalBox, feedbackDisabledForSampleBox, plannerReady, websiteAuthenticated, showOnboarding, taskQueue, animatePlanEntrance, animateEmptyScheduleEntrance, onPlanEntranceConsumed, requiresAccount = false, accountControl,
     onRunSampleTrial, onStartPersonalFlow, onDismissOnboarding, onOpenSetup, onRun, onCancelRun,
     onSetActiveShift, onMarkIssue, onPerformanceIssue,
     onFactoryRecipeChange, onTradeOrderChange,
@@ -542,6 +543,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                     animateEntrance={animatePlanEntrance}
                     onEntranceConsumed={onPlanEntranceConsumed}
                     onPerformanceIssue={onPerformanceIssue}
+                    feedbackDisabled={feedbackDisabledForSampleBox}
                   />
                 </Suspense>
               </>
@@ -592,6 +594,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                 </div>
               )}
               onIssue={onMarkIssue}
+              feedbackDisabled={feedbackDisabledForSampleBox}
               onFactoryRecipeChange={onFactoryRecipeChange}
               onTradeOrderChange={onTradeOrderChange}
             /> : (


### PR DESCRIPTION
## Summary
- disable room and performance feedback for the full-operator sample Box
- explain why the feedback action is unavailable
- cover the disabled sample-Box flow in E2E

## Validation
- ESLint on changed files
- git diff --check