### PR TITLE
功能：一图流布局添加反馈入口

### DIFF
--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
+import { FileWarning } from "lucide-react";
 
 import {
   factoryRecipeFor,
@@ -9,6 +10,8 @@ import {
 } from "@/blueprint";
 import { AnimatedNumber, AnimatedText } from "@/components/AnimatedText";
 import { LevelDiamonds, OperatorSlot, roomVisualFor } from "@/components";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { presentRoomEfficiency } from "@/efficiency";
 import {
   COMPACT_CARD_CLASS,
@@ -40,6 +43,7 @@ export interface CompactScheduleViewProps {
   activePlan?: MaaPlan;
   shiftDirection: ShiftDirection;
   onIssue: (row: RoomRow) => void;
+  feedbackDisabled?: boolean;
 }
 
 /** 布局宽度百分比，自己改数值 */
@@ -62,6 +66,8 @@ function CompactRoomCard({
   slots,
   currentMoraleByOperator,
   shiftDirection,
+  onIssue,
+  feedbackDisabled = false,
   horizontal,
   className = "",
   style,
@@ -73,6 +79,8 @@ function CompactRoomCard({
   slots: { slot: RoomRow["operatorSlots"][number] | undefined; positionLabel?: string }[];
   currentMoraleByOperator?: ReadonlyMap<string, number>;
   shiftDirection: ShiftDirection;
+  onIssue: (row: RoomRow) => void;
+  feedbackDisabled?: boolean;
   horizontal: boolean;
   className?: string;
   style?: CSSProperties;
@@ -198,6 +206,7 @@ function CompactRoomCard({
         style={{ ...rowStyle, ...style }}
       >
         {backgroundLayers}
+        <CompactFeedbackButton row={row} disabled={feedbackDisabled} onIssue={onIssue} />
         {details}
         {operatorArea}
       </div>
@@ -212,6 +221,7 @@ function CompactRoomCard({
       style={{ ...rowStyle, ...style }}
     >
       {backgroundLayers}
+      <CompactFeedbackButton row={row} disabled={feedbackDisabled} onIssue={onIssue} />
       {details}
       <div
         className={`relative z-10 ${
@@ -224,8 +234,33 @@ function CompactRoomCard({
   );
 }
 
+function CompactFeedbackButton({ row, disabled, onIssue }: { row: RoomRow; disabled: boolean; onIssue: (row: RoomRow) => void }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span className="absolute right-2 top-2 z-20">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="border border-white/10 bg-[#3C3C3C]/55 text-white/70 hover:bg-[#4B4B4B] hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
+              aria-label={`${row.title} 反馈排班问题`}
+              disabled={disabled}
+              onClick={() => onIssue(row)}
+            >
+              <FileWarning />
+            </Button>
+          </span>
+        }
+      />
+      <TooltipContent side="left">{disabled ? "全精二 Box 为体验数据，不能提交反馈" : "反馈排班问题"}</TooltipContent>
+    </Tooltip>
+  );
+}
+
 export function CompactScheduleView(props: CompactScheduleViewProps) {
-  const { rows, layout, currentMoraleByOperator, shiftDirection } = props;
+  const { rows, layout, currentMoraleByOperator, shiftDirection, onIssue, feedbackDisabled = false } = props;
 
   if (rows.length === 0) {
     return (
@@ -268,6 +303,8 @@ export function CompactScheduleView(props: CompactScheduleViewProps) {
         slots={slots}
         currentMoraleByOperator={currentMoraleByOperator}
         shiftDirection={shiftDirection}
+        onIssue={onIssue}
+        feedbackDisabled={feedbackDisabled}
         horizontal={COMPACT_AUXILIARY_GROUPS.has(row.group)}
         className="min-w-0"
         style={widthPercent !== undefined ? { flexBasis: `${widthPercent}%` } : { flex: 1 }}


### PR DESCRIPTION
## 内容
- 一图流布局的每个房间卡片右上角增加反馈按钮
- 点击后直接打开对应房间的排班问题反馈

## 验证
- 
px eslint src/components/CompactScheduleView.tsx src/components.tsx 通过
- 完整 TypeScript 检查受 main 已有的 Next 路由生成类型缺失影响，报错不涉及本 PR 文件