### PR TITLE
ci: 支持直接向 main 提交 PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## 验证
 
-- [ ] PR 的 base branch 是 `develop`；只有维护者的 `release/**` PR 可以指向 `main`，不经 `develop` 的特批发布还必须带有 `direct-main-release` 标签
+- [ ] PR 的 base branch 是 `main`
 - [ ] 已运行 `npm run check`
 - [ ] 已运行 `npm run build`
 - [ ] 交互改动已运行相关 Chromium / production-profile / WebKit 测试

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,18 @@ jobs:
   deploy:
     if: >-
       github.event_name == 'push' &&
-      (github.ref_name == 'main' || github.ref_name == 'develop') &&
+      github.ref_name == 'main' &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
       github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     environment:
-      name: ${{ github.ref_name == 'main' && 'production' || 'development' }}
+      name: production
     concurrency:
       group: deploy-${{ github.ref_name }}
       cancel-in-progress: false
     env:
-      DEPLOYMENT_ENV: ${{ github.ref_name == 'main' && 'production' || 'development' }}
+      DEPLOYMENT_ENV: production
       DEPLOY_SHA: ${{ github.sha }}
       DEPLOY_APP_ROOT: ${{ vars.DEPLOY_APP_ROOT }}
       DEPLOY_SERVICE: ${{ vars.DEPLOY_SERVICE }}

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -9,10 +9,10 @@ on:
         default: true
         type: boolean
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
-    branches: [main, develop]
+    branches: [main]
   schedule:
     - cron: "23 18 * * *"
 
@@ -42,36 +42,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout release ancestry
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Enforce the main release lane
+      - name: Validate the main contribution lane
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          EXPECTED_REPOSITORY: KnightCodeSquareMatrix/RIIC-Web
-          DIRECT_MAIN_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'direct-main-release') && '1' || '0' }}
         run: |
           set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" && "$BASE_REF" == "main" ]]; then
-            test "$HEAD_REPOSITORY" = "$EXPECTED_REPOSITORY"
-            [[ "$HEAD_REF" == release/* ]]
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            test "$BASE_REF" = "main"
             [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-            [[ "$DIRECT_MAIN_RELEASE" =~ ^[01]$ ]]
-            if [[ "$DIRECT_MAIN_RELEASE" == "1" ]]; then
-              echo "Maintainer-authorized direct main release; develop ancestry is intentionally skipped."
-            else
-              git fetch --no-tags origin develop:refs/remotes/origin/develop
-              git merge-base --is-ancestor "$HEAD_SHA" refs/remotes/origin/develop
-            fi
           fi
 
   changes:
@@ -443,7 +424,7 @@ jobs:
     needs: [changes, quality]
     if: >-
       github.event_name == 'push' &&
-      (github.ref_name == 'main' || github.ref_name == 'develop') &&
+      github.ref_name == 'main' &&
       needs.quality.result == 'success' &&
       needs.changes.outputs.deploy_required == 'true' &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&

--- a/.github/workflows/sync-arkntools-assets.yml
+++ b/.github/workflows/sync-arkntools-assets.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout frontend without credentials
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
           persist-credentials: false
 
@@ -166,14 +166,14 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      BASE_BRANCH: develop
+      BASE_BRANCH: main
       UPDATE_BRANCH: automation/arkntools-assets
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout publication base
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
 
       - name: Download reviewed publication artifact
@@ -229,7 +229,7 @@ jobs:
         shell: bash
         run: |
           body="$RUNNER_TEMP/arkntools-publication/pull-request-body.md"
-          number="$(gh pr list --base "$BASE_BRANCH" --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
+          number="$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
           if [[ -z "$number" ]]; then
             gh pr create \
               --base "$BASE_BRANCH" \
@@ -238,6 +238,7 @@ jobs:
               --body-file "$body"
           else
             gh pr edit "$number" \
+              --base "$BASE_BRANCH" \
               --title "chore: 同步 arkntools 干员素材与基建技能" \
               --body-file "$body"
           fi
@@ -251,4 +252,4 @@ jobs:
         shell: bash
         run: |
           echo "## arkntools 资源发布失败" >> "$GITHUB_STEP_SUMMARY"
-          echo "未创建或刷新自动资源 PR；develop 中最后一次已验证资源保持不变。" >> "$GITHUB_STEP_SUMMARY"
+          echo "未创建或刷新自动资源 PR；main 中最后一次已验证资源保持不变。" >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@
 
 ## 分支与 PR
 
-1. 从最新的 `develop` 创建功能分支。
-2. 将功能、修复、文档和资源同步 PR 的 base branch 设为 `develop`。
-3. 不要向 `main` 直接提交普通 PR。`main` 只接受维护者从本仓库 `release/**` 分支发起的发布 PR；确需跳过 `develop` 的特批发布，必须由维护者添加 `direct-main-release` 标签，且仍须通过其余全部质量门禁。
-4. PR 合并到 `develop` 后进入 development 发布通道；通过验收的变更再经 release PR 晋级 `main`。
+1. 从最新的 `main` 创建功能分支。
+2. 将功能、修复、文档和资源同步 PR 的 base branch 设为 `main`；来自 fork 的分支同样支持。
+3. 合并前必须通过 `quality` 状态、代码审查和分支保护。不要绕过检查直接推送。
+4. 合并到 `main` 后才可能进入生产部署流程；PR 本身不会获得部署凭据或触发部署。
 
 来自 fork 的 PR 使用只读 `GITHUB_TOKEN`，不会获得 Environment secrets，也不会触发部署。请不要为了验证部署而在 PR 中添加、打印或探测 secret。
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ npm run db:generate
 npm run db:migrate
 ```
 
-所有普通功能和修复 PR 都应提交到 `develop`；`main` 只接收维护者从同仓库 `release/**` 分支发起的发布 PR。特批的直接发布还必须带有维护者设置的 `direct-main-release` 标签，并通过其余全部质量门禁。完整流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。不要把本地环境文件、求解器二进制、运行记录、用户数据或浏览器自动化产物加入提交。
+所有功能、修复、文档和资源同步 PR 都应提交到 `main`，包括来自 fork 的贡献。合并前必须通过完整质量门禁与代码审查；只有合并后的上游 `main` push 才可能触发部署。完整流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。不要把本地环境文件、求解器二进制、运行记录、用户数据或浏览器自动化产物加入提交。
 
 ## 第三方素材
 

--- a/docs/REPOSITORY_ADMIN_CHECKLIST.md
+++ b/docs/REPOSITORY_ADMIN_CHECKLIST.md
@@ -10,19 +10,19 @@ Only the personal-repository owner, `KnightCodeSquareMatrix`, can complete the a
 - [ ] Invite `yeyouchuan` as a normal collaborator.
 - [ ] Disable GitHub Actions in the new repository.
 - [ ] Confirm the prepared public commit has no parent and that its tree passes `npm run check:public-repository`.
-- [ ] Push that one commit explicitly to `main` and `develop`; do not use `--mirror`, `--all`, or push tags.
+- [ ] Push that one commit explicitly to `main`; do not use `--mirror`, `--all`, or push tags.
 
 ## Branch and Actions policy
 
 - [ ] Set `main` as the default branch.
-- [ ] Protect both `main` and `develop`: require the `quality` status, at least one approval, resolved conversations, and block force pushes and deletion.
+- [ ] Protect `main`: require the `quality` status, at least one approval, resolved conversations, and block force pushes and deletion.
 - [ ] Require CODEOWNER review for the sensitive paths listed in `.github/CODEOWNERS`.
 - [ ] Do not routinely bypass protection as repository owner.
 - [ ] Keep the default `GITHUB_TOKEN` permission read-only.
-- [ ] Allow GitHub Actions to create pull requests so the narrowly scoped asset-sync workflow can update `develop`.
+- [ ] Allow GitHub Actions to create pull requests so the narrowly scoped asset-sync workflow can update `main`.
 - [ ] Enable private vulnerability reporting and the relevant GitHub security checks.
 
-The `quality` workflow also rejects every pull request to `main` unless its head is a `release/**` branch in this same repository. By default, that head commit must already be reachable from `develop`; a maintainer-applied `direct-main-release` label may explicitly waive only the ancestry check while preserving all remaining quality jobs. External and ordinary feature PRs target `develop`.
+The `quality` workflow accepts same-repository and fork pull requests targeting `main`. Every contribution still passes repository hygiene, core checks, and the required browser tests selected by its change scope. Pull requests use a read-only token and cannot deploy; branch protection and production Environment approval remain the merge and deployment trust boundaries.
 
 ## Deployment configuration
 
@@ -32,7 +32,7 @@ Create repository variable:
 
 Keep it at exactly `0` throughout initialization and preflight.
 
-Create `development` and `production` Environments. Enter these secrets separately in each Environment:
+Create the `production` Environment. If a separately reviewed staging workflow remains in use, create a `development` Environment as well. Enter these secrets separately in every enabled Environment:
 
 - `DEPLOY_HOST`
 - `DEPLOY_SSH_USER`
@@ -50,21 +50,21 @@ Enter these non-sensitive variables separately in each Environment:
 - `DEPLOY_RATE_LIMIT_ENABLED`
 - `DEPLOY_APPROVED_SOLVER_SHA256`
 
-Do not copy values out of old GitHub secrets; re-enter them from the owner-controlled secure store. In particular, the development health URL is an Environment secret, never a repository variable or committed value.
+Do not copy values out of old GitHub secrets; re-enter them from the owner-controlled secure store. In particular, public health URLs are Environment secrets, never repository variables or committed values.
 
-Restrict `development` to `develop`. Restrict `production` to `main` and require `KnightCodeSquareMatrix` as reviewer.
+Restrict `production` to `main` and require `KnightCodeSquareMatrix` as reviewer. Keep `development` disabled unless a separate staging workflow is explicitly enabled.
 
 ## Enablement checkpoints
 
-- [ ] Re-enable Actions only after branch protection and both Environments are configured.
-- [ ] Manually run full CI on `main` and `develop`; the deploy job must be skipped while the repository variable is `0`.
+- [ ] Re-enable Actions only after branch protection and every enabled Environment is configured.
+- [ ] Manually run full CI on `main`; the deploy job must be skipped while the repository variable is `0`.
 - [ ] Run `Deployment preflight` in `baseline` mode for a read-only report of the installed deploy helper contract and available disk space; root-only solver details remain hidden in this mode.
 - [ ] After private server maintenance, rerun preflight in `cutover-ready` mode.
 
 Set `DEPLOY_APPROVED_SOLVER_SHA256` to the independently verified digest of the approved shared solver for each Environment. The cutover-ready preflight requires a root-owned `shared/bin` solver and independent SHA-256 sidecar, verifies the Environment-approved digest, and compares both with the solver's Worker `ping` fingerprint. Prepare those private server assets from the owner-controlled release record; never derive and trust a digest solely from a runtime-user-writable file.
 - [ ] Disable automatic deployment in the old private repository before setting the public repository variable to `1`.
-- [ ] Change `deploy/PUBLIC_DEPLOYMENT_SOURCE` in a PR to `public-automation-v1` and merge it to `develop`. This path is intentionally classified as deploy-required.
-- [ ] Complete development acceptance, then create a same-repository `release/develop-to-main-YYYYMMDD` PR.
-- [ ] Approve the production Environment only after the release PR has passed `quality`.
+- [ ] Change `deploy/PUBLIC_DEPLOYMENT_SOURCE` in a PR to `public-automation-v1` and merge it to `main`. This path is intentionally classified as deploy-required.
+- [ ] Complete production acceptance on the `main`-targeting PR before merging it.
+- [ ] Approve the production Environment only after the merged change has passed `quality`.
 
-Do not delete old releases, helper binaries, or Git-cache backups until both environments have been stable for at least seven days.
+Do not delete old releases, helper binaries, or Git-cache backups until every enabled environment has been stable for at least seven days.

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -175,12 +175,15 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
     preflightWorkflow.indexOf("    steps:"),
   );
 
-  assert.match(qualityWorkflow, /HEAD_REPOSITORY[\s\S]+EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+"\$HEAD_REF" == release\/\*/);
+  assert.match(qualityWorkflow, /pull_request:\s*\n\s*branches: \[main\]/);
+  assert.match(qualityWorkflow, /push:\s*\n\s*branches: \[main\]/);
   assert.match(qualityWorkflow, /types: \[opened, synchronize, reopened, labeled, unlabeled\]/);
-  assert.match(qualityWorkflow, /DIRECT_MAIN_RELEASE: \$\{\{ contains\(github\.event\.pull_request\.labels\.\*\.name, 'direct-main-release'\)[\s\S]+"\$DIRECT_MAIN_RELEASE" == "1"[\s\S]+develop ancestry is intentionally skipped/);
-  assert.match(qualityWorkflow, /git merge-base --is-ancestor "\$HEAD_SHA" refs\/remotes\/origin\/develop/);
+  assert.match(qualityWorkflow, /Validate the main contribution lane[\s\S]+test "\$BASE_REF" = "main"[\s\S]+"\$HEAD_SHA" =~ \^\[0-9a-f\]\{40\}\$/);
+  assert.doesNotMatch(qualityWorkflow, /HEAD_REPOSITORY|EXPECTED_REPOSITORY|DIRECT_MAIN_RELEASE|release\/\*|refs\/remotes\/origin\/develop/);
   assert.match(qualityWorkflow, /github\.event_name == 'push'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /github\.event_name == 'push'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.doesNotMatch(qualityWorkflow, /github\.ref_name == 'develop'/);
+  assert.doesNotMatch(deployWorkflow, /github\.ref_name == 'develop'/);
   assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "5"/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release/);
   assert.match(deployWorkflow, /DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}/);
@@ -204,7 +207,7 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.doesNotMatch(deployWorkflow, /'\$DEPLOY_PUBLIC_HEALTH_URL'/);
   assert.match(deployWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);
   assert.match(deployWorkflow, /Verify public response compression[\s\S]+DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}[\s\S]+node scripts\/verify-public-compression\.mjs/);
-  assert.match(assetWorkflow, /BASE_BRANCH: develop/);
+  assert.match(assetWorkflow, /BASE_BRANCH: main/);
   assert.match(assetWorkflow, /gh pr (?:list|create)[\s\S]+--base "\$BASE_BRANCH"/);
 
   for (const workflow of workflows) {


### PR DESCRIPTION
## 变更

- 将前端质量工作流的 PR 与 push 通道统一为 main
- 允许同仓库和 fork 的功能分支直接向 main 提交 PR
- 保留 Pull request policy、仓库卫生、核心检查、浏览器测试与统一 quality 门禁
- 将自动资源同步的基准与 PR 目标改为 main
- 同步更新贡献说明、PR 模板、管理清单和静态测试

## 安全边界

- PR 工作流继续使用 pull_request 和只读 contents 权限，不接收部署 secrets
- 部署只允许上游仓库 main 合并后的 push，并继续要求完整质量检查、显式部署开关和 production Environment
- 敏感 workflow 与部署路径继续由 CODEOWNERS 审查

## 验证

- npm run check
- npm run build
- npm run audit:security
- 三份修改后的 workflow YAML 均已完成解析检查