### PR TITLE
fix: restore Admin solver metrics

### DIFF
--- a/src/server/admin-solver-metrics-trend.ts
+++ b/src/server/admin-solver-metrics-trend.ts
@@ -1,7 +1,7 @@
 import { and, gte, lte, sql } from "drizzle-orm";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 
-import * as schema from "./db/schema";
+import * as schema from "./db/schema.ts";
 
 export function buildAdminSolverTrendQuery(
   database: NodePgDatabase<typeof schema>,

--- a/src/server/admin-solver-metrics-trend.ts
+++ b/src/server/admin-solver-metrics-trend.ts
@@ -1,0 +1,31 @@
+import { and, gte, lte, sql } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+
+import * as schema from "./db/schema";
+
+export function buildAdminSolverTrendQuery(
+  database: NodePgDatabase<typeof schema>,
+  startedAt: Date,
+  endedAt: Date,
+  bucketSeconds: number,
+) {
+  if (!Number.isSafeInteger(bucketSeconds) || bucketSeconds <= 0) {
+    throw new Error("Solver metric trend bucket must be a positive integer.");
+  }
+
+  // The same bucket expression appears in SELECT, GROUP BY, and ORDER BY.
+  // A bound value would become a different PostgreSQL placeholder each time,
+  // so embed this trusted internal constant to preserve expression identity.
+  const bucketSecondsLiteral = sql.raw(String(bucketSeconds));
+  const trendBucket = sql<Date>`to_timestamp(floor(extract(epoch from ${schema.planRun.createdAt}) / ${bucketSecondsLiteral}) * ${bucketSecondsLiteral})`;
+
+  return database.select({
+    bucketStartedAt: trendBucket,
+    successCount: sql<number>`count(*) filter (where ${schema.planRun.status} = 'success')::int`,
+    failureCount: sql<number>`count(*) filter (where ${schema.planRun.status} = 'failed')::int`,
+    averageDurationMs: sql<number | null>`round(avg(${schema.planRun.durationMs}) filter (where ${schema.planRun.status} = 'success' and ${schema.planRun.durationMs} is not null))::int`,
+  }).from(schema.planRun).where(and(
+    gte(schema.planRun.createdAt, startedAt),
+    lte(schema.planRun.createdAt, endedAt),
+  )).groupBy(trendBucket).orderBy(trendBucket);
+}

--- a/src/server/business-data.integration.test.mjs
+++ b/src/server/business-data.integration.test.mjs
@@ -5,7 +5,10 @@ import process from "node:process";
 import test from "node:test";
 
 import { Pool } from "pg";
+import { drizzle } from "drizzle-orm/node-postgres";
 
+import { buildAdminSolverTrendQuery } from "./admin-solver-metrics-trend.ts";
+import * as schema from "./db/schema.ts";
 import {
   decryptOperboxSnapshot,
   encryptOperboxSnapshot,
@@ -15,60 +18,17 @@ import {
 const databaseUrl = process.env.AUTH_INTEGRATION_DATABASE_URL?.trim();
 if (!databaseUrl) throw new Error("AUTH_INTEGRATION_DATABASE_URL is required for the business-data integration test.");
 
-test("admin solver metrics aggregates run against PostgreSQL", async () => {
-  const pool = new Pool({ connectionString: databaseUrl, max: 4 });
+test("admin solver metrics trend query preserves PostgreSQL grouping identity", async () => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 2 });
+  const database = drizzle({ client: pool, schema });
   const now = new Date();
-  const windowStartedAt = new Date(now.getTime() - 15 * 60_000);
   const trendStartedAt = new Date(now.getTime() - 60 * 60_000);
   try {
-    const [solverRows, trendRows, taskRows, cacheRows] = await Promise.all([
-      pool.query(
-        `SELECT
-           count(*) FILTER (WHERE status = 'success')::int AS success_count,
-           count(*) FILTER (WHERE status = 'failed')::int AS failure_count,
-           round(avg(duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS average_duration_ms,
-           round(percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS p95_duration_ms
-         FROM app.plan_run
-         WHERE created_at >= $1 AND created_at <= $2`,
-        [windowStartedAt, now],
-      ),
-      pool.query(
-        `SELECT
-           to_timestamp(floor(extract(epoch FROM created_at) / $3) * $4) AS bucket_started_at,
-           count(*) FILTER (WHERE status = 'success')::int AS success_count,
-           count(*) FILTER (WHERE status = 'failed')::int AS failure_count,
-           round(avg(duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS average_duration_ms
-         FROM app.plan_run
-         WHERE created_at >= $1 AND created_at <= $2
-         GROUP BY to_timestamp(floor(extract(epoch FROM created_at) / $5) * $6)
-         ORDER BY to_timestamp(floor(extract(epoch FROM created_at) / $7) * $8)`,
-        [trendStartedAt, now, 300, 300, 300, 300, 300, 300],
-      ),
-      pool.query(
-        `SELECT
-           count(*) FILTER (WHERE status = 'pending')::int AS pending_count,
-           count(*) FILTER (WHERE status = 'running')::int AS running_count,
-           round(avg(extract(epoch FROM (started_at - created_at)) * 1000) FILTER (WHERE started_at IS NOT NULL AND created_at >= $1))::int AS average_wait_ms,
-           round(percentile_cont(0.95) WITHIN GROUP (ORDER BY extract(epoch FROM (started_at - created_at)) * 1000) FILTER (WHERE started_at IS NOT NULL AND created_at >= $1))::int AS p95_wait_ms
-         FROM app.plan_task
-         WHERE status IN ('pending', 'running') OR (created_at >= $1 AND created_at <= $2)`,
-        [windowStartedAt, now],
-      ),
-      pool.query(
-        `SELECT
-           coalesce(sum(hit_count) FILTER (WHERE public_result IS NOT NULL), 0)::int AS hit_count,
-           count(*) FILTER (WHERE public_result IS NOT NULL)::int AS ready_entry_count,
-           count(*) FILTER (WHERE public_result IS NULL AND lease_expires_at > $1)::int AS filling_entry_count
-         FROM app.plan_cache
-         WHERE expires_at > $1`,
-        [now],
-      ),
-    ]);
-
-    assert.equal(solverRows.rowCount, 1);
-    assert.ok(Array.isArray(trendRows.rows));
-    assert.equal(taskRows.rowCount, 1);
-    assert.equal(cacheRows.rowCount, 1);
+    const query = buildAdminSolverTrendQuery(database, trendStartedAt, now, 300);
+    const generated = query.toSQL();
+    assert.equal(generated.params.includes(300), false);
+    assert.match(generated.sql, /\/ 300\) \* 300\)/);
+    assert.ok(Array.isArray(await query));
   } finally {
     await pool.end();
   }

--- a/src/server/business-data.integration.test.mjs
+++ b/src/server/business-data.integration.test.mjs
@@ -15,6 +15,65 @@ import {
 const databaseUrl = process.env.AUTH_INTEGRATION_DATABASE_URL?.trim();
 if (!databaseUrl) throw new Error("AUTH_INTEGRATION_DATABASE_URL is required for the business-data integration test.");
 
+test("admin solver metrics aggregates run against PostgreSQL", async () => {
+  const pool = new Pool({ connectionString: databaseUrl, max: 4 });
+  const now = new Date();
+  const windowStartedAt = new Date(now.getTime() - 15 * 60_000);
+  const trendStartedAt = new Date(now.getTime() - 60 * 60_000);
+  try {
+    const [solverRows, trendRows, taskRows, cacheRows] = await Promise.all([
+      pool.query(
+        `SELECT
+           count(*) FILTER (WHERE status = 'success')::int AS success_count,
+           count(*) FILTER (WHERE status = 'failed')::int AS failure_count,
+           round(avg(duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS average_duration_ms,
+           round(percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS p95_duration_ms
+         FROM app.plan_run
+         WHERE created_at >= $1 AND created_at <= $2`,
+        [windowStartedAt, now],
+      ),
+      pool.query(
+        `SELECT
+           to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300) AS bucket_started_at,
+           count(*) FILTER (WHERE status = 'success')::int AS success_count,
+           count(*) FILTER (WHERE status = 'failed')::int AS failure_count,
+           round(avg(duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS average_duration_ms
+         FROM app.plan_run
+         WHERE created_at >= $1 AND created_at <= $2
+         GROUP BY to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300)
+         ORDER BY to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300)`,
+        [trendStartedAt, now],
+      ),
+      pool.query(
+        `SELECT
+           count(*) FILTER (WHERE status = 'pending')::int AS pending_count,
+           count(*) FILTER (WHERE status = 'running')::int AS running_count,
+           round(avg(extract(epoch FROM (started_at - created_at)) * 1000) FILTER (WHERE started_at IS NOT NULL AND created_at >= $1))::int AS average_wait_ms,
+           round(percentile_cont(0.95) WITHIN GROUP (ORDER BY extract(epoch FROM (started_at - created_at)) * 1000) FILTER (WHERE started_at IS NOT NULL AND created_at >= $1))::int AS p95_wait_ms
+         FROM app.plan_task
+         WHERE status IN ('pending', 'running') OR (created_at >= $1 AND created_at <= $2)`,
+        [windowStartedAt, now],
+      ),
+      pool.query(
+        `SELECT
+           coalesce(sum(hit_count) FILTER (WHERE public_result IS NOT NULL), 0)::int AS hit_count,
+           count(*) FILTER (WHERE public_result IS NOT NULL)::int AS ready_entry_count,
+           count(*) FILTER (WHERE public_result IS NULL AND lease_expires_at > $1)::int AS filling_entry_count
+         FROM app.plan_cache
+         WHERE expires_at > $1`,
+        [now],
+      ),
+    ]);
+
+    assert.equal(solverRows.rowCount, 1);
+    assert.ok(Array.isArray(trendRows.rows));
+    assert.equal(taskRows.rowCount, 1);
+    assert.equal(cacheRows.rowCount, 1);
+  } finally {
+    await pool.end();
+  }
+});
+
 test("app schema stores only encrypted Box data and cascades account-owned business rows", async () => {
   const pool = new Pool({ connectionString: databaseUrl, max: 2 });
   const userId = randomUUID();

--- a/src/server/business-data.integration.test.mjs
+++ b/src/server/business-data.integration.test.mjs
@@ -34,15 +34,15 @@ test("admin solver metrics aggregates run against PostgreSQL", async () => {
       ),
       pool.query(
         `SELECT
-           to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300) AS bucket_started_at,
+           to_timestamp(floor(extract(epoch FROM created_at) / $3) * $4) AS bucket_started_at,
            count(*) FILTER (WHERE status = 'success')::int AS success_count,
            count(*) FILTER (WHERE status = 'failed')::int AS failure_count,
            round(avg(duration_ms) FILTER (WHERE status = 'success' AND duration_ms IS NOT NULL))::int AS average_duration_ms
          FROM app.plan_run
          WHERE created_at >= $1 AND created_at <= $2
-         GROUP BY to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300)
-         ORDER BY to_timestamp(floor(extract(epoch FROM created_at) / 300) * 300)`,
-        [trendStartedAt, now],
+         GROUP BY to_timestamp(floor(extract(epoch FROM created_at) / $5) * $6)
+         ORDER BY to_timestamp(floor(extract(epoch FROM created_at) / $7) * $8)`,
+        [trendStartedAt, now, 300, 300, 300, 300, 300, 300],
       ),
       pool.query(
         `SELECT

--- a/src/server/business-records.ts
+++ b/src/server/business-records.ts
@@ -10,6 +10,7 @@ import {
 } from "@/solver-metrics-config";
 import { buildAdminSolverMetricsData } from "@/solver-metrics";
 import type { AppErrorCode, FeedbackRequest, SavedPlanCalculationContext, SolverObservation } from "@/types";
+import { buildAdminSolverTrendQuery } from "./admin-solver-metrics-trend";
 import { BUSINESS_DATA_TTL_MS, isBusinessDatabaseEnabled, isPlanCacheEnabled } from "./business-config";
 import { getDatabase } from "./db";
 import {
@@ -277,7 +278,6 @@ export async function queryAdminSolverMetrics(now = new Date()) {
   const windowStartedAt = new Date(now.getTime() - ADMIN_SOLVER_ERROR_WINDOW_MINUTES * 60_000);
   const trendStartedAt = new Date(now.getTime() - ADMIN_SOLVER_TREND_WINDOW_MINUTES * 60_000);
   const trendBucketSeconds = ADMIN_SOLVER_TREND_BUCKET_MINUTES * 60;
-  const trendBucket = sql<Date>`to_timestamp(floor(extract(epoch from ${planRun.createdAt}) / ${trendBucketSeconds}) * ${trendBucketSeconds})`;
   const database = getDatabase();
   const [solverRows, trendRows, taskRows, cacheRows] = await Promise.all([
     database.select({
@@ -292,15 +292,7 @@ export async function queryAdminSolverMetrics(now = new Date()) {
       gte(planRun.createdAt, windowStartedAt),
       lte(planRun.createdAt, now),
     )),
-    database.select({
-      bucketStartedAt: trendBucket,
-      successCount: sql<number>`count(*) filter (where ${planRun.status} = 'success')::int`,
-      failureCount: sql<number>`count(*) filter (where ${planRun.status} = 'failed')::int`,
-      averageDurationMs: sql<number | null>`round(avg(${planRun.durationMs}) filter (where ${planRun.status} = 'success' and ${planRun.durationMs} is not null))::int`,
-    }).from(planRun).where(and(
-      gte(planRun.createdAt, trendStartedAt),
-      lte(planRun.createdAt, now),
-    )).groupBy(trendBucket).orderBy(trendBucket),
+    buildAdminSolverTrendQuery(database, trendStartedAt, now, trendBucketSeconds),
     database.select({
       pendingCount: sql<number>`count(*) filter (where ${planTask.status} = 'pending')::int`,
       runningCount: sql<number>`count(*) filter (where ${planTask.status} = 'running')::int`,


### PR DESCRIPTION
## Summary
- fix the production Admin solver-metrics 500 by preserving PostgreSQL grouping-expression identity
- share the exact trend query builder between runtime and the PostgreSQL regression test
- keep the existing 5-minute/60-minute metric semantics unchanged

## Root cause
Drizzle expanded the parameterized bucket expression separately in `SELECT`, `GROUP BY`, and `ORDER BY`. PostgreSQL received different placeholders for the same 300-second value and rejected the query with `42803: plan_run.created_at must appear in the GROUP BY clause`.

## Verification
- reproduced the production failure against CI PostgreSQL
- fixed PostgreSQL integration test passed on diagnostic run `33466000985`
- targeted ESLint passed
- 55 API/solver-metrics tests passed
- production Next.js build passed
- no version bump and no dependency changes