### PR TITLE
fix: decode Admin trend timestamps

### DIFF
--- a/src/server/admin-solver-metrics-trend.ts
+++ b/src/server/admin-solver-metrics-trend.ts
@@ -17,7 +17,11 @@ export function buildAdminSolverTrendQuery(
   // A bound value would become a different PostgreSQL placeholder each time,
   // so embed this trusted internal constant to preserve expression identity.
   const bucketSecondsLiteral = sql.raw(String(bucketSeconds));
-  const trendBucket = sql<Date>`to_timestamp(floor(extract(epoch from ${schema.planRun.createdAt}) / ${bucketSecondsLiteral}) * ${bucketSecondsLiteral})`;
+  // sql<Date> only describes the TypeScript result; computed SQL expressions do
+  // not inherit a runtime decoder. Reuse the timestamp column decoder so the
+  // metrics formatter receives a Date instead of PostgreSQL's timestamp string.
+  const trendBucket = sql`to_timestamp(floor(extract(epoch from ${schema.planRun.createdAt}) / ${bucketSecondsLiteral}) * ${bucketSecondsLiteral})`
+    .mapWith(schema.planRun.createdAt);
 
   return database.select({
     bucketStartedAt: trendBucket,

--- a/src/server/business-data.integration.test.mjs
+++ b/src/server/business-data.integration.test.mjs
@@ -23,13 +23,23 @@ test("admin solver metrics trend query preserves PostgreSQL grouping identity", 
   const database = drizzle({ client: pool, schema });
   const now = new Date();
   const trendStartedAt = new Date(now.getTime() - 60 * 60_000);
+  const diagnosticId = randomUUID();
   try {
+    await pool.query(
+      `INSERT INTO app.plan_run
+       (diagnostic_id,source_type,status,layout_template,room_count,operator_count,rotation,fiammetta_enable,created_at,expires_at)
+       VALUES ($1,'sample','success','243',1,1,'abc',false,$2,now()+interval '1 day')`,
+      [diagnosticId, now],
+    );
     const query = buildAdminSolverTrendQuery(database, trendStartedAt, now, 300);
     const generated = query.toSQL();
     assert.equal(generated.params.includes(300), false);
     assert.match(generated.sql, /\/ 300\) \* 300\)/);
-    assert.ok(Array.isArray(await query));
+    const rows = await query;
+    assert.ok(rows.length > 0);
+    assert.ok(rows.every((row) => row.bucketStartedAt instanceof Date));
   } finally {
+    await pool.query("DELETE FROM app.plan_run WHERE diagnostic_id=$1", [diagnosticId]).catch(() => undefined);
     await pool.end();
   }
 });


### PR DESCRIPTION
## Summary
- decode computed solver trend timestamps with the schema timestamp decoder
- add a PostgreSQL regression test that inserts a real trend row and requires a `Date`

## Root cause
`sql<Date>` only supplied a compile-time type. Drizzle returned the computed `to_timestamp(...)` value as a string, and the metrics formatter crashed when calling `getTime()`.

## Verification
- regression test fails on the previous implementation in run 33477575135
- ESLint passes
- 310 unit tests pass
- PostgreSQL integration, API contracts, production build, and Chromium E2E pass in run 33478136131