### PR TITLE
优化排班页面的技能详情弹窗

### DIFF
--- a/src/app/api/building-terms/route.ts
+++ b/src/app/api/building-terms/route.ts
@@ -1,0 +1,14 @@
+import termCatalogJson from "@/generated/arkntools/term-catalog.json" with { type: "json" };
+import { createRequestId, successResponse } from "@/server/api-contract";
+
+type TermRecord = { id: string; name: string; desc: string; descText: string };
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return successResponse(
+    termCatalogJson as Record<string, TermRecord>,
+    createRequestId(),
+  );
+}

--- a/src/components/OperatorSkillTooltip.tsx
+++ b/src/components/OperatorSkillTooltip.tsx
@@ -3,7 +3,7 @@
 import type { ReactElement } from "react";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { RichTextStatic } from "@/components/RichTextStatic";
+import { RichTextHoverTerms } from "@/components/RichTextHoverTerms";
 import {
   BUILDING_SKILL_ENHANCED_WORD,
   buildingSkillUnlockLabel,
@@ -54,7 +54,7 @@ function SkillBlock({ skill }: { skill: BuildingSkillPresentation }) {
         )}
       </span>
       <span className="mt-1 block">
-        {skill.descriptionRich ? <RichTextStatic text={skill.descriptionRich} /> : skill.description}
+        {skill.descriptionRich ? <RichTextHoverTerms text={skill.descriptionRich} /> : skill.description}
       </span>
     </div>
   );

--- a/src/components/RichTextHoverTerms.tsx
+++ b/src/components/RichTextHoverTerms.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+
+import { RichTextStatic } from "@/components/RichTextStatic";
+import { parseRichText, type RichTextNode } from "@/components/skill-query/rich-text";
+
+type TermRecord = { id: string; name: string; desc: string; descText: string };
+type TermCatalog = Record<string, TermRecord>;
+
+let termCatalogPromise: Promise<TermCatalog> | null = null;
+
+function loadTermCatalog(): Promise<TermCatalog> {
+  termCatalogPromise ??= fetch("/api/building-terms", {
+    method: "GET",
+    credentials: "same-origin",
+    headers: { accept: "application/json" },
+  })
+    .then(async (response) => {
+      if (!response.ok) throw new Error("Unable to load building terms");
+      const payload = await response.json() as { data?: TermCatalog };
+      if (!payload.data) throw new Error("Invalid building term response");
+      return payload.data;
+    })
+    .catch((error) => {
+      termCatalogPromise = null;
+      throw error;
+    });
+  return termCatalogPromise;
+}
+
+function renderHoverNodes(
+  nodes: readonly RichTextNode[],
+  catalog: TermCatalog | null,
+  ensureCatalog: () => void,
+): ReactNode {
+  return nodes.map((node, index) => {
+    if (node.type === "text") return node.text;
+    if (node.type === "style") {
+      return (
+        <span key={index} className={`riic-rt ${node.className}`}>
+          {renderHoverNodes(node.children, catalog, ensureCatalog)}
+        </span>
+      );
+    }
+    const term = catalog?.[node.id];
+    return (
+      <span
+        key={index}
+        className="group/term relative inline-block"
+        onPointerEnter={ensureCatalog}
+        onFocus={ensureCatalog}
+      >
+        <span className="riic-term" tabIndex={0}>
+          {renderHoverNodes(node.children, catalog, ensureCatalog)}
+        </span>
+        {term ? (
+          <span
+            className="pointer-events-none invisible absolute bottom-[calc(100%+0.5rem)] left-1/2 z-[60] w-max max-w-[min(20rem,calc(100vw-2rem))] -translate-x-1/2 translate-y-1 rounded-md border border-white/20 bg-zinc-900 px-3 py-2.5 font-normal leading-relaxed text-zinc-100 opacity-0 shadow-[0_10px_30px_rgb(0_0_0/0.38)] transition-[opacity,transform,visibility] duration-150 ease-out whitespace-normal group-hover/term:visible group-hover/term:translate-y-0 group-hover/term:opacity-100 group-focus-within/term:visible group-focus-within/term:translate-y-0 group-focus-within/term:opacity-100"
+            role="tooltip"
+          >
+            <strong className="block font-semibold">{term.name}</strong>
+            <span className="mt-1 block font-normal">
+              <RichTextStatic text={term.desc} />
+            </span>
+          </span>
+        ) : null}
+      </span>
+    );
+  });
+}
+
+/** 紧凑 tooltip 富文本：仅在首次悬停或聚焦词条时加载词条目录。 */
+export function RichTextHoverTerms({ text }: { text: string }) {
+  const nodes = useMemo(() => parseRichText(text), [text]);
+  const [catalog, setCatalog] = useState<TermCatalog | null>(null);
+  const ensureCatalog = useCallback(() => {
+    if (catalog) return;
+    void loadTermCatalog().then(setCatalog, () => undefined);
+  }, [catalog]);
+
+  return (
+    <span className="whitespace-pre-line">
+      {renderHoverNodes(nodes, catalog, ensureCatalog)}
+    </span>
+  );
+}


### PR DESCRIPTION
## 变更

优化排班页面中的基建技能详情交互。

- 排班页技能描述改用支持悬停词条的富文本组件。
- 鼠标悬停或键盘聚焦彩色词条时，在词条上方显示详情卡片。
- 词条详情使用静态富文本，避免产生嵌套弹窗。
- 详情卡片不会接管鼠标事件，因此不会导致外层干员技能窗口关闭。
- 上面修改仅针对排班页面的技能描述，查询页面没改。

## 验证

- [x] PR 的 base branch 是 `develop`
- [x] 已运行 `npm run check`
- [x] 已运行 `npm run build`
- [x] 已运行 `npm run audit:security`，结果为 0 个漏洞
- [x] 已通过本地 Chrome 排班页面交互验证
- [x] 本次不涉及数据库改动
- [x] 未包含凭据、用户数据、内部文档、solver 或真实部署信息

## 许可

- [x] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布
- [x] 第三方代码或素材已注明来源、许可证与固定版本