### PR TITLE
test: add read-only production runtime diagnostics

### DIFF
--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -166,7 +166,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Read-only incident diagnostics
-        if: startsWith(github.ref_name, 'investigate/')
+        if: inputs.mode == 'baseline'
         shell: bash
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}

--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -34,6 +34,7 @@ jobs:
       cancel-in-progress: false
     env:
       DEPLOY_APP_ROOT: ${{ vars.DEPLOY_APP_ROOT }}
+      DEPLOY_SERVICE: ${{ vars.DEPLOY_SERVICE }}
       DEPLOY_RUN_USER: ${{ vars.DEPLOY_RUN_USER || 'arkinfra' }}
       DEPLOY_INTERNAL_PORT: ${{ vars.DEPLOY_INTERNAL_PORT }}
       DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
@@ -60,6 +61,7 @@ jobs:
           [[ "$DEPLOY_SSH_USER" =~ ^[A-Za-z0-9_-]+$ ]]
           test "$DEPLOY_SSH_USER" != "root"
           [[ "$DEPLOY_APP_ROOT" =~ ^/opt/arknights-infra(-[A-Za-z0-9._-]+)?$ ]]
+          [[ "$DEPLOY_SERVICE" =~ ^arknights-infra(-[A-Za-z0-9_.@-]+)?$ ]]
           [[ "$DEPLOY_RUN_USER" =~ ^[A-Za-z0-9_-]+$ ]]
           test "$DEPLOY_RUN_USER" != "root"
           [[ "$DEPLOY_INTERNAL_PORT" =~ ^[0-9]{2,5}$ ]]
@@ -162,6 +164,63 @@ jobs:
             echo
             echo "Preflight is read-only: no archive, release directory, symlink switch, or service restart was requested."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Read-only incident diagnostics
+        if: startsWith(github.ref_name, 'investigate/')
+        shell: bash
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+        run: |
+          set -euo pipefail
+          ssh_options=(
+            -o BatchMode=yes
+            -o ConnectTimeout=15
+            -o ConnectionAttempts=2
+            -o ServerAliveInterval=15
+            -o ServerAliveCountMax=3
+          )
+
+          timeout --kill-after=10s 90s ssh "${ssh_options[@]}" \
+            "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
+            bash -s -- "$DEPLOY_SERVICE" "$DEPLOY_RUN_USER" <<'REMOTE'
+          set -euo pipefail
+          service="$1"
+          run_user="$2"
+          [[ "$service" =~ ^arknights-infra(-[A-Za-z0-9_.@-]+)?$ ]]
+          [[ "$run_user" =~ ^[A-Za-z0-9_-]+$ ]]
+
+          echo '=== host resources ==='
+          uptime
+          free -m
+          df -Pk /opt
+
+          echo '=== application processes ==='
+          ps -u "$run_user" -o pid=,ppid=,etimes=,rss=,comm= | sort -k5,5 -k1,1n
+
+          echo '=== application units ==='
+          mapfile -t units < <(
+            systemctl list-unit-files --type=service --no-legend "${service}*.service" \
+              | awk '{ print $1 }' \
+              | grep -E '^arknights-infra[-A-Za-z0-9_.@]*\.service$' \
+              | sort -u
+          )
+          ((${#units[@]} > 0))
+          for unit in "${units[@]}"; do
+            systemctl show --no-pager "$unit" \
+              --property=Id,ActiveState,SubState,Result,MainPID,NRestarts,MemoryCurrent,MemoryPeak,TasksCurrent,TasksMax,CPUUsageNSec,ExecMainStartTimestamp,ExecMainExitTimestamp
+          done
+
+          echo '=== recent application journals ==='
+          for unit in "${units[@]}"; do
+            echo "--- $unit ---"
+            journalctl --no-pager -o short-iso --since '90 minutes ago' -n 300 -u "$unit" || true
+          done
+
+          echo '=== recent kernel OOM evidence ==='
+          journalctl -k --no-pager -o short-iso --since '90 minutes ago' \
+            | grep -Ei 'out of memory|oom-kill|killed process' || true
+          REMOTE
 
       - name: Remove SSH credentials from the runner
         if: always()

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -191,6 +191,10 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
     preflightWorkflow.indexOf("    env:"),
     preflightWorkflow.indexOf("    steps:"),
   );
+  const runtimeDiagnostics = preflightWorkflow.slice(
+    preflightWorkflow.indexOf("      - name: Read-only incident diagnostics"),
+    preflightWorkflow.indexOf("      - name: Remove SSH credentials from the runner"),
+  );
 
   assert.match(qualityWorkflow, /HEAD_REPOSITORY[\s\S]+EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+"\$HEAD_REF" == release\/\*/);
   assert.match(qualityWorkflow, /types: \[opened, synchronize, reopened, labeled, unlabeled\]/);
@@ -215,6 +219,13 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(preflightWorkflow, /solver_source=not-inspected-root-only/);
   assert.doesNotMatch(preflightWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release|cache_repository|expected_origin|public_cache_ready|cache_public_origin_ready|repository\.git|git --git-dir/);
   assert.doesNotMatch(preflightWorkflow, /current_release\/\.env\.production\.local|current_release="\$\(readlink/);
+  assert.match(runtimeDiagnostics, /if: inputs\.mode == 'baseline'/);
+  assert.match(runtimeDiagnostics, /ps -u "\$run_user" -o pid=,ppid=,etimes=,rss=,comm=/);
+  assert.match(runtimeDiagnostics, /systemctl show --no-pager[\s\S]+journalctl --no-pager/);
+  assert.doesNotMatch(
+    runtimeDiagnostics,
+    /^\s+(?:sudo|systemctl (?:start|stop|restart)|kill |rm )/m,
+  );
   assert.match(preflightWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);
   assert.match(deployWorkflow, /printf '%s\\n' "\$DEPLOY_PUBLIC_HEALTH_URL" \| ssh[\s\S]+'\$public_health_argument'/);
   assert.match(deployWorkflow, /'\$DEPLOY_EXPECTED_REPOSITORY'[\s\S]+'\$DEPLOY_APPROVED_SOLVER_SHA256'[\s\S]+'\$DEPLOY_TREE_SHA'/);


### PR DESCRIPTION
Adds a bounded, read-only runtime diagnostics section to the existing baseline deployment preflight.

It reports host resources, application process counts, systemd unit state, recent unit journals, and kernel OOM evidence. It does not read process arguments or environment values and the regression test rejects service mutations.

This is CI-only and does not request an application deployment. It is needed to diagnose the delayed 502/504 incident before the delta-cache optimization is restored.

Validation: node --test scripts/build-tooling.test.mjs scripts/ci-change-scope.test.mjs (27 passed).