### PR TITLE
fix: handle systemd templates in runtime diagnostics

### DIFF
--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -197,12 +197,18 @@ jobs:
 
           echo '=== application processes ==='
           ps -u "$run_user" -o pid=,ppid=,etimes=,rss=,comm= | sort -k5,5 -k1,1n
+          while read -r pid; do
+            [[ "$pid" =~ ^[0-9]+$ ]]
+            printf 'pid=%s cgroup=' "$pid"
+            awk -F: '$1 == "0" { print $3 }' "/proc/$pid/cgroup"
+          done < <(ps -u "$run_user" -o pid=)
 
           echo '=== application units ==='
           mapfile -t units < <(
             systemctl list-unit-files --type=service --no-legend "${service}*.service" \
               | awk '{ print $1 }' \
               | grep -E '^arknights-infra[-A-Za-z0-9_.@]*\.service$' \
+              | grep -v '@\.service$' \
               | sort -u
           )
           ((${#units[@]} > 0))

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -221,6 +221,8 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.doesNotMatch(preflightWorkflow, /current_release\/\.env\.production\.local|current_release="\$\(readlink/);
   assert.match(runtimeDiagnostics, /if: inputs\.mode == 'baseline'/);
   assert.match(runtimeDiagnostics, /ps -u "\$run_user" -o pid=,ppid=,etimes=,rss=,comm=/);
+  assert.match(runtimeDiagnostics, /awk -F: '\$1 == "0" \{ print \$3 \}' "\/proc\/\$pid\/cgroup"/);
+  assert.match(runtimeDiagnostics, /grep -v '@\\\.service\$'/);
   assert.match(runtimeDiagnostics, /systemctl show --no-pager[\s\S]+journalctl --no-pager/);
   assert.doesNotMatch(
     runtimeDiagnostics,


### PR DESCRIPTION
Fixes the read-only baseline diagnostics after the first production run encountered a systemd template unit. Template unit definitions are skipped and each application PID now includes its cgroup for precise service ownership.

No service mutation is performed. The build-tooling regression test passes (19 tests).