### PR TITLE
chore: prepare v0.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to RIIC-Web are documented in this file.
 
+## [0.2.3] - 2026-09-02
+
+### Changed
+
+- Plan results no longer repeat the same training advice in the compact details view; the dedicated training section remains available.
+
+### Fixed
+
+- Skland imports now show the correct operator count when Amiya has multiple forms.
+- A delayed Skland restore no longer overwrites a MAA operator box imported while the restore is still in progress, while existing Skland boxes continue to refresh normally.
+
+### For contributors
+
+- `package.json` and `package-lock.json` record release `0.2.3`.
+
 ## [0.2.2] - 2026-09-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "arknights-infra-calc-beta-test",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "license": "PolyForm-Noncommercial-1.0.0",
   "packages": {
     "": {
       "name": "arknights-infra-calc-beta-test",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "PolyForm-Noncommercial-1.0.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arknights-infra-calc-beta-test",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## What changed

- Record release version 0.2.3 in `package.json` and `package-lock.json`.
- Add a concise user-facing changelog for PRs #70, #75, and #83.
- Keep runtime behavior identical to the already-tested develop commit.

## Validation

- `npm test` — 310/310 passed
- `git diff --check`
- Final develop runtime before this metadata commit — 97 Chromium E2E passed, production profile passed, server-side deployment and internal health checks passed.

## Rollout note

The development public-health secret currently points to an unreachable preview endpoint, so its external compression probe reports `fetch failed` after a successful server-side deployment. The release owner explicitly approved continuing with the complete CI suite and internal deployment health as the pre-production gate.