### PR TITLE
v0.3.0 fix: unblock plan worker deployment readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to RIIC-Web are documented in this file.
 
 ### Fixed
 
+- Worker readiness no longer waits for the historical artifact recovery scan, preventing large retained record sets from exhausting the deployment health window.
 - Worker notification connections now reconnect after initial handshake or socket failures without leaving the queue asleep.
 - Queue schema upgrades now serialize concurrent migrations and build admission indexes online, avoiding conflicting deploys and unnecessary scheduling downtime.
 - Artifact completion no longer becomes permanently pending when database confirmation is temporarily unavailable or a process crashes before its run record is created.

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -72,6 +72,18 @@ test("the plan worker centrally dispatches an eight-task pipeline across four is
   assert.match(workerRuntime, /PLAN_TASK_PIPELINE_DEPTH = 2/);
   assert.match(infra, /export async function warmPlanServeLane[\s\S]+getPlanServeClient\(serveLane\)[\s\S]+await serveClient\.ping\(\)[\s\S]+inspectSolverDeploymentReadiness/);
   assert.match(workerRuntime, /warmPlanServeLane[\s\S]+length: PLAN_TASK_WORKER_CONCURRENCY[\s\S]+warmPlanServeLane\(serveLane\)[\s\S]+recoverStaleRunningTasks[\s\S]+recordPlanWorkerHeartbeat/);
+  const startup = workerRuntime.slice(workerRuntime.indexOf("export async function runPlanWorker"));
+  const firstHeartbeat = startup.indexOf("await recordPlanWorkerHeartbeat");
+  const heartbeatTimer = startup.indexOf("const heartbeatTimer = setInterval");
+  const artifactRecovery = startup.indexOf("void resumePendingPlanArtifactFinalizations");
+  assert.ok(firstHeartbeat >= 0 && firstHeartbeat < heartbeatTimer);
+  assert.ok(heartbeatTimer < artifactRecovery);
+  const artifactResume = infra.slice(
+    infra.indexOf("export async function resumePendingPlanArtifactFinalizations"),
+    infra.indexOf("export async function waitForPlanArtifactFinalizers"),
+  );
+  assert.match(artifactResume, /batchSize = 64[\s\S]+await Promise\.all[\s\S]+await readdir\(runDir\)/);
+  assert.doesNotMatch(artifactResume, /existsSync/);
   assert.match(workerRuntime, /capacity = PLAN_TASK_WORKER_CONCURRENCY \* PLAN_TASK_PIPELINE_DEPTH/);
   assert.match(workerRuntime, /runPlanWorkerDispatcher[\s\S]+Math\.min\(\.\.\.laneLoads\)[\s\S]+laneLoads\.findIndex[\s\S]+dependencies\.claim[\s\S]+dependencies\.execute\(task, serveLane\)/);
   assert.match(workerRuntime, /listenForPlanTaskAvailability[\s\S]+using 2s fallback polling/);

--- a/scripts/plan-worker-runtime.mts
+++ b/scripts/plan-worker-runtime.mts
@@ -414,7 +414,6 @@ export async function runPlanWorker(): Promise<void> {
   if (!/^[0-9a-f]{40}$/.test(releaseSha)) throw new Error("APP_RELEASE_SHA must be a full lowercase Git commit SHA.");
 
   const startedAt = new Date();
-  const resumedArtifacts = await resumePendingPlanArtifactFinalizations();
   await Promise.all(Array.from(
     { length: PLAN_TASK_WORKER_CONCURRENCY },
     (_, serveLane) => warmPlanServeLane(serveLane),
@@ -430,7 +429,7 @@ export async function runPlanWorker(): Promise<void> {
     pipelineDepth: PLAN_TASK_PIPELINE_DEPTH,
     inFlight: 0,
   });
-  console.log(`[plan-worker] started release=${releaseSha} solverLanes=${PLAN_TASK_WORKER_CONCURRENCY} pipelineDepth=${PLAN_TASK_PIPELINE_DEPTH} capacity=${PLAN_TASK_WORKER_CONCURRENCY * PLAN_TASK_PIPELINE_DEPTH} recovered=${recovery.recovered} failed=${recovery.failed} resumedArtifacts=${resumedArtifacts}`);
+  console.log(`[plan-worker] started release=${releaseSha} solverLanes=${PLAN_TASK_WORKER_CONCURRENCY} pipelineDepth=${PLAN_TASK_PIPELINE_DEPTH} capacity=${PLAN_TASK_WORKER_CONCURRENCY * PLAN_TASK_PIPELINE_DEPTH} recovered=${recovery.recovered} failed=${recovery.failed}`);
 
   let shuttingDown = false;
   let heartbeatInFlight = false;
@@ -458,6 +457,10 @@ export async function runPlanWorker(): Promise<void> {
   }, CLEANUP_INTERVAL_MS);
   heartbeatTimer.unref();
   cleanupTimer.unref();
+
+  void resumePendingPlanArtifactFinalizations()
+    .then((resumedArtifacts) => console.log(`[plan-worker] artifact recovery queued=${resumedArtifacts}`))
+    .catch((error) => console.error("[plan-worker] artifact recovery scan failed:", error));
 
   const stopListening = await listenForPlanTaskAvailability(() => wake.notify()).catch((error) => {
     console.error("[plan-worker] LISTEN unavailable; using 2s fallback polling:", error);

--- a/src/server/infra.ts
+++ b/src/server/infra.ts
@@ -1141,17 +1141,26 @@ export async function resumePendingPlanArtifactFinalizations(
   await mkdir(cliRunRoot, { recursive: true });
   const entries = await readdir(cliRunRoot, { withFileTypes: true });
   let resumed = 0;
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const runDir = path.join(cliRunRoot, entry.name);
-    const envelopePath = path.join(runDir, "run-envelope.json");
-    if (
-      !existsSync(envelopePath)
-      || existsSync(path.join(runDir, "artifact-finalized.json"))
-      || existsSync(path.join(runDir, "artifact-failed.json"))
-    ) continue;
-    enqueuePlanArtifactEnvelope(envelopePath, dependencies);
-    resumed += 1;
+  const directories = entries.filter((entry) => entry.isDirectory());
+  const batchSize = 64;
+  for (let offset = 0; offset < directories.length; offset += batchSize) {
+    const envelopePaths = await Promise.all(
+      directories.slice(offset, offset + batchSize).map(async (entry) => {
+        const runDir = path.join(cliRunRoot, entry.name);
+        const files = new Set(await readdir(runDir).catch(() => []));
+        if (
+          !files.has("run-envelope.json")
+          || files.has("artifact-finalized.json")
+          || files.has("artifact-failed.json")
+        ) return null;
+        return path.join(runDir, "run-envelope.json");
+      }),
+    );
+    for (const envelopePath of envelopePaths) {
+      if (!envelopePath) continue;
+      enqueuePlanArtifactEnvelope(envelopePath, dependencies);
+      resumed += 1;
+    }
   }
   return resumed;
 }


### PR DESCRIPTION
﻿## Summary

- Publishes the first Worker heartbeat only after all four solver lanes are warm, then starts heartbeat renewal before historical artifact recovery.
- Runs retained artifact discovery in asynchronous 64-directory batches and queues finalization in the background, so large private-record sets cannot block deployment readiness.
- Adds a regression guard for startup ordering and non-blocking artifact discovery.

## Incident evidence

The first `develop` deployment of v0.3.0 completed migrations and database readiness, but `/api/health` did not become ready within the deployment window. The deployment helper rolled back automatically. Read-only server diagnostics showed sufficient memory and disk with no OOM evidence; the only new pre-heartbeat operation was the retained artifact scan.

- Failed deployment: https://github.com/KnightCodeSquareMatrix/RIIC-Web/actions/runs/33589594016
- Read-only diagnostics: https://github.com/KnightCodeSquareMatrix/RIIC-Web/actions/runs/33590355921

## Verification

- Targeted Worker/artifact/build-tooling regression tests: 33/33 pass.
- `npm run check`: pass (335 main tests, 2 mounted/API tests, 56 API-contract tests, 13 shift-comparison tests).
- Worker bundle and `node --check`: pass.
- Next.js production build and TypeScript: pass.

?? Generated with OpenAI Codex
