### PR TITLE
功能：练卡建议展示对应基建技能

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -422,9 +422,11 @@ test("calculator owns scheduling controls and training advice uses a single tech
         {
           priority: "高",
           kind: "promote",
-          operator: "阿米娅",
+          operator: "清流",
           domain_id: "manufacture",
           message: "优先完成精英化与技能等级，补齐制造站轮换深度。",
+          current_elite: 0,
+          tier_up_requirement: "精1",
         },
         {
           priority: "中",
@@ -441,6 +443,7 @@ test("calculator owns scheduling controls and training advice uses a single tech
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/");
   await expect(page.locator('[data-workbench-hydrated="true"]')).toBeVisible();
+  await page.getByRole("button", { name: "中文", exact: true }).click();
 
   const calculatorControls = page.locator("[data-calculator-controls]");
   await expect(calculatorControls).toBeVisible();
@@ -469,6 +472,16 @@ test("calculator owns scheduling controls and training advice uses a single tech
   await expect(advicePortrait).toHaveAttribute("height", "80");
   await expect(advicePortrait).toHaveAttribute("loading", "lazy");
   await expect(advicePortrait).toHaveAttribute("decoding", "async");
+  await advicePortrait.hover();
+  const adviceSkillTooltip = page.locator('[data-slot="tooltip-content"]').filter({ hasText: "再生能源" });
+  await expect(adviceSkillTooltip).toBeVisible();
+  await expect(adviceSkillTooltip).toContainText("干员基建技能 · 已标出本次目标");
+  await expect(adviceSkillTooltip).toContainText("本次目标");
+  await page.keyboard.press("Escape");
+  await expect(adviceSkillTooltip).toBeHidden();
+  const adviceSkillTrigger = adviceCards.first().locator('[tabindex="0"]').first();
+  await adviceSkillTrigger.click();
+  await expect(adviceSkillTooltip).toBeVisible();
   const cardBoxes = await adviceCards.evaluateAll((elements) => elements.map((element) => {
     const box = element.getBoundingClientRect();
     return { left: box.left, top: box.top, width: box.width };

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1137,6 +1137,7 @@ function OperatorSlotShell({
   compactView,
   frameClassName,
   frameContent,
+  frameFocusable = false,
   frameWrapper = (frame) => frame,
   label,
   labelClassName,
@@ -1149,6 +1150,7 @@ function OperatorSlotShell({
   compactView: boolean;
   frameClassName: string;
   frameContent?: ReactNode;
+  frameFocusable?: boolean;
   /** 可选：包装头像框元素（例如包上技能 tooltip 的 trigger）。默认原样返回。 */
   frameWrapper?: (frame: ReactElement) => ReactElement;
   label: ReactNode;
@@ -1161,9 +1163,12 @@ function OperatorSlotShell({
       className={cn(
         "relative aspect-square h-[var(--operator-slot-size)] min-w-0 shrink-0 overflow-hidden border-2 max-sm:border",
         frameClassName,
+        frameFocusable && "cursor-help outline-none transition-[border-color,box-shadow] hover:border-white/90 focus-visible:border-[#FFD501] focus-visible:ring-2 focus-visible:ring-[#FFD501]/70",
         centerFrameInList && "max-sm:h-auto max-sm:w-full sm:absolute sm:left-0 sm:top-1/2 sm:-translate-y-1/2",
       )}
       aria-label={ariaLabel}
+      role={frameFocusable ? "button" : undefined}
+      tabIndex={frameFocusable ? 0 : undefined}
     >
       {frameContent}
     </div>
@@ -1253,6 +1258,9 @@ export function OperatorSlot({
   portraitSize = 180,
   positionLabel,
   showSkillTooltip = false,
+  skillTooltipFocusable = false,
+  skillTooltipHighlightIds = [],
+  skillTooltipContextLabel,
   searchQuery = "",
 }: {
   slot: RoomRow["operatorSlots"][number] | undefined;
@@ -1267,6 +1275,11 @@ export function OperatorSlot({
   positionLabel?: string;
   /** 悬停卡片时展示干员全部基建技能 tooltip，并关闭卡片自身的原生 title hover。 */
   showSkillTooltip?: boolean;
+  /** 让头像进入键盘焦点顺序；仅用于需要主动查看技能的界面，避免排班图产生过多 Tab 停靠点。 */
+  skillTooltipFocusable?: boolean;
+  /** 练卡建议等场景中，需要在技能 tooltip 内强调的技能。 */
+  skillTooltipHighlightIds?: readonly string[];
+  skillTooltipContextLabel?: string;
   searchQuery?: string;
 }) {
   const shouldReduceMotion = useReducedMotion();
@@ -1279,9 +1292,12 @@ export function OperatorSlot({
   const enterX = shouldReduceMotion ? 0 : shiftDirection * 6;
   const exitX = shouldReduceMotion ? 0 : shiftDirection * -4;
   const occupantLabel = displayName ?? (autofill ? (locale === "en" ? "Auto-fill" : "自动补位") : (locale === "en" ? "Empty" : "空置"));
-  const ariaLabel = displayPositionLabel
+  const occupantAriaLabel = displayPositionLabel
     ? `${displayPositionLabel}${locale === "en" ? ": " : "："}${occupantLabel}`
     : occupantLabel;
+  const ariaLabel = showSkillTooltip && skillTooltipFocusable && slot
+    ? `${occupantAriaLabel}${locale === "en" ? ". Focus to view infrastructure skills" : "，聚焦可查看基建技能"}`
+    : occupantAriaLabel;
   const searchMatched = Boolean(slot && searchQuery && slot.name.toLocaleLowerCase("zh-CN").includes(searchQuery));
   const frameClassName = slot
     ? "border-[#7F7F7F] bg-[#3C3C3C] shadow-[inset_0_0_18px_rgba(255,255,255,0.16)]"
@@ -1379,9 +1395,15 @@ export function OperatorSlot({
           </motion.div>
         </AnimatePresence>
       }
+      frameFocusable={showSkillTooltip && skillTooltipFocusable && Boolean(slot)}
       frameWrapper={showSkillTooltip && slot ? (frame) => (
         <Suspense fallback={frame}>
-          <OperatorSkillTooltip name={slot.name} trigger={frame} />
+          <OperatorSkillTooltip
+            name={slot.name}
+            trigger={frame}
+            highlightedSkillIds={skillTooltipHighlightIds}
+            contextLabel={skillTooltipContextLabel}
+          />
         </Suspense>
       ) : undefined}
       label={slot ? <AnimatedText value={displayName ?? slot.name} trend={shiftDirection} /> : autofill ? (locale === "en" ? "Auto-fill" : "自动补位") : (locale === "en" ? "Slot" : "占")}

--- a/src/components/OperatorSkillTooltip.tsx
+++ b/src/components/OperatorSkillTooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactElement } from "react";
+import { cloneElement, useState, type KeyboardEventHandler, type MouseEventHandler, type ReactElement } from "react";
 
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { RichTextHoverTerms } from "@/components/RichTextInteractive";
@@ -12,38 +12,83 @@ import {
   type BuildingSkillPresentation,
 } from "@/operatorPortraits";
 import { demoBuildingSkill, useLanguageDemo } from "@/language-demo";
+import { cn } from "@/lib/utils";
 
 /**
  * 悬停干员头像框时展示该干员全部基建技能的 tooltip。
  * trigger 直接复用干员卡片的头像框元素（有真实盒子），tooltip 固定出现在头像框上边缘中间。
  */
-export function OperatorSkillTooltip({ name, trigger }: { name: string; trigger: ReactElement }) {
+export function OperatorSkillTooltip({
+  name,
+  trigger,
+  highlightedSkillIds = [],
+  contextLabel,
+}: {
+  name: string;
+  trigger: ReactElement;
+  highlightedSkillIds?: readonly string[];
+  contextLabel?: string;
+}) {
   const { locale } = useLanguageDemo();
+  const [open, setOpen] = useState(false);
   const skills = operatorBuildingSkillList(name);
   if (skills.length === 0) return trigger; // 未知干员：原样渲染，不包 Tooltip
+  const highlighted = new Set(highlightedSkillIds);
+  const sourceProps = trigger.props as {
+    onClick?: MouseEventHandler<HTMLElement>;
+    onKeyDown?: KeyboardEventHandler<HTMLElement>;
+  };
+  const interactiveTrigger = cloneElement(trigger as ReactElement<Record<string, unknown>>, {
+    onClick: ((event) => {
+      sourceProps.onClick?.(event);
+      if (!event.defaultPrevented) setOpen(true);
+    }) as MouseEventHandler<HTMLElement>,
+    onKeyDown: ((event) => {
+      sourceProps.onKeyDown?.(event);
+      if (!event.defaultPrevented && (event.key === "Enter" || event.key === " ")) {
+        event.preventDefault();
+        setOpen(true);
+      }
+    }) as KeyboardEventHandler<HTMLElement>,
+  });
 
   return (
-    <Tooltip>
-      <TooltipTrigger render={trigger} />
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <TooltipTrigger closeOnClick={false} render={interactiveTrigger} />
       <TooltipContent
         side="top"
         align="center"
-        className="max-w-md flex-col items-start gap-2 whitespace-normal px-3 py-2.5 text-left leading-relaxed"
+        className="max-w-[calc(100vw-2rem)] flex-col items-start gap-2 whitespace-normal px-3 py-2.5 text-left leading-relaxed sm:max-w-md"
       >
+        {contextLabel ? (
+          <span className="border-b border-background/15 pb-1 text-[11px] font-semibold tracking-wide text-background/60">
+            {contextLabel}
+          </span>
+        ) : null}
         {skills.map((sourceSkill) => (
-          <SkillBlock key={sourceSkill.id} skill={demoBuildingSkill(sourceSkill.id, locale, sourceSkill) as BuildingSkillPresentation} />
+          <SkillBlock
+            key={sourceSkill.id}
+            locale={locale}
+            skill={demoBuildingSkill(sourceSkill.id, locale, sourceSkill) as BuildingSkillPresentation}
+            highlighted={highlighted.has(sourceSkill.id)}
+          />
         ))}
       </TooltipContent>
     </Tooltip>
   );
 }
 
-function SkillBlock({ skill }: { skill: BuildingSkillPresentation }) {
+function SkillBlock({ skill, locale, highlighted }: { skill: BuildingSkillPresentation; locale: "zh" | "en"; highlighted: boolean }) {
   return (
-    <div className="min-w-0">
-      <span className="flex items-center gap-1.5 font-semibold">
+    <div className={cn("min-w-0", highlighted && "border-l-2 border-[#FFD501] pl-2")}>
+      <span className="flex flex-wrap items-center gap-1.5 font-semibold">
         <img src={skill.icon} alt="" aria-hidden="true" className="size-7 shrink-0 object-contain" />
         <span>{skill.name}</span>
+        {highlighted ? (
+          <span className="rounded-sm bg-[#FFD501] px-1.5 py-0.5 text-[10px] font-bold text-[#202223]">
+            {locale === "en" ? "THIS TARGET" : "本次目标"}
+          </span>
+        ) : null}
       </span>
       <span className="mt-1 block text-background/72">
         {skill.enhanced ? (

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { MOTION_DURATION, MOTION_EASE_OUT } from "@/motion";
 import { operatorPortraitFor, operatorProfessionFor } from "@/operatorPortraits";
 import type { OperBoxEntry, UserProfileAction } from "@/types";
+import { legacyTrainingTarget, trainingAdviceSkillSummary } from "@/components/training-advice/skill-selection";
 
 const DOMAIN_LABELS: Record<string, string> = { trade: "贸易站", trading: "贸易站", manufacture: "制造站", manu: "制造站", power: "发电站", control: "控制中枢", general: "综合" };
 const DOMAIN_GROUPS: Record<string, string> = { trade: "trading", trading: "trading", manufacture: "manufacture", manu: "manufacture", power: "power", control: "control", general: "training" };
@@ -29,6 +30,13 @@ export function RecommendationCard({ action, entry, variant = "full", index = 0,
   const reduceMotion = useReducedMotion();
   const priority = action.priority || "未分级";
   const isHighPriority = /高|urgent|critical|p0|p1/i.test(priority);
+  const skillSummary = trainingAdviceSkillSummary(
+    action.operator,
+    action.current_elite !== undefined || entry
+      ? { elite: action.current_elite ?? entry?.elite, level: entry?.level }
+      : undefined,
+    legacyTrainingTarget(action.tier_up_requirement),
+  );
   const content = variant === "compact" ? (
     <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-3 border-b border-border/60 py-3 last:border-0" data-recommendation-card="compact">
       <div className="min-w-0">
@@ -52,6 +60,11 @@ export function RecommendationCard({ action, entry, variant = "full", index = 0,
           }}
           portraitSize={80}
           showSkillTooltip={showSkillTooltip}
+          skillTooltipFocusable={showSkillTooltip && skillSummary.skills.length > 0}
+          skillTooltipHighlightIds={skillSummary.highlightedSkillIds}
+          skillTooltipContextLabel={skillSummary.highlightedSkillIds.length
+            ? "干员基建技能 · 已标出本次目标"
+            : "该干员的基建技能"}
         />
         <div className="grid min-w-0 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
           <div className="min-w-0"><div className="flex flex-wrap items-center gap-2 text-xs text-white/55"><span className="font-medium text-[var(--room-accent)]">{recommendationDomainLabel(action.domain_id)}</span><span aria-hidden="true">·</span><span>{recommendationKindLabel(action.kind)}</span></div><p className="font-number mt-2 max-w-[72ch] text-pretty text-sm leading-6 text-white/82">{action.message || "暂无具体说明"}</p></div>

--- a/src/components/pages/TrainingAdvice.tsx
+++ b/src/components/pages/TrainingAdvice.tsx
@@ -360,7 +360,7 @@ export function TrainingAdvice({
             <div className="grid min-w-0 gap-3" data-training-advice-list>
               <Suspense fallback={<p className="py-4 text-sm text-white/62" role="status">正在加载培养建议…</p>}>
                 {actions.map((action, index) => (
-                  <RecommendationCard key={actionKey(action, index)} action={action} entry={ownedByName.get(action.operator)} index={index} showSkillTooltip={false} />
+                  <RecommendationCard key={actionKey(action, index)} action={action} entry={ownedByName.get(action.operator)} index={index} />
                 ))}
               </Suspense>
             </div>

--- a/src/components/training-advice/TrainingAdviceActionCard.tsx
+++ b/src/components/training-advice/TrainingAdviceActionCard.tsx
@@ -22,6 +22,7 @@ import {
   trainingProductLabel,
   trainingReasonLabel,
 } from "./presentation";
+import { trainingAdviceSkillSummary } from "./skill-selection";
 
 const ACTION_LABELS: Record<string, string> = { acquire: "获取", train: "培养" };
 type ActionCardItem = TrainingNewbieItem | TrainingRecommendation;
@@ -42,6 +43,7 @@ export function TrainingAdviceActionCard({
   const currentText = action.current ? `${en ? "Current" : "当前"} ${trainingLevelText(action.current, en)} → ` : "";
   const targetText = trainingLevelText(action.target, en);
   const operatorName = demoOperatorName(action.operator, locale);
+  const skillSummary = trainingAdviceSkillSummary(action.operator, action.current, action.target);
 
   return (
     <motion.div
@@ -68,6 +70,11 @@ export function TrainingAdviceActionCard({
             }}
             portraitSize={80}
             showSkillTooltip
+            skillTooltipFocusable={skillSummary.skills.length > 0}
+            skillTooltipHighlightIds={skillSummary.highlightedSkillIds}
+            skillTooltipContextLabel={skillSummary.highlightedSkillIds.length
+              ? (en ? "Operator skills · target skill highlighted" : "干员基建技能 · 已标出本次目标")
+              : (en ? "Operator infrastructure skills" : "该干员的基建技能")}
           />
           <div className="grid min-w-0 gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
             <div className="min-w-0">

--- a/src/components/training-advice/presentation.test.ts
+++ b/src/components/training-advice/presentation.test.ts
@@ -16,6 +16,7 @@ import {
   trainingScaleLabel,
 } from "./presentation.ts";
 import type { TrainingCombination, TrainingRecommendation } from "@/types";
+import { legacyTrainingTarget, trainingAdviceSkillSummary } from "./skill-selection.ts";
 
 const target = { kind: "explicit" as const, elite: 1, level: 30 };
 
@@ -95,4 +96,24 @@ test("preserves the server-defined combination and recommendation order", () => 
 
   assert.deepEqual(sortTrainingCombinations(combinations).map((item) => item.id), ["complete-first", "missing-second"]);
   assert.deepEqual(sortTrainingRecommendations(recommendations).map((item) => item.operator), ["服务端第一名", "服务端第二名"]);
+});
+
+test("marks the infrastructure skill unlocked by the recommended training target", () => {
+  const summary = trainingAdviceSkillSummary(
+    "清流",
+    { elite: 0, level: 30 },
+    { kind: "explicit", elite: 1, level: 1 },
+  );
+
+  assert.deepEqual(
+    summary.skills.filter((skill) => summary.highlightedSkillIds.includes(skill.id)).map((skill) => skill.name),
+    ["再生能源"],
+  );
+});
+
+test("legacy training requirements are parsed without guessing missing targets", () => {
+  assert.deepEqual(legacyTrainingTarget("需精2"), { kind: "explicit", elite: 2, level: 1 });
+  assert.deepEqual(legacyTrainingTarget("Elite 1"), { kind: "explicit", elite: 1, level: 1 });
+  assert.equal(legacyTrainingTarget("按技能要求"), undefined);
+  assert.equal(legacyTrainingTarget("提升 2 级"), undefined);
 });

--- a/src/components/training-advice/skill-selection.ts
+++ b/src/components/training-advice/skill-selection.ts
@@ -1,0 +1,67 @@
+import {
+  operatorBuildingSkillList,
+  type BuildingSkillPresentation,
+} from "../../operatorPortraits.ts";
+import type { TrainingAdviceState, TrainingAdviceTarget } from "../../types.ts";
+
+type SkillLevel = Pick<TrainingAdviceState, "elite" | "level">;
+
+export interface TrainingAdviceSkillSummary {
+  skills: BuildingSkillPresentation[];
+  highlightedSkillIds: string[];
+}
+
+function levelScore(value: Partial<SkillLevel> | undefined): number | null {
+  if (typeof value?.elite !== "number") return null;
+  return value.elite * 100_000 + (value.level ?? 1);
+}
+
+function targetLevelScore(target: TrainingAdviceTarget | undefined): number | null {
+  if (!target || target.kind === "no_requirement" || target.kind === "needs_review") return null;
+  return levelScore(target);
+}
+
+/**
+ * 展示干员全部基建技能，并标出从当前练度升到本次目标时会解锁或强化的技能。
+ * 练卡协议暂不含 skill_id，因此这里只根据协议给出的解锁练度做确定性标注，不猜技能联动。
+ */
+export function trainingAdviceSkillSummary(
+  operator: string,
+  current?: Partial<SkillLevel>,
+  target?: TrainingAdviceTarget,
+): TrainingAdviceSkillSummary {
+  const skills = operatorBuildingSkillList(operator);
+  const targetScore = targetLevelScore(target);
+  if (!skills.length || targetScore === null) return { skills, highlightedSkillIds: [] };
+
+  const currentScore = levelScore(current);
+  if (currentScore !== null) {
+    return {
+      skills,
+      highlightedSkillIds: skills
+        .filter((skill) => {
+          const score = levelScore(skill);
+          return score !== null && score > currentScore && score <= targetScore;
+        })
+        .map((skill) => skill.id),
+    };
+  }
+
+  const unlockedAtTarget = skills.filter((skill) => {
+    const score = levelScore(skill);
+    return score !== null && score <= targetScore;
+  });
+  const latestScore = Math.max(...unlockedAtTarget.map((skill) => levelScore(skill) ?? -1));
+  return {
+    skills,
+    highlightedSkillIds: unlockedAtTarget
+      .filter((skill) => levelScore(skill) === latestScore)
+      .map((skill) => skill.id),
+  };
+}
+
+export function legacyTrainingTarget(requirement?: string): TrainingAdviceTarget | undefined {
+  const matchedElite = requirement?.match(/(?:精(?:英)?\s*|elite\s*)([012])/i)?.[1];
+  if (matchedElite === undefined) return undefined;
+  return { kind: "explicit", elite: Number(matchedElite), level: 1 };
+}


### PR DESCRIPTION
## 改动

- 练卡建议头像悬停时展示该干员的全部基建技能
- 根据当前练度与培养目标，高亮本次会解锁或强化的技能
- 新旧练卡建议结果均支持点击、触摸、Enter / Space 与 Escape 操作
- 限制小屏浮层宽度，并补充清晰的焦点状态
- 不包含本地 5174 免登录逻辑

## 验证

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test`（350 项通过）
- [x] `npm run test:api-contract`（65 项通过）
- [x] `npm run test:shift-comparison`（13 项通过）
- [x] `npm run check:public-repository`
- [x] Chromium 定向交互测试

## 许可

- [x] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布
- [x] 未引入新的第三方代码或素材