### PR TITLE
fix(skills): 技能查询每次手动展开 10 名干员

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -36,6 +36,30 @@ test("mobile interactive targets remain at least 44 CSS pixels", async ({ page }
   expect(undersized).toEqual([]);
 });
 
+test("skill query reveals results ten at a time only after manual expansion", async ({ page }) => {
+  await mockApis(page);
+  await seedPreferences(page);
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/skills");
+
+  const skillQuery = page.locator("[data-skill-query-page]");
+  const results = skillQuery.locator('article[aria-label$="的基建技能"]');
+  const loadMore = skillQuery.locator("[data-load-more]");
+  const expandButton = loadMore.getByRole("button", { name: /再展开 10 名/ });
+
+  await expect(skillQuery).toBeVisible();
+  await expect(results).toHaveCount(10);
+  await loadMore.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(300);
+  await expect(results).toHaveCount(10);
+  await expect(expandButton).toBeVisible();
+
+  await expandButton.click();
+  await expect(results).toHaveCount(20);
+  await expandButton.click();
+  await expect(results).toHaveCount(30);
+});
+
 test("an empty generated profile explains that no training action is needed", async ({ page }) => {
   await mockApis(page);
   await seedV4Session(page);

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -49,7 +49,7 @@ test("skill query reveals results ten at a time only after manual expansion", as
 
   await expect(skillQuery).toBeVisible();
   await expect(results).toHaveCount(10);
-  await loadMore.scrollIntoViewIfNeeded();
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
   await page.waitForTimeout(300);
   await expect(results).toHaveCount(10);
   await expect(expandButton).toBeVisible();

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -199,7 +199,7 @@ test("CI gates releases on Chromium and schedules the full WebKit suite", async 
   assert.match(workflow, /deploy:[\s\S]+needs: \[changes, quality\]/);
   assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 91);
+  assert.equal(readinessTestCount, 92);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: false/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 3 : undefined/);

--- a/src/components/pages/SkillQuery.tsx
+++ b/src/components/pages/SkillQuery.tsx
@@ -148,8 +148,11 @@ export function SkillQuery() {
               key={`${query}:${selectedRoom ?? ""}:${selectedTag ?? ""}`}
               hasMore={hasMore}
               onLoad={loadMore}
+              auto={false}
               className="mt-4 border-t border-border/60 pt-2"
-              labels={en ? { idle: "Load more", loading: "Loading", error: "Load failed — retry", end: "All results shown" } : undefined}
+              labels={en
+                ? { idle: "Show 10 more", loading: "Loading", error: "Load failed — retry", end: "All results shown" }
+                : { idle: "再展开 10 名" }}
             />
           </>
         )}


### PR DESCRIPTION
## 变更

- 技能查询页默认仅显示 10 名干员。
- 关闭滚动触发的自动加载，改由用户点击“再展开 10 名”。
- 每次点击追加 10 名，并同步英文按钮文案。
- 新增回归测试，覆盖滚动不自动展开及连续两次手动展开。

## 验证

- [x] PR 的 base branch 是 `develop`；只有维护者的 `release/**` PR 可以指向 `main`，不经 `develop` 的特批发布还必须带有 `direct-main-release` 标签
- [ ] 已运行 `npm run check`（定向 ESLint 已通过）
- [ ] 已运行 `npm run build`
- [x] 交互改动已运行相关 Chromium 测试：定向用例 1 passed
- [x] 本 PR 无数据库改动，无需迁移
- [x] 未包含凭据、用户数据、内部文档、服务器 helper、solver 或真实部署信息

## 许可

- [x] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布（请提交者确认）
- [x] 未引入第三方代码或素材