### PR TITLE
fix: 为求解报错保存独立复现资料

### DIFF
--- a/scripts/plan-worker-runtime.mts
+++ b/scripts/plan-worker-runtime.mts
@@ -11,6 +11,7 @@ import {
   getPlanCacheSolverIdentity,
   resumePendingPlanArtifactFinalizations,
   runPlan,
+  savePlanFailureArtifact,
   stopInfraServeClients,
   waitForPlanArtifactFinalizers,
   warmPlanServeLane,
@@ -65,6 +66,7 @@ type PlanTaskExecutionDependencies = {
   markSolverFinished: typeof markPlanTaskSolverFinished;
   toPublicPlanData: typeof toPublicPlanData;
   describeArtifact: typeof describePlanArtifact;
+  saveFailureArtifact: typeof savePlanFailureArtifact;
   releaseCacheLease: typeof releasePlanCacheLease;
   completeCache: typeof completePlanCache;
   updateRunExecution: typeof updatePlanRunExecutionBestEffort;
@@ -86,6 +88,7 @@ const productionTaskExecutionDependencies: PlanTaskExecutionDependencies = {
   markSolverFinished: markPlanTaskSolverFinished,
   toPublicPlanData,
   describeArtifact: describePlanArtifact,
+  saveFailureArtifact: savePlanFailureArtifact,
   releaseCacheLease: releasePlanCacheLease,
   completeCache: completePlanCache,
   updateRunExecution: updatePlanRunExecutionBestEffort,
@@ -265,6 +268,27 @@ export async function executePlanTask(
     return solverDurationMs === null ? null : Math.max(1, solverDurationMs);
   } catch (error) {
     if (lease) await dependencies.releaseCacheLease(lease).catch(() => undefined);
+    const errorCode = errorCodeOf(error);
+    const deferredArtifact = artifactResult ? await dependencies.describeArtifact(artifactResult) : null;
+    const fallbackArtifact = await dependencies.saveFailureArtifact({
+      diagnosticId,
+      layout: payload.layout,
+      operbox: payload.operbox,
+      sourceName: payload.sourceName,
+      rotation: payload.rotation,
+      fiammettaEnable: payload.fiammettaEnable,
+      dataOwnerTag: payload.dataOwnerTag,
+      errorCode,
+    }).catch((artifactError) => {
+      console.error(JSON.stringify({
+        level: "error",
+        event: "plan_failure_artifact_write_failed",
+        taskId: id,
+        errorType: artifactError instanceof Error ? artifactError.name : typeof artifactError,
+      }));
+      return null;
+    });
+    const artifact = fallbackArtifact ?? deferredArtifact;
     await dependencies.recordRun({
       diagnosticId,
       userId: task.userId,
@@ -276,11 +300,13 @@ export async function executePlanTask(
       operatorCount: payload.operatorCount,
       rotation: payload.rotation,
       fiammettaEnable: payload.fiammettaEnable,
-      errorCode: errorCodeOf(error),
+      errorCode,
       executionSource: taskSource === "failed" ? null : taskSource,
       solverDurationMs,
-      artifact: artifactResult ? await dependencies.describeArtifact(artifactResult) : null,
-      artifactStatus: artifactResult?.artifactEnvelopePath ? "pending" : "none",
+      artifact,
+      artifactStatus: deferredArtifact && artifactResult?.artifactEnvelopePath
+        ? "pending"
+        : artifact ? "complete" : "none",
       createdAt: new Date(),
     });
     await dependencies.completeTask(id, { status: "failed", error: "排班失败，请重试。" });
@@ -288,7 +314,7 @@ export async function executePlanTask(
       level: "error",
       event: "plan_task_failed",
       taskId: id,
-      errorCode: errorCodeOf(error),
+      errorCode,
       errorType: error instanceof Error ? error.name : typeof error,
     }));
     return solverDurationMs === null ? null : Math.max(1, solverDurationMs);

--- a/scripts/plan-worker-runtime.test.mjs
+++ b/scripts/plan-worker-runtime.test.mjs
@@ -74,6 +74,7 @@ function executionHarness(overrides = {}) {
     markSolverFinished: async () => { calls.push("solver-finished"); return true; },
     toPublicPlanData: () => result,
     describeArtifact: async () => ({ key: "artifact", bytes: 1, sha256: "b".repeat(64) }),
+    saveFailureArtifact: async () => { calls.push("failure-artifact"); return null; },
     releaseCacheLease: async () => { calls.push("lease-release"); },
     completeCache: async () => { calls.push("cache-complete"); },
     updateRunExecution: async () => { calls.push("timing"); return true; },
@@ -144,6 +145,9 @@ test("a solver lease is cached and the artifact is queued only after task public
 
 test("a failed solver releases its cache lease before recording the terminal task", async () => {
   const lease = { kind: "lease", keyHmac: "cache-key", leaseOwner: "lease-owner" };
+  const task = claimedTask();
+  const recorded = [];
+  const failureArtifacts = [];
   const { calls, dependencies } = executionHarness({
     getCacheSolverIdentity: async () => ({
       protocol_version: 1,
@@ -153,13 +157,32 @@ test("a failed solver releases its cache lease before recording the terminal tas
     }),
     resolveCache: async () => lease,
     runPlan: async () => { throw new Error("solver unavailable"); },
+    saveFailureArtifact: async (input) => {
+      calls.push("failure-artifact");
+      failureArtifacts.push(input);
+      return { key: input.diagnosticId, bytes: 1, sha256: "d".repeat(64) };
+    },
+    recordRun: async (input) => { recorded.push(input); calls.push(`record:${input.status}`); return true; },
   });
 
-  assert.equal(await executePlanTask(claimedTask(), 1, dependencies), null);
+  assert.equal(await executePlanTask(task, 1, dependencies), null);
   assert.equal(await waitForPlanExecutionUpdates(1_000), true);
+  assert.deepEqual(failureArtifacts, [{
+    diagnosticId: task.id,
+    layout: task.payload.layout,
+    operbox: task.payload.operbox,
+    sourceName: task.payload.sourceName,
+    rotation: task.payload.rotation,
+    fiammettaEnable: task.payload.fiammettaEnable,
+    dataOwnerTag: task.payload.dataOwnerTag,
+    errorCode: "AIC-SYS-5000",
+  }]);
+  assert.equal(recorded[0].artifact.key, task.id);
+  assert.equal(recorded[0].artifactStatus, "complete");
   assert.deepEqual(calls, [
     "start:solver",
     "lease-release",
+    "failure-artifact",
     "record:failed",
     "task:failed",
     "timing",
@@ -210,6 +233,7 @@ test("an unsuccessful solver response preserves its public error and queues the 
   assert.deepEqual(calls, [
     "start:solver",
     "solver-finished",
+    "failure-artifact",
     "record:failed",
     "task:failed",
     "artifact-enqueue",

--- a/src/server/infra-private-records.test.ts
+++ b/src/server/infra-private-records.test.ts
@@ -235,7 +235,7 @@ test("Skland owned-data deletion removes only matching runs and feedback without
     else process.env.BETA_BUSINESS_DB_ENABLED = previousBusinessDbEnabled;
   });
 
-  const { deleteFeedbackArtifacts, deletePlanRunArtifacts, deleteSklandOwnedData, maintainPrivateRecords, readFeedbackReproduction, readPlanReproduction, runPlan, saveFeedback } = await import("./infra.ts");
+  const { deleteFeedbackArtifacts, deletePlanRunArtifacts, deleteSklandOwnedData, maintainPrivateRecords, readFeedbackReproduction, readPlanReproduction, runPlan, saveFeedback, savePlanFailureArtifact } = await import("./infra.ts");
 
   const planInput = {
     layout: {
@@ -281,7 +281,64 @@ test("Skland owned-data deletion removes only matching runs and feedback without
     assert.ok(files.includes(deferArtifacts ? "run-envelope.json" : "result.json"));
     const storedOperbox = JSON.parse(await readFile(path.join(runsRoot, runName!, "operbox.json"), "utf8"));
     assert.equal(storedOperbox[0].name, "阿米娅");
+    if (deferArtifacts) {
+      const fullTaskOperbox = [
+        ...planInput.operbox,
+        {
+          id: "char_unowned_deferred_fixture",
+          name: "Unowned deferred fixture operator",
+          own: false,
+          level: 1,
+          elite: 0,
+          potential: 1,
+          rarity: 4,
+        },
+      ];
+      await savePlanFailureArtifact({
+        ...planInput,
+        diagnosticId: failed.runId!,
+        layout: planInput.layout as BaseBlueprint,
+        operbox: fullTaskOperbox,
+        rotation: "abc_12_6_6",
+        errorCode: "AIC-PLAN-3004",
+      });
+      const taskSnapshot = await readPlanReproduction(failed.runId!);
+      assert.equal(taskSnapshot.operbox?.length, fullTaskOperbox.length);
+      assert.equal(taskSnapshot.operbox?.[1]?.own, false);
+    }
   }
+  const workerFailureDiagnosticId = "12121212-1212-4212-8212-121212121212";
+  const workerFailureOperbox = [
+    ...planInput.operbox,
+    {
+      id: "char_unowned_fixture",
+      name: "Unowned fixture operator",
+      own: false,
+      level: 1,
+      elite: 0,
+      potential: 1,
+      rarity: 4,
+    },
+  ];
+  const workerFailureArtifact = await savePlanFailureArtifact({
+    diagnosticId: workerFailureDiagnosticId,
+    layout: planInput.layout as BaseBlueprint,
+    operbox: workerFailureOperbox,
+    sourceName: "worker failure fixture",
+    rotation: "main_backup_12_12",
+    fiammettaEnable: false,
+    dataOwnerTag: targetOwnerTag,
+    errorCode: "AIC-SYS-5000",
+  });
+  assert.equal(workerFailureArtifact?.key, workerFailureDiagnosticId);
+  const workerFailureReproduction = await readPlanReproduction(workerFailureDiagnosticId);
+  assert.equal(workerFailureReproduction.available, true);
+  assert.equal(workerFailureReproduction.operbox?.length, workerFailureOperbox.length);
+  assert.equal(workerFailureReproduction.operbox?.[1]?.own, false);
+  assert.equal(workerFailureReproduction.rotationCount, 2);
+  assert.equal(workerFailureReproduction.fiammettaEnabled, false);
+  assert.equal(workerFailureReproduction.error, "AIC-SYS-5000");
+
   const reproduction = await readPlanReproduction(reproductionDiagnosticId);
   assert.equal(reproduction.available, true);
   assert.equal(reproduction.rotation, "abc_12_6_6");
@@ -418,7 +475,7 @@ test("Skland owned-data deletion removes only matching runs and feedback without
   await utimes(unrelatedRun, retainedAt, retainedAt);
   await maintainPrivateRecords();
   await rm(legacyPurgeMarker, { force: true });
-  assert.deepEqual(await deleteSklandOwnedData([targetOwnerTag]), { runs: 1, feedback: 3 });
+  assert.deepEqual(await deleteSklandOwnedData([targetOwnerTag]), { runs: 2, feedback: 3 });
   await assert.rejects(stat(targetRun), { code: "ENOENT" });
   await assert.rejects(stat(linkedFeedback), { code: "ENOENT" });
   await assert.rejects(stat(ownedFeedback), { code: "ENOENT" });

--- a/src/server/infra.ts
+++ b/src/server/infra.ts
@@ -703,10 +703,14 @@ export async function readPlanReproduction(
       unavailableReason: lookup.status === "invalid" ? "invalid" : missingReproductionReason(fallback),
     });
   }
+  const taskSnapshotDir = path.join(lookup.directory, "task-reproduction");
   const [layout, operbox, context, stderrExcerpt, stdoutExcerpt] = await Promise.all([
-    readJsonIfExists(path.join(lookup.directory, "layout.json")),
-    readJsonIfExists(path.join(lookup.directory, "operbox.json")),
-    readJsonIfExists(path.join(lookup.directory, "reproduction.json")),
+    readJsonIfExists(path.join(taskSnapshotDir, "layout.json"))
+      .then((value) => value ?? readJsonIfExists(path.join(lookup.directory, "layout.json"))),
+    readJsonIfExists(path.join(taskSnapshotDir, "operbox.json"))
+      .then((value) => value ?? readJsonIfExists(path.join(lookup.directory, "operbox.json"))),
+    readJsonIfExists(path.join(taskSnapshotDir, "reproduction.json"))
+      .then((value) => value ?? readJsonIfExists(path.join(lookup.directory, "reproduction.json"))),
     readTextTail(path.join(lookup.directory, "stderr.txt")),
     readTextTail(path.join(lookup.directory, "stdout.txt")),
   ]);
@@ -1195,6 +1199,112 @@ export async function saveFeedback(
     feedbackId,
     savedAt,
   };
+}
+
+export async function savePlanFailureArtifact(input: PlanRequestBody & {
+  diagnosticId: string;
+  errorCode: string;
+}): Promise<PrivateArtifactDescriptor | null> {
+  assertPlanBody(input);
+  if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[1-8][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/i.test(input.diagnosticId)) {
+    throw new Error("Plan failure diagnostic ID is invalid.");
+  }
+
+  await ensurePrivateStorageBoundaries();
+  const startedAt = new Date().toISOString();
+  const suffix = `_${input.diagnosticId}`;
+  const existingDir = (await runDirectories())
+    .find((candidate) => path.basename(candidate).endsWith(suffix));
+  if (existingDir) {
+    const existing = await lookupPrivateRun(input.diagnosticId);
+    if (existing.status !== "found") throw new Error("Existing plan failure artifact is invalid.");
+    const existingArtifact = existsSync(path.join(existingDir, "run-envelope.json"))
+      ? path.join(existingDir, "run-envelope.json")
+      : path.join(existingDir, "result.json");
+    const snapshotDir = path.join(existingDir, "task-reproduction");
+    const snapshotPaths = [
+      path.join(snapshotDir, "layout.json"),
+      path.join(snapshotDir, "operbox.json"),
+      path.join(snapshotDir, "reproduction.json"),
+    ];
+    if (snapshotPaths.every((filePath) => existsSync(filePath))) {
+      return artifactDescriptor(input.diagnosticId, [existingArtifact, ...snapshotPaths]);
+    }
+
+    const stagingSnapshotDir = `${snapshotDir}.pending-${randomUUID()}`;
+    await mkdir(stagingSnapshotDir);
+    try {
+      await Promise.all([
+        writeJsonAtomic(path.join(stagingSnapshotDir, "layout.json"), input.layout),
+        writeJsonAtomic(path.join(stagingSnapshotDir, "operbox.json"), input.operbox),
+        writeJsonAtomic(path.join(stagingSnapshotDir, "reproduction.json"), {
+          version: 1,
+          diagnosticId: input.diagnosticId,
+          sourceName: input.sourceName ?? null,
+          rotation: input.rotation,
+          fiammettaEnabled: input.fiammettaEnable ?? true,
+        }),
+      ]);
+      await rename(stagingSnapshotDir, snapshotDir);
+    } catch (error) {
+      await rm(stagingSnapshotDir, { recursive: true, force: true }).catch(() => undefined);
+      throw error;
+    }
+    return artifactDescriptor(input.diagnosticId, [existingArtifact, ...snapshotPaths]);
+  }
+
+  const runDir = path.join(
+    cliRunRoot,
+    makeStampedDirName(startedAt, input.sourceName, input.diagnosticId),
+  );
+  const stagingDir = `${runDir}.pending-${randomUUID()}`;
+  const layoutPath = path.join(stagingDir, "layout.json");
+  const operboxPath = path.join(stagingDir, "operbox.json");
+  const reproductionPath = path.join(stagingDir, "reproduction.json");
+  const resultPath = path.join(stagingDir, "result.json");
+  const ownerPath = path.join(stagingDir, "owner.json");
+  const artifactPaths = [layoutPath, operboxPath, reproductionPath, resultPath];
+
+  await mkdir(stagingDir);
+  try {
+    await Promise.all([
+      writeJsonAtomic(layoutPath, input.layout),
+      writeJsonAtomic(operboxPath, input.operbox),
+      writeJsonAtomic(reproductionPath, {
+        version: 1,
+        diagnosticId: input.diagnosticId,
+        sourceName: input.sourceName ?? null,
+        rotation: input.rotation,
+        fiammettaEnabled: input.fiammettaEnable ?? true,
+      }),
+      writeJsonAtomic(resultPath, {
+        success: false,
+        startedAt,
+        durationMs: 0,
+        error: input.errorCode,
+        runId: input.diagnosticId,
+      } satisfies PlanApiResponse),
+      ...(input.dataOwnerTag ? [
+        writeJsonAtomic(ownerPath, {
+          version: 1,
+          ownerTag: input.dataOwnerTag,
+          diagnosticId: input.diagnosticId,
+          sourceName: input.sourceName ?? null,
+          createdAt: startedAt,
+        }, true),
+      ] : []),
+    ]);
+    if (input.dataOwnerTag) artifactPaths.push(ownerPath);
+    await rename(stagingDir, runDir);
+  } catch (error) {
+    await rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return artifactDescriptor(
+    input.diagnosticId,
+    artifactPaths.map((filePath) => path.join(runDir, path.basename(filePath))),
+  );
 }
 
 export async function describePlanArtifact(result: PlanApiResponse): Promise<PrivateArtifactDescriptor | null> {


### PR DESCRIPTION
## 修改内容
- Worker 在求解任务异常返回前，从持久化任务 payload 独立保存复现资料
- 对已有 CLI 失败制品补充 task-reproduction 快照，Admin 优先读取完整原始 Box
- 保存基建布局、完整干员 Box、轮换配置和菲亚梅塔状态，并沿用 30 天清理与数据归属删除
- 添加 Worker 异常分支和私有存储回归测试

## 原因
求解调用在返回 PlanApiResponse 前抛错时，plan_run 只写摘要且 artifactStatus=none，导致后台无法读取复现 JSON。

## 验证
- npm run check
- npm run audit:security
- npm run build
- npm run worker:build && node --check dist/plan-worker.cjs
- npm run test:e2e（首次 6 worker：90 通过、16 个资源争用超时）
- npx playwright test --project=chromium --last-failed --workers=1（16/16 通过）

## 影响范围
- CLI：不修改协议或求解逻辑
- 公共 API：不修改响应 DTO
- 森空岛会话：不修改；私有快照继续按 ownerTag 清理
- 存储：新增失败任务 task-reproduction 私有快照，30 天到期
- 反馈 JSON / MAA JSON：不修改