### PR TITLE
fix: 修复不完整求解报错制品

### DIFF
--- a/scripts/plan-worker-runtime.mts
+++ b/scripts/plan-worker-runtime.mts
@@ -198,8 +198,10 @@ export async function executePlanTask(
     taskSource = "solver";
     await dependencies.markExecutionStarted(id, "solver");
     artifactResult = await dependencies.runPlan({
-      layout: payload.layout,
-      operbox: payload.operbox,
+      // runPlan normalizes its input in place. Keep the encrypted task payload intact
+      // so a later failure snapshot still contains the user's complete reproduction.
+      layout: structuredClone(payload.layout),
+      operbox: structuredClone(payload.operbox),
       sourceName: payload.sourceName,
       rotation: payload.rotation,
       fiammettaEnable: payload.fiammettaEnable,

--- a/scripts/plan-worker-runtime.test.mjs
+++ b/scripts/plan-worker-runtime.test.mjs
@@ -146,6 +146,11 @@ test("a solver lease is cached and the artifact is queued only after task public
 test("a failed solver releases its cache lease before recording the terminal task", async () => {
   const lease = { kind: "lease", keyHmac: "cache-key", leaseOwner: "lease-owner" };
   const task = claimedTask();
+  task.payload.operbox = [
+    { id: "owned", name: "Owned", own: true, level: 80, elite: 2, potential: 6, rarity: 6 },
+    { id: "unowned", name: "Unowned", own: false, level: 1, elite: 0, potential: 1, rarity: 5 },
+  ];
+  const expectedFailureOperbox = task.payload.operbox.map((operator) => ({ ...operator }));
   const recorded = [];
   const failureArtifacts = [];
   const { calls, dependencies } = executionHarness({
@@ -156,7 +161,10 @@ test("a failed solver releases its cache lease before recording the terminal tas
       observed_at: "2026-09-02T00:00:00.000Z",
     }),
     resolveCache: async () => lease,
-    runPlan: async () => { throw new Error("solver unavailable"); },
+    runPlan: async (input) => {
+      input.operbox.splice(0, input.operbox.length, input.operbox[0]);
+      throw new Error("solver unavailable");
+    },
     saveFailureArtifact: async (input) => {
       calls.push("failure-artifact");
       failureArtifacts.push(input);
@@ -170,13 +178,14 @@ test("a failed solver releases its cache lease before recording the terminal tas
   assert.deepEqual(failureArtifacts, [{
     diagnosticId: task.id,
     layout: task.payload.layout,
-    operbox: task.payload.operbox,
+    operbox: expectedFailureOperbox,
     sourceName: task.payload.sourceName,
     rotation: task.payload.rotation,
     fiammettaEnable: task.payload.fiammettaEnable,
     dataOwnerTag: task.payload.dataOwnerTag,
     errorCode: "AIC-SYS-5000",
   }]);
+  assert.deepEqual(task.payload.operbox, expectedFailureOperbox);
   assert.equal(recorded[0].artifact.key, task.id);
   assert.equal(recorded[0].artifactStatus, "complete");
   assert.deepEqual(calls, [

--- a/src/server/infra-private-records.test.ts
+++ b/src/server/infra-private-records.test.ts
@@ -339,6 +339,32 @@ test("Skland owned-data deletion removes only matching runs and feedback without
   assert.equal(workerFailureReproduction.fiammettaEnabled, false);
   assert.equal(workerFailureReproduction.error, "AIC-SYS-5000");
 
+  const incompleteFailureDiagnosticId = "13131313-1313-4313-8313-131313131313";
+  const incompleteFailureDir = path.join(
+    runsRoot,
+    `2026-09-03T00-00-00-000Z_incomplete_${incompleteFailureDiagnosticId}`,
+  );
+  await mkdir(incompleteFailureDir);
+  await writeFile(path.join(incompleteFailureDir, "pre-error-marker.txt"), "preserve me", "utf8");
+  const repairedFailureArtifact = await savePlanFailureArtifact({
+    diagnosticId: incompleteFailureDiagnosticId,
+    layout: planInput.layout as BaseBlueprint,
+    operbox: workerFailureOperbox,
+    sourceName: "incomplete worker failure fixture",
+    rotation: "main_backup_12_12",
+    fiammettaEnable: false,
+    dataOwnerTag: targetOwnerTag,
+    errorCode: "AIC-BOX-1101",
+  });
+  assert.equal(repairedFailureArtifact?.key, incompleteFailureDiagnosticId);
+  assert.equal(await readFile(path.join(incompleteFailureDir, "pre-error-marker.txt"), "utf8"), "preserve me");
+  const repairedFailureReproduction = await readPlanReproduction(incompleteFailureDiagnosticId);
+  assert.equal(repairedFailureReproduction.available, true);
+  assert.equal(repairedFailureReproduction.operbox?.length, workerFailureOperbox.length);
+  assert.equal(repairedFailureReproduction.rotationCount, 2);
+  assert.equal(repairedFailureReproduction.fiammettaEnabled, false);
+  assert.equal(repairedFailureReproduction.error, "AIC-BOX-1101");
+
   const reproduction = await readPlanReproduction(reproductionDiagnosticId);
   assert.equal(reproduction.available, true);
   assert.equal(reproduction.rotation, "abc_12_6_6");

--- a/src/server/infra.ts
+++ b/src/server/infra.ts
@@ -613,12 +613,14 @@ async function lookupPrivateRun(diagnosticId: string): Promise<PrivateRunLookup>
   const directory = (await runDirectories())
     .find((candidate) => path.basename(candidate).endsWith(suffix));
   if (!directory) return { status: "missing" };
-  let result = await readJsonIfExists(path.join(directory, "result.json"));
-  if (!isObject(result)) {
-    const envelope = await readJsonIfExists(path.join(directory, "run-envelope.json"));
-    result = isObject(envelope) ? envelope.result : null;
-  }
-  return isObject(result) && result.runId === diagnosticId
+  const [storedResult, envelope, failureResult] = await Promise.all([
+    readJsonIfExists(path.join(directory, "result.json")),
+    readJsonIfExists(path.join(directory, "run-envelope.json")),
+    readJsonIfExists(path.join(directory, "task-reproduction", "result.json")),
+  ]);
+  const result = [storedResult, isObject(envelope) ? envelope.result : null, failureResult]
+    .find((candidate): candidate is JsonRecord => isObject(candidate) && candidate.runId === diagnosticId);
+  return result
     ? { status: "found", directory, result }
     : { status: "invalid", directory };
 }
@@ -1216,41 +1218,60 @@ export async function savePlanFailureArtifact(input: PlanRequestBody & {
   const existingDir = (await runDirectories())
     .find((candidate) => path.basename(candidate).endsWith(suffix));
   if (existingDir) {
-    const existing = await lookupPrivateRun(input.diagnosticId);
-    if (existing.status !== "found") throw new Error("Existing plan failure artifact is invalid.");
-    const existingArtifact = existsSync(path.join(existingDir, "run-envelope.json"))
-      ? path.join(existingDir, "run-envelope.json")
-      : path.join(existingDir, "result.json");
+    const envelopePath = path.join(existingDir, "run-envelope.json");
+    const resultPath = path.join(existingDir, "result.json");
+    const existingArtifact = existsSync(envelopePath)
+      ? envelopePath
+      : existsSync(resultPath) ? resultPath : null;
     const snapshotDir = path.join(existingDir, "task-reproduction");
     const snapshotPaths = [
       path.join(snapshotDir, "layout.json"),
       path.join(snapshotDir, "operbox.json"),
       path.join(snapshotDir, "reproduction.json"),
+      path.join(snapshotDir, "result.json"),
     ];
     if (snapshotPaths.every((filePath) => existsSync(filePath))) {
-      return artifactDescriptor(input.diagnosticId, [existingArtifact, ...snapshotPaths]);
+      return artifactDescriptor(input.diagnosticId, [
+        ...(existingArtifact ? [existingArtifact] : []),
+        ...snapshotPaths,
+      ]);
     }
 
-    const stagingSnapshotDir = `${snapshotDir}.pending-${randomUUID()}`;
-    await mkdir(stagingSnapshotDir);
-    try {
-      await Promise.all([
-        writeJsonAtomic(path.join(stagingSnapshotDir, "layout.json"), input.layout),
-        writeJsonAtomic(path.join(stagingSnapshotDir, "operbox.json"), input.operbox),
-        writeJsonAtomic(path.join(stagingSnapshotDir, "reproduction.json"), {
-          version: 1,
-          diagnosticId: input.diagnosticId,
-          sourceName: input.sourceName ?? null,
-          rotation: input.rotation,
-          fiammettaEnabled: input.fiammettaEnable ?? true,
-        }),
-      ]);
-      await rename(stagingSnapshotDir, snapshotDir);
-    } catch (error) {
-      await rm(stagingSnapshotDir, { recursive: true, force: true }).catch(() => undefined);
-      throw error;
+    const writeSnapshot = async (target: string) => Promise.all([
+      writeJsonAtomic(path.join(target, "layout.json"), input.layout),
+      writeJsonAtomic(path.join(target, "operbox.json"), input.operbox),
+      writeJsonAtomic(path.join(target, "reproduction.json"), {
+        version: 1,
+        diagnosticId: input.diagnosticId,
+        sourceName: input.sourceName ?? null,
+        rotation: input.rotation,
+        fiammettaEnabled: input.fiammettaEnable ?? true,
+      }),
+      writeJsonAtomic(path.join(target, "result.json"), {
+        success: false,
+        startedAt,
+        durationMs: 0,
+        error: input.errorCode,
+        runId: input.diagnosticId,
+      } satisfies PlanApiResponse),
+    ]);
+    if (existsSync(snapshotDir)) {
+      await writeSnapshot(snapshotDir);
+    } else {
+      const stagingSnapshotDir = `${snapshotDir}.pending-${randomUUID()}`;
+      await mkdir(stagingSnapshotDir);
+      try {
+        await writeSnapshot(stagingSnapshotDir);
+        await rename(stagingSnapshotDir, snapshotDir);
+      } catch (error) {
+        await rm(stagingSnapshotDir, { recursive: true, force: true }).catch(() => undefined);
+        throw error;
+      }
     }
-    return artifactDescriptor(input.diagnosticId, [existingArtifact, ...snapshotPaths]);
+    return artifactDescriptor(input.diagnosticId, [
+      ...(existingArtifact ? [existingArtifact] : []),
+      ...snapshotPaths,
+    ]);
   }
 
   const runDir = path.join(


### PR DESCRIPTION
## 改了什么
- 求解 Worker 调用求解器前深拷贝布局与干员 Box，失败补存仍使用未被归一化修改的完整输入。
- 允许在同一诊断 ID 已创建但尚未写完的运行目录中补建私有复现制品。
- 为补建快照写入可被后台读取的失败结果标记，并保留既有运行文件。
- 增加 Worker 输入隔离和不完整目录修复的回归测试。

## 为什么
最新求解报错可能在 runPlan 创建目录后、写入 result.json 前失败。旧补存逻辑把该目录判定为无效并再次抛错，Worker 又将补存异常降级吞掉，最终后台只看到 artifact=none。runPlan 还会原地归一化 Box，造成补存输入丢失未拥有干员。

## 验证
- node --test --experimental-strip-types src/server/infra-private-records.test.ts scripts/plan-worker-runtime.test.mjs（17/17）
- npm run check（通过）
- npm run audit:security（0 vulnerabilities）
- npm run build（通过）
- npm run worker:build && node --check dist/plan-worker.cjs（通过）
- npm run test:e2e（首轮 105/108；3 个并发资源超时用单 Worker 复跑 3/3 通过）

## 影响面
- CLI：不修改求解协议或核心算法，只隔离 Worker 传入对象。
- 公共 API：无 DTO 或响应变化。
- 森空岛会话：无变化。
- 存储：修复求解失败私有制品补存，新增 task-reproduction/result.json 标记；仍只在服务端私有目录保存。
- 反馈 JSON / MAA JSON：无公开格式变化。