### PR TITLE
release: promote CI fast path to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,11 @@ name: Deploy verified branch
 
 on:
   workflow_call:
+    inputs:
+      artifact_name:
+        description: Immutable release artifact produced by the post-merge build job
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -45,7 +50,6 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
-          cache: npm
 
       - name: Resolve verified release identity
         shell: bash
@@ -59,6 +63,7 @@ jobs:
           {
             printf 'DEPLOY_TREE_SHA=%s\n' "$deploy_tree_sha"
             printf 'SOURCE_DATE_EPOCH=%s\n' "$source_date_epoch"
+            printf 'DEPLOY_ARTIFACT_PARENT=%s\n' "$RUNNER_TEMP/riic-web-release-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           } >> "$GITHUB_ENV"
 
       - name: Validate deployment configuration
@@ -105,61 +110,70 @@ jobs:
             echo "DEPLOY_PUBLIC_HEALTH_CHECK_ENABLED=0" >> "$GITHUB_ENV"
           fi
 
-      - name: Install verified build dependencies
-        run: npm ci
+      - name: Download verified release artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ runner.temp }}/riic-web-release-${{ github.run_id }}-${{ github.run_attempt }}/download
 
-      - name: Build standalone release
-        env:
-          APP_BUILD_ID: ${{ env.DEPLOY_SHA }}
-          APP_DEPLOYMENT_ENV: ${{ env.DEPLOYMENT_ENV }}
-          SKLAND_FEATURE_ENABLED: "1"
-          ACCOUNT_CLOUD_SYNC_ENABLED: "1"
-          DATABASE_URL: ""
-          DATABASE_MIGRATION_URL: ""
-          BETTER_AUTH_SECRET: ""
-          BETTER_AUTH_URL: ""
-          RESEND_API_KEY: ""
-          AUTH_EMAIL_FROM: ""
-        run: npm run build && npm run worker:build
-
-      - name: Stage and archive standalone release
+      - name: Validate and extract release artifact
         shell: bash
         run: |
           set -euo pipefail
-          artifact_parent="$(mktemp -d "$RUNNER_TEMP/riic-web-release.XXXXXX")"
-          artifact_root="$artifact_parent/release"
-          local_archive="$RUNNER_TEMP/arknights-infra-${DEPLOYMENT_ENV}-${DEPLOY_SHA}.tar.gz"
-          {
-            printf 'DEPLOY_ARTIFACT_PARENT=%s\n' "$artifact_parent"
-            printf 'DEPLOY_ARTIFACT_ROOT=%s\n' "$artifact_root"
-            printf 'DEPLOY_LOCAL_ARCHIVE=%s\n' "$local_archive"
-          } >> "$GITHUB_ENV"
-
-          RELEASE_SHA="$DEPLOY_SHA" RELEASE_TREE_SHA="$DEPLOY_TREE_SHA" \
-            npm run release:stage -- --output "$artifact_root"
-          tar --sort=name \
-            --mtime="@$SOURCE_DATE_EPOCH" \
-            --owner=0 \
-            --group=0 \
-            --numeric-owner \
-            --mode='u+rwX,go+rX,go-w' \
-            --format=gnu \
-            -cf - \
-            -C "$artifact_root" . \
-            | gzip --best --no-name --rsyncable > "$local_archive"
+          download_root="$DEPLOY_ARTIFACT_PARENT/download"
+          artifact_root="$DEPLOY_ARTIFACT_PARENT/release"
+          local_archive="$download_root/arknights-infra-${DEPLOYMENT_ENV}-${DEPLOY_SHA}.tar.gz"
+          checksum_file="$download_root/SHA256SUMS"
+          test -d "$download_root"
+          test ! -L "$download_root"
+          test -f "$local_archive"
+          test ! -L "$local_archive"
+          test -f "$checksum_file"
+          test ! -L "$checksum_file"
+          test "$(find "$download_root" -mindepth 1 -maxdepth 1 -type f | wc -l)" = "2"
+          test -z "$(find "$download_root" -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+          (cd "$download_root" && sha256sum --check --strict SHA256SUMS)
           gzip -t "$local_archive"
+
+          install -d -m 700 "$artifact_root"
+          while IFS= read -r archive_entry; do
+            case "$archive_entry" in
+              /*|../*|*/../*|*/..) echo "Unsafe release archive entry: $archive_entry" >&2; exit 1 ;;
+            esac
+          done < <(tar -tzf "$local_archive")
+          tar --extract --gzip --file "$local_archive" --directory "$artifact_root" \
+            --no-same-owner --no-same-permissions
+
+          node --input-type=module - "$artifact_root/.release-artifact.json" "$DEPLOY_SHA" "$DEPLOY_TREE_SHA" <<'NODE'
+          import assert from "node:assert/strict";
+          import { readFile } from "node:fs/promises";
+          const [metadataPath, expectedSha, expectedTree] = process.argv.slice(2);
+          const metadata = JSON.parse(await readFile(metadataPath, "utf8"));
+          assert.equal(metadata.formatVersion, 1);
+          assert.equal(metadata.kind, "riic-web-standalone");
+          assert.equal(metadata.releaseSha, expectedSha);
+          assert.equal(metadata.releaseTreeSha, expectedTree);
+          NODE
+
+          unsupported_local_entry="$(find "$artifact_root" -mindepth 1 ! -type f ! -type d -print -quit)"
+          if [[ -n "$unsupported_local_entry" ]]; then
+            echo "Standalone release tree contains unsupported filesystem entries: $unsupported_local_entry" >&2
+            exit 1
+          fi
 
           archive_bytes="$(stat -c '%s' "$local_archive")"
           archive_sha256="$(sha256sum "$local_archive" | cut -d ' ' -f 1)"
           [[ "$archive_bytes" =~ ^[1-9][0-9]*$ ]]
           [[ "$archive_sha256" =~ ^[0-9a-f]{64}$ ]]
           {
+            printf 'DEPLOY_ARTIFACT_ROOT=%s\n' "$artifact_root"
+            printf 'DEPLOY_LOCAL_ARCHIVE=%s\n' "$local_archive"
             printf 'DEPLOY_ARCHIVE_BYTES=%s\n' "$archive_bytes"
             printf 'DEPLOY_ARCHIVE_SHA256=%s\n' "$archive_sha256"
           } >> "$GITHUB_ENV"
 
           {
-            echo "### Standalone release artifact"
+            echo "### Downloaded release artifact"
             echo
             echo "| Environment | Commit | Tree | Bytes | SHA-256 |"
             echo "| --- | --- | --- | ---: | --- |"
@@ -373,14 +387,8 @@ jobs:
           set -euo pipefail
           if [[ -n "${DEPLOY_ARTIFACT_PARENT:-}" ]]; then
             case "$DEPLOY_ARTIFACT_PARENT" in
-              "$RUNNER_TEMP"/riic-web-release.*) rm -rf -- "$DEPLOY_ARTIFACT_PARENT" ;;
+              "$RUNNER_TEMP"/riic-web-release-[0-9]*-[0-9]*) rm -rf -- "$DEPLOY_ARTIFACT_PARENT" ;;
               *) echo "Refusing to remove unexpected artifact path: $DEPLOY_ARTIFACT_PARENT" >&2; exit 1 ;;
-            esac
-          fi
-          if [[ -n "${DEPLOY_LOCAL_ARCHIVE:-}" ]]; then
-            case "$DEPLOY_LOCAL_ARCHIVE" in
-              "$RUNNER_TEMP"/arknights-infra-*.tar.gz) rm -f -- "$DEPLOY_LOCAL_ARCHIVE" ;;
-              *) echo "Refusing to remove unexpected archive path: $DEPLOY_LOCAL_ARCHIVE" >&2; exit 1 ;;
             esac
           fi
 

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -1,4 +1,4 @@
-name: Frontend quality
+name: Post-merge release
 
 on:
   workflow_dispatch:
@@ -8,9 +8,6 @@ on:
         required: false
         default: true
         type: boolean
-  pull_request:
-    branches: [main, develop]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main, develop]
   schedule:
@@ -20,8 +17,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: frontend-quality-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: post-merge-release-${{ github.ref }}
+  cancel-in-progress: false
 
 env:
   BETA_DEBUG_TOOLS_ENABLED: "0"
@@ -36,44 +33,6 @@ env:
   AUTH_EMAIL_FROM: Authentication Test <auth@example.test>
 
 jobs:
-  pull_request_policy:
-    name: Pull request policy
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout release ancestry
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Enforce the main release lane
-        shell: bash
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-          HEAD_REF: ${{ github.head_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          EXPECTED_REPOSITORY: KnightCodeSquareMatrix/RIIC-Web
-          DIRECT_MAIN_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'direct-main-release') && '1' || '0' }}
-        run: |
-          set -euo pipefail
-          if [[ "$EVENT_NAME" == "pull_request" && "$BASE_REF" == "main" ]]; then
-            test "$HEAD_REPOSITORY" = "$EXPECTED_REPOSITORY"
-            [[ "$HEAD_REF" == release/* ]]
-            [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
-            [[ "$DIRECT_MAIN_RELEASE" =~ ^[01]$ ]]
-            if [[ "$DIRECT_MAIN_RELEASE" == "1" ]]; then
-              echo "Maintainer-authorized direct main release; develop ancestry is intentionally skipped."
-            else
-              git fetch --no-tags origin develop:refs/remotes/origin/develop
-              git merge-base --is-ancestor refs/remotes/origin/develop "$HEAD_SHA"
-            fi
-          fi
-
   changes:
     name: Change scope
     if: github.event_name != 'schedule'
@@ -93,18 +52,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Use Node.js 22
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-        with:
-          node-version: 22
-
       - name: Classify changed paths
         id: scope
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PUSH_BEFORE_SHA: ${{ github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: |
@@ -118,14 +70,7 @@ jobs:
             --summary "$GITHUB_STEP_SUMMARY"
           )
 
-          if [[ "$EVENT_NAME" == "pull_request" ]] \
-            && [[ "$PR_BASE_SHA" =~ ^[0-9a-f]{40}$ ]] \
-            && [[ "$PR_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] \
-            && git cat-file -e "${PR_BASE_SHA}^{commit}" \
-            && git cat-file -e "${PR_HEAD_SHA}^{commit}"; then
-            git diff --name-only -z "$PR_BASE_SHA...$PR_HEAD_SHA" > "$changed_files"
-            "${classifier[@]}"
-          elif [[ "$EVENT_NAME" == "push" ]] \
+          if [[ "$EVENT_NAME" == "push" ]] \
             && [[ "$PUSH_BEFORE_SHA" =~ ^[0-9a-f]{40}$ ]] \
             && [[ "$PUSH_BEFORE_SHA" != "0000000000000000000000000000000000000000" ]] \
             && [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] \
@@ -138,10 +83,25 @@ jobs:
           fi
 
   repository_hygiene:
-    name: Public repository hygiene
+    name: Repository hygiene
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Reject private paths and sensitive content
+        run: npm run check:public-repository
+
+  static_checks:
+    name: Static and unit checks
+    needs: changes
+    if: needs.changes.outputs.run_core == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -152,16 +112,35 @@ jobs:
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 22
+          cache: npm
 
-      - name: Reject private paths and sensitive content
-        run: npm run check:public-repository
+      - name: Install dependencies
+        run: npm ci
 
-  checks:
-    name: Core checks
+      - name: Security audit
+        run: npm run audit:security
+
+      - name: Generated asset consistency
+        run: npm run assets:check
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: API contract tests
+        run: npm run test:api-contract
+
+      - name: Shift comparison tests
+        run: npm run test:shift-comparison
+
+  database_checks:
+    name: Database integration
     needs: changes
     if: needs.changes.outputs.run_core == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:18.4@sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
@@ -176,7 +155,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -258,57 +236,113 @@ jobs:
       - name: PostgreSQL authentication integration
         run: npm run test:auth-integration
 
-      - name: Security audit
-        run: npm run audit:security
+  release_artifact:
+    name: Build release once
+    needs: changes
+    if: needs.changes.outputs.run_core == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      DEPLOYMENT_ENV: ${{ github.ref_name == 'main' && 'production' || 'development' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
-      - name: Generated asset consistency
-        run: npm run assets:check
+      - name: Use Node.js 22
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: npm
 
-      - name: Lint
-        run: npm run lint
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Unit tests
-        run: npm test
-
-      - name: API contract tests
-        run: npm run test:api-contract
-
-      - name: Shift comparison tests
-        run: npm run test:shift-comparison
-
-      - name: Production build
+      - name: Build standalone application and worker
         env:
-          APP_DEPLOYMENT_ENV: production
+          APP_BUILD_ID: ${{ github.sha }}
+          APP_DEPLOYMENT_ENV: ${{ env.DEPLOYMENT_ENV }}
           SKLAND_FEATURE_ENABLED: "1"
+          ACCOUNT_CLOUD_SYNC_ENABLED: "1"
           DATABASE_URL: ""
           DATABASE_MIGRATION_URL: ""
           BETTER_AUTH_SECRET: ""
           BETTER_AUTH_URL: ""
           RESEND_API_KEY: ""
           AUTH_EMAIL_FROM: ""
-        run: npm run build
+        run: npm run build && npm run worker:build && node --check dist/plan-worker.cjs
 
-      - name: Production worker build
-        run: npm run worker:build && node --check dist/plan-worker.cjs
-
-      - name: Initial bundle budget
-        run: npm run check:bundle-budget
-
-      - name: Production output tracing
-        run: npm run check:build-traces
-
-      - name: Production client feature boundary
+      - name: Release output checks
         env:
           APP_DEPLOYMENT_ENV: production
           SKLAND_FEATURE_ENABLED: "1"
-        run: npm run check:production-client
+        run: |
+          npm run check:bundle-budget
+          npm run check:build-traces
+          npm run check:production-client
+
+      - name: Stage verified release artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_parent="$(mktemp -d "$RUNNER_TEMP/riic-web-release.XXXXXX")"
+          release_root="$release_parent/release"
+          upload_root="$RUNNER_TEMP/riic-web-release-upload"
+          archive="$upload_root/arknights-infra-${DEPLOYMENT_ENV}-${GITHUB_SHA}.tar.gz"
+          release_tree_sha="$(git rev-parse 'HEAD^{tree}')"
+          source_date_epoch="$(git show -s --format=%ct HEAD)"
+          [[ "$release_tree_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$source_date_epoch" =~ ^[1-9][0-9]*$ ]]
+          install -d -m 700 "$upload_root"
+
+          RELEASE_SHA="$GITHUB_SHA" RELEASE_TREE_SHA="$release_tree_sha" \
+            npm run release:stage -- --output "$release_root"
+          tar --sort=name \
+            --mtime="@$source_date_epoch" \
+            --owner=0 \
+            --group=0 \
+            --numeric-owner \
+            --mode='u+rwX,go+rX,go-w' \
+            --format=gnu \
+            -cf - \
+            -C "$release_root" . \
+            | gzip --best --no-name --rsyncable > "$archive"
+          gzip -t "$archive"
+
+          archive_bytes="$(stat -c '%s' "$archive")"
+          archive_sha256="$(sha256sum "$archive" | cut -d ' ' -f 1)"
+          [[ "$archive_bytes" =~ ^[1-9][0-9]*$ ]]
+          [[ "$archive_sha256" =~ ^[0-9a-f]{64}$ ]]
+          printf '%s  %s\n' "$archive_sha256" "$(basename "$archive")" > "$upload_root/SHA256SUMS"
+          {
+            echo "### Verified release artifact"
+            echo
+            echo "| Environment | Commit | Tree | Bytes | SHA-256 |"
+            echo "| --- | --- | --- | ---: | --- |"
+            echo "| $DEPLOYMENT_ENV | \`${GITHUB_SHA:0:12}\` | \`${release_tree_sha:0:12}\` | $archive_bytes | \`$archive_sha256\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload release for deployment
+        if: github.event_name == 'push' && needs.changes.outputs.deploy_required == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: riic-web-release-${{ github.sha }}
+          path: ${{ runner.temp }}/riic-web-release-upload/*
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
 
   browser_e2e:
-    name: E2E (chromium)
+    name: Chromium E2E (${{ matrix.shard }})
     needs: changes
     if: needs.changes.outputs.run_browser == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
     container:
       image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:c091b21d9fae78c76e85cd4356431e9b018402f172a214fc7d7a5e9a7e29d8ac
       options: --user 1001
@@ -328,7 +362,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -348,7 +381,50 @@ jobs:
         run: npm run db:migrate
 
       - name: Chromium end-to-end tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}
+
+  browser_boundaries:
+    name: Browser release boundaries
+    needs: changes
+    if: needs.changes.outputs.run_browser == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    container:
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:c091b21d9fae78c76e85cd4356431e9b018402f172a214fc7d7a5e9a7e29d8ac
+      options: --user 1001
+    env:
+      DATABASE_URL: postgresql://arknights_e2e:e2e-test-only@postgres:5432/arknights_auth_test
+      DATABASE_MIGRATION_URL: postgresql://arknights_e2e:e2e-test-only@postgres:5432/arknights_auth_test
+      AUTH_INTEGRATION_DATABASE_URL: postgresql://arknights_e2e:e2e-test-only@postgres:5432/arknights_auth_test
+    services:
+      postgres:
+        image: postgres:18.4@sha256:a02db8cac496f15b094798a38254f14d6e00741f709360e5e00bb6668ea31636
+        env:
+          POSTGRES_DB: arknights_auth_test
+          POSTGRES_USER: arknights_e2e
+          POSTGRES_PASSWORD: e2e-test-only
+        options: >-
+          --health-cmd "pg_isready -U arknights_e2e -d arknights_auth_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Apply committed authentication migrations
+        run: npm run db:migrate
 
       - name: WebKit Skland QR smoke test
         run: npm run test:e2e:webkit:skland-qr
@@ -380,7 +456,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 10
-
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -406,22 +481,23 @@ jobs:
     name: quality
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [pull_request_policy, changes, repository_hygiene, checks, browser_e2e]
+    needs: [changes, repository_hygiene, static_checks, database_checks, release_artifact, browser_e2e, browser_boundaries]
     if: always() && github.event_name != 'schedule'
     steps:
-      - name: Verify all required jobs passed
+      - name: Verify all post-merge checks passed
         env:
-          POLICY_RESULT: ${{ needs.pull_request_policy.result }}
           CHANGES_RESULT: ${{ needs.changes.result }}
           HYGIENE_RESULT: ${{ needs.repository_hygiene.result }}
-          CHECKS_RESULT: ${{ needs.checks.result }}
+          STATIC_RESULT: ${{ needs.static_checks.result }}
+          DATABASE_RESULT: ${{ needs.database_checks.result }}
+          BUILD_RESULT: ${{ needs.release_artifact.result }}
           BROWSER_E2E_RESULT: ${{ needs.browser_e2e.result }}
+          BROWSER_BOUNDARIES_RESULT: ${{ needs.browser_boundaries.result }}
           RUN_CORE: ${{ needs.changes.outputs.run_core }}
           RUN_BROWSER: ${{ needs.changes.outputs.run_browser }}
           DEPLOY_REQUIRED: ${{ needs.changes.outputs.deploy_required }}
         run: |
           set -euo pipefail
-          test "$POLICY_RESULT" = "success"
           test "$CHANGES_RESULT" = "success"
           test "$HYGIENE_RESULT" = "success"
           [[ "$DEPLOY_REQUIRED" == "true" || "$DEPLOY_REQUIRED" == "false" ]]
@@ -439,17 +515,23 @@ jobs:
             printf '%s required=%s result=%s\n' "$label" "$required" "$actual"
           }
 
-          verify_result "$RUN_CORE" "$CHECKS_RESULT" core
-          verify_result "$RUN_BROWSER" "$BROWSER_E2E_RESULT" browser
+          verify_result "$RUN_CORE" "$STATIC_RESULT" static
+          verify_result "$RUN_CORE" "$DATABASE_RESULT" database
+          verify_result "$RUN_CORE" "$BUILD_RESULT" build
+          verify_result "$RUN_BROWSER" "$BROWSER_E2E_RESULT" chromium
+          verify_result "$RUN_BROWSER" "$BROWSER_BOUNDARIES_RESULT" browser-boundaries
 
   deploy:
-    needs: [changes, quality]
+    needs: [changes, quality, release_artifact]
     if: >-
       github.event_name == 'push' &&
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
       needs.quality.result == 'success' &&
+      needs.release_artifact.result == 'success' &&
       needs.changes.outputs.deploy_required == 'true' &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
       github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
     uses: ./.github/workflows/deploy.yml
+    with:
+      artifact_name: riic-web-release-${{ github.sha }}
     secrets: inherit

--- a/.github/workflows/main-release-policy.yml
+++ b/.github/workflows/main-release-policy.yml
@@ -1,0 +1,47 @@
+name: Main release policy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-release-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  release_lane:
+    name: Release branch only
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout release ancestry
+        if: contains(github.event.pull_request.labels.*.name, 'direct-main-release') == false
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce the main release lane
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          EXPECTED_REPOSITORY: KnightCodeSquareMatrix/RIIC-Web
+          DIRECT_MAIN_RELEASE: ${{ contains(github.event.pull_request.labels.*.name, 'direct-main-release') && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          test "$HEAD_REPOSITORY" = "$EXPECTED_REPOSITORY"
+          [[ "$HEAD_REF" == release/* ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$DIRECT_MAIN_RELEASE" =~ ^[01]$ ]]
+          if [[ "$DIRECT_MAIN_RELEASE" == "1" ]]; then
+            echo "Maintainer-authorized direct main release; develop ancestry is intentionally skipped."
+          else
+            git fetch --no-tags origin develop:refs/remotes/origin/develop
+            git merge-base --is-ancestor refs/remotes/origin/develop "$HEAD_SHA"
+          fi

--- a/.github/workflows/sync-arkntools-assets.yml
+++ b/.github/workflows/sync-arkntools-assets.yml
@@ -242,10 +242,6 @@ jobs:
               --body-file "$body"
           fi
 
-      - name: Dispatch full frontend quality workflow
-        shell: bash
-        run: gh workflow run frontend-quality.yml --ref "$UPDATE_BRANCH"
-
       - name: Report publication failure
         if: failure()
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,23 @@
 
 1. 从最新的 `develop` 创建功能分支。
 2. 将功能、修复、文档和资源同步 PR 的 base branch 设为 `develop`。
-3. 不要向 `main` 直接提交普通 PR。`main` 只接受维护者从本仓库 `release/**` 分支发起的发布 PR；确需跳过 `develop` 的特批发布，必须由维护者添加 `direct-main-release` 标签，且仍须通过其余全部质量门禁。
-4. PR 合并到 `develop` 后进入 development 发布通道；通过验收的变更再经 release PR 晋级 `main`。
+3. 不要向 `main` 直接提交普通 PR。`main` 只接受维护者从本仓库 `release/**` 分支发起的发布 PR；确需跳过 `develop` 的特批发布，必须由维护者添加 `direct-main-release` 标签。
+4. 普通 PR 不运行远程质量检查；PR 合并到 `develop` 或 `main` 后，目标分支才并行执行质量检查、生成一次发布产物，并在全部检查通过后部署。通过 development 验收的变更再经 release PR 晋级 `main`。
 
-来自 fork 的 PR 使用只读 `GITHUB_TOKEN`，不会获得 Environment secrets，也不会触发部署。请不要为了验证部署而在 PR 中添加、打印或探测 secret。
+来自 fork 的 PR 不会获得 Environment secrets，也不会触发部署。只有指向 `main` 的发布 PR 会运行只读、无依赖安装的分支来源检查。请不要为了验证部署而在 PR 中添加、打印或探测 secret。
+
+## Git 身份与贡献归属
+
+GitHub 按每个 commit 的 author email 关联贡献者，而不是按谁合并了 PR 推断作者。提交前请把本仓库的 Git 身份设为 GitHub 账号中已验证的邮箱，或 GitHub 设置页提供的 `noreply` 邮箱：
+
+```bash
+git config user.name "YOUR_GITHUB_NAME"
+git config user.email "YOUR_GITHUB_NOREPLY_EMAIL"
+git config --get user.name
+git config --get user.email
+```
+
+修改邮箱只影响后续 commit；历史 commit 应将当时使用的邮箱添加到同一个 GitHub 账号，由 GitHub 重建归属，不要为修正统计重写公开分支历史。维护者在整合他人改动时，如一个 commit 确实包含双方工作，应使用关联到对方 GitHub 账号的 `Co-authored-by: Name <email>` trailer。
 
 ## 本地验证
 

--- a/docs/CI_RELEASE_FLOW.md
+++ b/docs/CI_RELEASE_FLOW.md
@@ -1,0 +1,17 @@
+# CI and release flow
+
+The public repository deliberately separates code review from release verification.
+
+| Event | Automated work | Deployment |
+| --- | --- | --- |
+| Pull request to `develop` | None; contributors provide local test evidence | Never |
+| Pull request to `main` | Release-branch and `develop` ancestry policy only | Never |
+| Push/merge to `develop` | Changed-path classification, then parallel static, database, build, four-shard Chromium, and browser-boundary checks | Development after `quality` passes |
+| Push/merge to `main` | The same post-merge gate | Production after `quality` and Environment approval |
+| Nightly/manual compatibility run | Full WebKit suite | Never for the scheduled event |
+
+The release build is immutable within one workflow run. `Build release once` creates the solver-free standalone archive and uploads it with a one-day retention period. The deploy job downloads and validates that exact archive; it must not install dependencies or rebuild the application.
+
+For runtime changes, the latency target from branch push to a development deployment, or to the start of a production health observation, is 6–7 minutes. Production then deliberately observes 20 successful health samples over 300 seconds in the root-owned deployment helper. That observation occurs after the new release is already serving traffic, so it is reported separately from time-to-online. Human Environment approval wait time is also excluded from automation latency.
+
+Documentation-only pushes skip build, browser checks, and deployment. Test/tooling-only pushes run the relevant checks but do not deploy unless a release workflow itself changed.

--- a/docs/REPOSITORY_ADMIN_CHECKLIST.md
+++ b/docs/REPOSITORY_ADMIN_CHECKLIST.md
@@ -15,14 +15,17 @@ Only the personal-repository owner, `KnightCodeSquareMatrix`, can complete the a
 ## Branch and Actions policy
 
 - [ ] Set `main` as the default branch.
-- [ ] Protect both `main` and `develop`: require the `quality` status, at least one approval, resolved conversations, and block force pushes and deletion.
+- [ ] Protect both `main` and `develop`: require at least one approval, resolved conversations, and block force pushes and deletion. Do not require post-merge `quality` as a PR status.
+- [ ] On `main` only, require the lightweight `Release branch only` status so ordinary feature PRs cannot bypass the release lane.
 - [ ] Require CODEOWNER review for the sensitive paths listed in `.github/CODEOWNERS`.
 - [ ] Do not routinely bypass protection as repository owner.
 - [ ] Keep the default `GITHUB_TOKEN` permission read-only.
 - [ ] Allow GitHub Actions to create pull requests so the narrowly scoped asset-sync workflow can update `develop`.
 - [ ] Enable private vulnerability reporting and the relevant GitHub security checks.
 
-The `quality` workflow also rejects every pull request to `main` unless its head is a `release/**` branch in this same repository. By default, that head commit must already be reachable from `develop`; a maintainer-applied `direct-main-release` label may explicitly waive only the ancestry check while preserving all remaining quality jobs. External and ordinary feature PRs target `develop`.
+Ordinary pull requests do not run the post-merge quality workflow. A separate lightweight policy rejects every pull request to `main` unless its head is a `release/**` branch in this same repository. By default, that head commit must already be reachable from `develop`; a maintainer-applied `direct-main-release` label may explicitly waive only the ancestry check. External and ordinary feature PRs target `develop`. Every push produced by a merge into `develop` or `main` runs the full parallel quality gate before deployment.
+
+Roll this policy out in order so branch protection never waits for a status that the new workflow no longer emits: first remove the old PR-required `quality` status from `develop` (or use the repository-owner bypass for the migration PR), merge the workflow change to `develop`, and promote it to `main`. Only after `Main release policy` exists on `main` and has emitted `Release branch only` at least once should that lightweight status become required on `main`.
 
 ## Deployment configuration
 
@@ -65,6 +68,6 @@ Set `DEPLOY_APPROVED_SOLVER_SHA256` to the independently verified digest of the 
 - [ ] Disable automatic deployment in the old private repository before setting the public repository variable to `1`.
 - [ ] Change `deploy/PUBLIC_DEPLOYMENT_SOURCE` in a PR to `public-automation-v1` and merge it to `develop`. This path is intentionally classified as deploy-required.
 - [ ] Complete development acceptance, then create a same-repository `release/develop-to-main-YYYYMMDD` PR.
-- [ ] Approve the production Environment only after the release PR has passed `quality`.
+- [ ] After merging the reviewed release PR, approve the production Environment only when the post-merge `quality` job has passed.
 
 Do not delete old releases, helper binaries, or Git-cache backups until both environments have been stable for at least seven days.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,10 +6,10 @@ const webServerPort = new URL(baseURL).port || "80";
 export default defineConfig({
   testDir: "./e2e",
   testIgnore: "production-profile.spec.ts",
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 3 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   expect: {
     timeout: process.env.CI ? 10_000 : 5_000,
   },

--- a/scripts/arkntools-pr-summary.mjs
+++ b/scripts/arkntools-pr-summary.mjs
@@ -71,6 +71,6 @@ console.log(`## arkntools 自动资源同步
 - 新增技能定义：${[...afterSkillIds].filter((id) => !beforeSkillIds.has(id)).length}
 - 移除技能定义：${[...beforeSkillIds].filter((id) => !afterSkillIds.has(id)).length}
 
-同步工作流已执行资源完整性检查、lint、单元测试、API 契约测试和生产构建；完整 Chromium E2E 由随后调度的 Frontend quality 工作流执行。
+同步工作流已执行资源完整性检查、lint、单元测试、API 契约测试和生产构建；合并到 develop 后，Post-merge release 工作流会执行完整 Chromium E2E 和部署前检查。
 
 本 PR 只修改当前前端仓库的受管资源，不会向 arkntools 仓库写入内容。`);

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -148,7 +148,7 @@ test("CI enforces route and document preload JavaScript budgets after building",
   const budgetCheck = await readRepoFile("scripts/check-bundle-budget.mjs");
 
   assert.equal(packageJson.scripts["check:bundle-budget"], "node scripts/check-bundle-budget.mjs");
-  assert.match(workflow, /Production build[\s\S]+npm run check:bundle-budget/);
+  assert.match(workflow, /Build standalone application and worker[\s\S]+Release output checks[\s\S]+npm run check:bundle-budget/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_140_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_180_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_615_000/);
@@ -197,17 +197,19 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
     packageJson.scripts["test:e2e:webkit:skland-qr"],
     "playwright test e2e/production-readiness-skland.spec.ts --project=webkit --grep \"Skland login exposes both methods\"",
   );
-  assert.match(workflow, /browser_e2e:[\s\S]+npm run test:e2e[\s\S]+npm run test:e2e:webkit:skland-qr[\s\S]+npm run test:e2e:production-profile/);
+  assert.match(workflow, /browser_e2e:[\s\S]+shard: \[1\/4, 2\/4, 3\/4, 4\/4\][\s\S]+npm run test:e2e -- --shard=\$\{\{ matrix\.shard \}\}/);
+  assert.match(workflow, /browser_boundaries:[\s\S]+npm run test:e2e:webkit:skland-qr[\s\S]+npm run test:e2e:production-profile/);
   assert.match(workflow, /webkit_e2e:[\s\S]+github\.event_name == 'schedule'[\s\S]+npm run test:e2e:webkit/);
-  assert.match(workflow, /quality:[\s\S]+needs: \[pull_request_policy, changes, repository_hygiene, checks, browser_e2e\]/);
+  assert.match(workflow, /quality:[\s\S]+needs: \[changes, repository_hygiene, static_checks, database_checks, release_artifact, browser_e2e, browser_boundaries\]/);
   assert.doesNotMatch(workflow, /quality:[\s\S]+needs: \[[^\]]*webkit_e2e/);
-  assert.match(workflow, /deploy:[\s\S]+needs: \[changes, quality\]/);
-  assert.match(workflow, /cancel-in-progress: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+  assert.match(workflow, /deploy:[\s\S]+needs: \[changes, quality, release_artifact\]/);
+  assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
+  assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
   assert.equal(readinessTestCount, 94);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
-  assert.match(playwrightConfig, /fullyParallel: false/);
-  assert.match(playwrightConfig, /workers: process\.env\.CI \? 3 : undefined/);
+  assert.match(playwrightConfig, /fullyParallel: true/);
+  assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);
   assert.match(playwrightConfig, /timeout: process\.env\.CI \? 10_000 : 5_000/);
 });
 
@@ -220,12 +222,14 @@ test("CI change scope keeps one required quality gate and fails closed", async (
   assert.match(workflow, /repository_hygiene:[\s\S]+npm run check:public-repository/);
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /node scripts\/ci-change-scope\.mjs/);
-  assert.match(workflow, /git diff --name-only -z "\$PR_BASE_SHA\.\.\.\$PR_HEAD_SHA"/);
+  assert.doesNotMatch(workflow, /PR_BASE_SHA|PR_HEAD_SHA/);
   assert.match(workflow, /git diff --name-only -z "\$PUSH_BEFORE_SHA\.\.\$HEAD_SHA"/);
   assert.match(workflow, /"\$\{classifier\[@\]\}" --force-full/);
-  assert.match(workflow, /checks:[\s\S]+needs: changes[\s\S]+needs\.changes\.outputs\.run_core == 'true'/);
+  assert.match(workflow, /static_checks:[\s\S]+needs: changes[\s\S]+needs\.changes\.outputs\.run_core == 'true'/);
+  assert.match(workflow, /database_checks:[\s\S]+needs: changes[\s\S]+needs\.changes\.outputs\.run_core == 'true'/);
+  assert.match(workflow, /release_artifact:[\s\S]+needs: changes[\s\S]+needs\.changes\.outputs\.run_core == 'true'/);
   assert.match(workflow, /browser_e2e:[\s\S]+needs: changes[\s\S]+needs\.changes\.outputs\.run_browser == 'true'/);
-  assert.match(workflow, /quality:[\s\S]+test "\$CHANGES_RESULT" = "success"[\s\S]+test "\$HYGIENE_RESULT" = "success"[\s\S]+"\$DEPLOY_REQUIRED" == "true"[\s\S]+"\$required" == "true"[\s\S]+verify_result "\$RUN_CORE"[\s\S]+verify_result "\$RUN_BROWSER"/);
+  assert.match(workflow, /quality:[\s\S]+test "\$CHANGES_RESULT" = "success"[\s\S]+test "\$HYGIENE_RESULT" = "success"[\s\S]+"\$DEPLOY_REQUIRED" == "true"[\s\S]+"\$required" == "true"[\s\S]+verify_result "\$RUN_CORE" "\$STATIC_RESULT"[\s\S]+verify_result "\$RUN_BROWSER" "\$BROWSER_E2E_RESULT"/);
   assert.match(workflow, /deploy:[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'/);
 
   assert.match(classifier, /fullScope\(paths, "empty-change-set"\)/);
@@ -235,10 +239,11 @@ test("CI change scope keeps one required quality gate and fails closed", async (
 
 test("public deployment automation is repository-bound, opt-in, and secret-safe", async () => {
   const qualityWorkflow = await readRepoFile(".github/workflows/frontend-quality.yml");
+  const policyWorkflow = await readRepoFile(".github/workflows/main-release-policy.yml");
   const deployWorkflow = await readRepoFile(".github/workflows/deploy.yml");
   const preflightWorkflow = await readRepoFile(".github/workflows/deployment-preflight.yml");
   const assetWorkflow = await readRepoFile(".github/workflows/sync-arkntools-assets.yml");
-  const workflows = [qualityWorkflow, deployWorkflow, preflightWorkflow, assetWorkflow];
+  const workflows = [qualityWorkflow, policyWorkflow, deployWorkflow, preflightWorkflow, assetWorkflow];
   const deployJobEnvironment = deployWorkflow.slice(
     deployWorkflow.indexOf("    env:"),
     deployWorkflow.indexOf("    steps:"),
@@ -252,10 +257,12 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
     preflightWorkflow.indexOf("      - name: Remove SSH credentials from the runner"),
   );
 
-  assert.match(qualityWorkflow, /HEAD_REPOSITORY[\s\S]+EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+"\$HEAD_REF" == release\/\*/);
-  assert.match(qualityWorkflow, /types: \[opened, synchronize, reopened, labeled, unlabeled\]/);
-  assert.match(qualityWorkflow, /DIRECT_MAIN_RELEASE: \$\{\{ contains\(github\.event\.pull_request\.labels\.\*\.name, 'direct-main-release'\)[\s\S]+"\$DIRECT_MAIN_RELEASE" == "1"[\s\S]+develop ancestry is intentionally skipped/);
-  assert.match(qualityWorkflow, /git merge-base --is-ancestor refs\/remotes\/origin\/develop "\$HEAD_SHA"/);
+  assert.doesNotMatch(qualityWorkflow, /^\s*pull_request\s*:/m);
+  assert.match(policyWorkflow, /pull_request:[\s\S]+branches: \[main\]/);
+  assert.match(policyWorkflow, /HEAD_REPOSITORY[\s\S]+EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+"\$HEAD_REF" == release\/\*/);
+  assert.match(policyWorkflow, /types: \[opened, synchronize, reopened, labeled, unlabeled\]/);
+  assert.match(policyWorkflow, /DIRECT_MAIN_RELEASE: \$\{\{ contains\(github\.event\.pull_request\.labels\.\*\.name, 'direct-main-release'\)[\s\S]+"\$DIRECT_MAIN_RELEASE" == "1"[\s\S]+develop ancestry is intentionally skipped/);
+  assert.match(policyWorkflow, /git merge-base --is-ancestor refs\/remotes\/origin\/develop "\$HEAD_SHA"/);
   assert.match(qualityWorkflow, /github\.event_name == 'push'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /github\.event_name == 'push'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
@@ -301,21 +308,21 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   }
 });
 
-test("deploy builds and transfers a verified solver-free standalone artifact", async () => {
+test("CI builds once and deploy transfers the verified solver-free standalone artifact", async () => {
   const deployWorkflow = await readRepoFile(".github/workflows/deploy.yml");
   const qualityWorkflow = await readRepoFile(".github/workflows/frontend-quality.yml");
 
   assert.match(deployWorkflow, /Use Node\.js 22[\s\S]+actions\/setup-node@[0-9a-f]{40}[\s\S]+node-version: 22/);
   assert.match(deployWorkflow, /Resolve verified release identity[\s\S]+git rev-parse 'HEAD\^\{tree\}'[\s\S]+DEPLOY_TREE_SHA=%s/);
   assert.match(deployWorkflow, /Validate deployment configuration[\s\S]+\[\[ "\$DEPLOY_TREE_SHA" =~ \^\[0-9a-f\]\{40\}\$ \]\]/);
-  assert.match(deployWorkflow, /Install verified build dependencies[\s\S]+run: npm ci/);
-  assert.match(deployWorkflow, /Build standalone release[\s\S]+APP_DEPLOYMENT_ENV:[\s\S]+SKLAND_FEATURE_ENABLED: "1"[\s\S]+ACCOUNT_CLOUD_SYNC_ENABLED: "1"[\s\S]+run: npm run build/);
-  assert.match(deployWorkflow, /run: npm run build && npm run worker:build/);
-  assert.match(qualityWorkflow, /Production worker build[\s\S]+npm run worker:build && node --check dist\/plan-worker\.cjs/);
-  assert.match(deployWorkflow, /RELEASE_SHA="\$DEPLOY_SHA" RELEASE_TREE_SHA="\$DEPLOY_TREE_SHA"[\s\S]+npm run release:stage -- --output "\$artifact_root"/);
-  assert.match(deployWorkflow, /tar --sort=name[\s\S]+--mtime="@\$SOURCE_DATE_EPOCH"[\s\S]+--mode='u\+rwX,go\+rX,go-w'[\s\S]+gzip --best --no-name --rsyncable[\s\S]+gzip -t "\$local_archive"/);
+  assert.match(qualityWorkflow, /Build standalone application and worker[\s\S]+APP_BUILD_ID: \$\{\{ github\.sha \}\}[\s\S]+APP_DEPLOYMENT_ENV:[\s\S]+SKLAND_FEATURE_ENABLED: "1"[\s\S]+ACCOUNT_CLOUD_SYNC_ENABLED: "1"[\s\S]+npm run build && npm run worker:build && node --check dist\/plan-worker\.cjs/);
+  assert.match(qualityWorkflow, /RELEASE_SHA="\$GITHUB_SHA" RELEASE_TREE_SHA="\$release_tree_sha"[\s\S]+npm run release:stage -- --output "\$release_root"/);
+  assert.match(qualityWorkflow, /tar --sort=name[\s\S]+--mtime="@\$source_date_epoch"[\s\S]+--mode='u\+rwX,go\+rX,go-w'[\s\S]+gzip --best --no-name --rsyncable[\s\S]+gzip -t "\$archive"/);
+  assert.match(qualityWorkflow, /actions\/upload-artifact@[0-9a-f]{40}[\s\S]+name: riic-web-release-\$\{\{ github\.sha \}\}[\s\S]+compression-level: 0/);
+  assert.match(deployWorkflow, /actions\/download-artifact@[0-9a-f]{40}[\s\S]+name: \$\{\{ inputs\.artifact_name \}\}/);
+  assert.match(deployWorkflow, /Validate and extract release artifact[\s\S]+sha256sum --check --strict SHA256SUMS[\s\S]+metadata\.releaseSha, expectedSha[\s\S]+metadata\.releaseTreeSha, expectedTree/);
+  assert.doesNotMatch(deployWorkflow, /npm ci|npm run build|npm run worker:build|npm run release:stage/);
   assert.match(deployWorkflow, /archive_sha256="\$\(sha256sum "\$local_archive"[\s\S]+DEPLOY_ARCHIVE_SHA256=%s/);
-  assert.match(deployWorkflow, /Build standalone release[\s\S]+APP_BUILD_ID: \$\{\{ env\.DEPLOY_SHA \}\}/);
   assert.match(
     deployWorkflow,
     /Sync standalone release tree[\s\S]+release_tree_cache="\.cache\/riic-web\/\$\{DEPLOYMENT_ENV\}-standalone-tree"[\s\S]+--recursive[\s\S]+--times[\s\S]+--perms[\s\S]+--checksum[\s\S]+--compress[\s\S]+--delete-delay[\s\S]+--partial[\s\S]+--inplace[\s\S]+"\$DEPLOY_ARTIFACT_ROOT\/"[\s\S]+"\$ssh_target:\$release_tree_cache\/"/,
@@ -327,7 +334,7 @@ test("deploy builds and transfers a verified solver-free standalone artifact", a
   assert.doesNotMatch(deployWorkflow, /\bscp\b/);
   assert.match(deployWorkflow, /DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
   assert.match(deployWorkflow, /'\$DEPLOY_APPROVED_SOLVER_SHA256' \\\n\s+'\$DEPLOY_TREE_SHA'/);
-  assert.match(deployWorkflow, /Remove staged release artifacts from the runner[\s\S]+if: always\(\)[\s\S]+"\$RUNNER_TEMP"\/riic-web-release\.\*[\s\S]+"\$RUNNER_TEMP"\/arknights-infra-\*\.tar\.gz/);
+  assert.match(deployWorkflow, /Remove staged release artifacts from the runner[\s\S]+if: always\(\)[\s\S]+"\$RUNNER_TEMP"\/riic-web-release-\[0-9\]\*-\[0-9\]\*/);
   assert.doesNotMatch(deployWorkflow, /git (?:archive|bundle)|repository\.git|DEPLOY_PREVIOUS_SHA|remote_bundle|bin\/infra-cli/);
 });
 
@@ -358,11 +365,11 @@ test("CI browser jobs use the matching pinned Playwright image without runtime a
   const pinnedImage = new RegExp(`image: mcr\\.microsoft\\.com/playwright:v${escapedVersion}-noble@sha256:[a-f0-9]{64}`, "g");
   const browserJobs = workflow.slice(workflow.indexOf("  browser_e2e:"), workflow.indexOf("  quality:"));
 
-  assert.equal(workflow.match(pinnedImage)?.length, 2);
-  assert.equal(browserJobs.match(/@postgres:5432\/arknights_auth_test/g)?.length, 6);
+  assert.equal(workflow.match(pinnedImage)?.length, 3);
+  assert.equal(browserJobs.match(/@postgres:5432\/arknights_auth_test/g)?.length, 9);
   assert.doesNotMatch(browserJobs, /playwright install(?:-deps)?/);
   assert.doesNotMatch(browserJobs, /Initialize limited database roles/);
-  assert.equal(browserJobs.match(/options: --user 1001/g)?.length, 2);
+  assert.equal(browserJobs.match(/options: --user 1001/g)?.length, 3);
 });
 
 test("production injects the client feature flag at every browser boundary", async () => {
@@ -383,8 +390,8 @@ test("production injects the client feature flag at every browser boundary", asy
   assert.match(sklandPage, /process\.env\.APP_CLIENT_SKLAND_ENABLED !== "1"/);
   assert.match(setupDialog, /process\.env\.APP_CLIENT_SKLAND_ENABLED === "1"/);
   assert.match(developmentSklandCenter, /SklandStatus/);
-  assert.match(workflow, /Production build[\s\S]+APP_DEPLOYMENT_ENV: production[\s\S]+SKLAND_FEATURE_ENABLED: "1"/);
-  assert.match(workflow, /Production client feature boundary[\s\S]+APP_DEPLOYMENT_ENV: production[\s\S]+SKLAND_FEATURE_ENABLED: "1"/);
+  assert.match(workflow, /Build standalone application and worker[\s\S]+APP_DEPLOYMENT_ENV: \$\{\{ env\.DEPLOYMENT_ENV \}\}[\s\S]+SKLAND_FEATURE_ENABLED: "1"/);
+  assert.match(workflow, /Release output checks[\s\S]+APP_DEPLOYMENT_ENV: production[\s\S]+SKLAND_FEATURE_ENABLED: "1"[\s\S]+npm run check:production-client/);
 });
 
 test("workbench views use five prefetched route entries under one persistent layout", async () => {


### PR DESCRIPTION
## 目的
将已在 `develop` 验证通过的 CI / CD 快速流程晋级到生产分支。

## 变更
- 普通 PR 只做轻量范围与仓库卫生检查
- 完整质量检查仅在合并到 `develop` / `main` 后运行
- Chromium E2E 拆为 4 个并行分片
- 构建一次并把同一份已验证制品交给部署任务
- 发布制品不包含服务器 root 管理的求解器，部署时校验求解器指纹
- 增加 `main` 仅允许 release 分支晋级的策略检查
- 修正贡献者汇总脚本按提交邮箱映射身份

## 验证
- PR #125 已审批并合并到 `develop`
- develop 真实发布成功：质量阶段约 3 分 34 秒，部署及健康/压缩验证 1 分 25 秒，总计 5 分 07 秒
- 发布分支同时包含当前 `main` 与 `develop` 的完整历史，生产版本信息不会回退

## 风险
仅调整 GitHub Actions、发布装配及相关文档/测试；不替换、不上传求解器二进制。