### PR TITLE
ci: account for bilingual shell bundle size

### DIFF
--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -6,19 +6,19 @@ import { gzipSync } from "node:zlib";
 
 // The calculator keeps its always-visible board in the initial graph. Secondary workbench
 // views have independent route chunks and may carry their own datasets without joining `/`.
-const MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_140_000;
-// The language switch itself is part of the shell; translation catalogs stay in an on-demand chunk.
-// Status-aware queue polling and the release-candidate workbench polish add a small
-// shared policy to the main graph. Keep less than 8 KB of headroom over the verified build.
-const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_180_000;
+const MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_167_000;
+// The language switch and compact bilingual shell copy are part of the initial graph;
+// full-page translation catalogs stay in their on-demand route chunks. Keep roughly
+// 8 KB of raw headroom over the verified disabled and enabled production builds.
+const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000;
 // Task progress UI and training tooltips add intentional code to secondary workbench routes.
 // Keep the ceiling narrow enough to flag unrelated bundle growth.
 const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_555_000;
 const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_615_000;
-const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_240_000;
-const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_295_000;
-const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 395_000;
-const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 415_000;
+const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000;
+const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000;
+const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000;
+const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 422_000;
 const MAX_DOCUMENT_INITIAL_JS_FILES = 18;
 const WORKBENCH_ROUTES = ["/", "/training", "/skills", "/skland", "/account"];
 const statsUrl = new URL("../.next/diagnostics/route-bundle-stats.json", import.meta.url);


### PR DESCRIPTION
Updates the guarded root and document bundle ceilings for the intentional bilingual shell copy introduced by PR #104. Both Skland-disabled and Skland-enabled measurements retain roughly 8 KB of raw headroom; route independence, gzip, file-count, and compact-schedule split checks remain enforced.