### PR TITLE
fix: 按 1280px 视口宽度设置侧边栏默认状态

### DIFF
--- a/e2e/production-readiness-planning.spec.ts
+++ b/e2e/production-readiness-planning.spec.ts
@@ -356,6 +356,37 @@ test("desktop sidebar state survives navigation and a hard reload without hydrat
   expect(hydrationErrors).toEqual([]);
 });
 
+test("desktop sidebar defaults open at 1280px and collapsed below it", async ({ page, context }) => {
+  await mockApis(page);
+  await seedPreferences(page);
+  await context.clearCookies();
+  const hydrationErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error" && /hydration|server rendered html/i.test(message.text())) {
+      hydrationErrors.push(message.text());
+    }
+  });
+
+  const sidebar = page.locator('[data-slot="sidebar"]:not([data-mobile="true"])');
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto("/");
+  await expect(sidebar).toHaveAttribute("data-state", "expanded");
+
+  await page.setViewportSize({ width: 1279, height: 900 });
+  await page.reload();
+  await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+
+  await context.addCookies([{ name: "sidebar_state", value: "true", domain: "127.0.0.1", path: "/" }]);
+  await page.reload();
+  await expect(sidebar).toHaveAttribute("data-state", "expanded");
+
+  await context.addCookies([{ name: "sidebar_state", value: "false", domain: "127.0.0.1", path: "/" }]);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.reload();
+  await expect(sidebar).toHaveAttribute("data-state", "collapsed");
+  expect(hydrationErrors).toEqual([]);
+});
+
 test("100% Skland match does not count fatigue-only notices as adjustments", async ({ page }) => {
   await mockApis(page, {
     sklandConfigured: true,

--- a/e2e/production-readiness-planning.spec.ts
+++ b/e2e/production-readiness-planning.spec.ts
@@ -927,9 +927,10 @@ test("shared action buttons keep their geometry after WebKit interactions", asyn
   await expectButtonGeometryStable(planButton);
 });
 
-test("tooltips wait once and then open adjacent help instantly within the provider window", async ({ page, browserName }) => {
+test("tooltips wait once and then open adjacent help instantly within the provider window", async ({ page, browserName, context }) => {
   await mockApis(page);
   await seedPreferences(page);
+  await context.addCookies([{ name: "sidebar_state", value: "false", domain: "127.0.0.1", path: "/" }]);
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/");
 

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -206,7 +206,7 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
   assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 95);
+  assert.equal(readinessTestCount, 96);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: true/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1781,7 +1781,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         if (event.key === "Escape" && websiteAuthDialogOpen) handleWebsiteAuthDialogOpenChange(false);
       }}
     >
-    <SidebarProvider defaultOpen={false}>
+    <SidebarProvider defaultOpen defaultOpenBreakpoint={1280}>
       <AppSidebar page={page} onPageChange={handleAppPageChange} />
       <SidebarInset>
         <AppTopBar />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -457,7 +457,7 @@
   }
 
   .compact-auxiliary-grid .infra-operator-slot {
-    --operator-slot-size: clamp(56px, 9cqw, 70px);
+    --operator-slot-size: clamp(64px, 12cqw, 70px);
   }
 }
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -55,6 +55,7 @@ function useSidebar() {
 
 function SidebarProvider({
   defaultOpen = true,
+  defaultOpenBreakpoint,
   open: openProp,
   onOpenChange: setOpenProp,
   className,
@@ -63,6 +64,7 @@ function SidebarProvider({
   ...props
 }: React.ComponentProps<"div"> & {
   defaultOpen?: boolean
+  defaultOpenBreakpoint?: number
   open?: boolean
   onOpenChange?: (open: boolean) => void
 }) {
@@ -80,8 +82,10 @@ function SidebarProvider({
       .find((entry) => entry.startsWith(`${SIDEBAR_COOKIE_NAME}=`))
     if (cookie) {
       _setOpen(cookie.split("=")[1] === "true")
+    } else if (defaultOpenBreakpoint !== undefined) {
+      _setOpen(window.innerWidth >= defaultOpenBreakpoint)
     }
-  }, [])
+  }, [defaultOpenBreakpoint])
   const open = openProp ?? _open
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {


### PR DESCRIPTION
## 变更

- 没有保存侧边栏偏好时，视口宽度大于等于 1280px 默认展开。
- 没有保存侧边栏偏好时，视口宽度小于 1280px 默认收缩。
- 已保存的手动展开/收缩状态优先于响应式默认值，并继续在刷新后保留。
- 默认展开时保持一图流辅助设施头像至少 64px，避免主内容变窄造成可读性回退。
- tooltip 时序测试明确固定为侧栏收缩场景，因为展开时导航标签已直接可见。
- 增加 1279/1280px 边界、保存状态优先级和 hydration 错误回归覆盖。

## 验证

- [x] 最终 #111/#114/#132 集成树运行 npm run check
- [x] 最终集成树运行 npm run build
- [x] Chromium 完整套件 110 项首轮通过，2 项受本变更影响的布局/tooltip 用例修正后与侧栏边界用例一起串行 3/3 通过
- [x] 无数据库改动
- [x] 未引入第三方代码或素材

## 许可

- [x] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布