### PR TITLE
feat: 完善调整练度流程与森空岛制造站映射

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
 import { requestId, diagnosticId, waitForOwnAnimations, gotoStable, expectVisibleNumbersUseNumberFont, profile, planData, scheduleVisualPlanData, sampleData, authenticatedSklandSnapshot, mockApis, openSklandOverview, seedPreferences, seedV4Session } from "./production-readiness.fixture";
 
 test.beforeEach(async ({ page }) => {
@@ -11,6 +11,16 @@ test.beforeEach(async ({ page }) => {
     }),
   }));
 });
+
+async function expectSetupAction(button: Locator) {
+  await expect(button).toHaveAttribute("data-setup-action", "");
+  const expectedHeight = await button.evaluate(() => (
+    window.matchMedia("(max-width: 639px)").matches ? "44px" : "36px"
+  ));
+  await expect(button).toHaveCSS("height", expectedHeight);
+  await expect(button).toHaveCSS("border-radius", "18px");
+  await expect(button).toHaveCSS("font-size", "12px");
+}
 
 test("mobile interactive targets remain at least 44 CSS pixels", async ({ page }) => {
   await mockApis(page);
@@ -66,7 +76,9 @@ test("setup keeps Box parse errors local and actionable", async ({ page }) => {
   const dialog = page.getByRole("dialog");
   await dialog.getByRole("button", { name: /第 1 步，共 3 步：干员数据/ }).click();
   await expect(dialog.locator(".setup-data-summary")).toHaveCount(1);
-  await dialog.getByRole("button", { name: "更换", exact: true }).click();
+  const changeBoxButton = dialog.getByRole("button", { name: "更换", exact: true });
+  await expectSetupAction(changeBoxButton);
+  await changeBoxButton.click();
   await page.getByRole("tab", { name: "森空岛", exact: true }).click();
   await expect(dialog.locator(".setup-import-action")).toHaveCount(1);
   await page.getByRole("tab", { name: "MAA", exact: true }).click();
@@ -80,7 +92,9 @@ test("setup keeps Box parse errors local and actionable", async ({ page }) => {
   expect(boxContentBox?.width).toBeCloseTo(boxViewportBox?.width ?? 0, 0);
   const textarea = dialog.getByPlaceholder("粘贴 Arknights_OperBox_Export.json 内容");
   await textarea.fill("not valid json");
-  await dialog.getByRole("button", { name: "导入 JSON" }).click();
+  const importJsonButton = dialog.getByRole("button", { name: "导入 JSON" });
+  await expectSetupAction(importJsonButton);
+  await importJsonButton.click();
 
   await expect(textarea).toHaveAttribute("aria-invalid", "true");
   await expect(dialog.locator('[role="alert"]')).toHaveCount(1);
@@ -152,6 +166,118 @@ test("setup with an empty BOX starts on operator data", async ({ page }) => {
   await expect(dialog.getByRole("button", { name: /第 1 步，共 3 步：干员数据/ })).toHaveAttribute("aria-current", "step");
 });
 
+test("progression adjustments sync back to the schedule settings manual BOX", async ({ page }) => {
+  await mockApis(page);
+  const adjustedPlanData = {
+    ...planData,
+    rotation: {
+      ...planData.rotation,
+      daily: {
+        ...planData.rotation.daily,
+        production: {
+          ...planData.rotation.daily.production,
+          lmd: 41_200,
+        },
+      },
+    },
+    diagnosticId: `${diagnosticId}-progression-adjustment`,
+  };
+  let releaseAdjustment!: () => void;
+  const adjustmentGate = new Promise<void>((resolve) => {
+    releaseAdjustment = resolve;
+  });
+  await page.route("**/api/plan", async (route) => {
+    await adjustmentGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true, data: adjustedPlanData, requestId }),
+    });
+  });
+  await seedV4Session(page, planData, { boxSource: "maa" });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "调整练度", exact: true }).click();
+  const adjustmentDialog = page.getByRole("dialog");
+  const rosterScopeTabs = adjustmentDialog.getByRole("tablist", { name: "干员列表范围" });
+  const scheduledTab = rosterScopeTabs.getByRole("tab", { name: /进入排班/ });
+  const unscheduledTab = rosterScopeTabs.getByRole("tab", { name: /未进排班/ });
+  await expect(rosterScopeTabs).toHaveAttribute("data-slot", "tabs-list");
+  await expect(scheduledTab).toHaveAttribute("data-slot", "tabs-trigger");
+  await expect(scheduledTab).toHaveAttribute("aria-selected", "true");
+  await unscheduledTab.click();
+  await expect(unscheduledTab).toHaveAttribute("aria-selected", "true");
+  await scheduledTab.click();
+  await adjustmentDialog.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
+  const adjustmentStage = adjustmentDialog.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" });
+  await adjustmentStage.getByRole("radio", { name: "精1", exact: true }).click();
+  await adjustmentDialog.getByRole("button", { name: "按调整重新试算", exact: true }).click();
+  const activity = page.locator('[data-slot="live-activity"]');
+  await expect(activity).toHaveAttribute("data-activity-phase", "running");
+  await expect(activity).toBeVisible();
+  await expect(activity).toContainText("正在调整练度");
+  releaseAdjustment();
+  await expect(activity).toHaveAttribute("data-activity-phase", "success");
+  await expect(activity).toContainText("调整练度已完成");
+  await expect(adjustmentDialog).toBeHidden();
+
+  const scheduleVariantTabs = page.getByRole("tablist", { name: "排班方案切换" });
+  await expect(scheduleVariantTabs).toHaveAttribute("data-slot", "tabs-list");
+  await expect(scheduleVariantTabs.getByRole("tab", { name: "调整练度方案", exact: true })).toHaveAttribute("aria-selected", "true");
+  const scheduleViewControls = page.locator("[data-schedule-view-controls]");
+  const scheduleLayoutTabs = scheduleViewControls.getByRole("tablist", { name: "排班布局切换" });
+  await expect(scheduleViewControls).toContainText("当前方案");
+  await expect(scheduleViewControls).toContainText("一图流布局");
+  const [variantTabsBox, layoutTabsBox] = await Promise.all([
+    scheduleVariantTabs.boundingBox(),
+    scheduleLayoutTabs.boundingBox(),
+  ]);
+  expect(variantTabsBox?.y).toBeCloseTo(layoutTabsBox?.y ?? 0, 0);
+  await expect(page.getByText(/正在查看调整练度方案/)).toHaveCount(0);
+
+  const lmdProduction = page.locator('[data-daily-product="lmd-orders"] [data-animated-value="number"]');
+  await expect(lmdProduction).toHaveAttribute("aria-label", "41,200");
+  await scheduleVariantTabs.getByRole("tab", { name: "当前方案", exact: true }).click();
+  expect(await lmdProduction.evaluate((element) => (
+    element.getAnimations({ subtree: true }).filter((animation) => animation.playState === "running").length
+  ))).toBeGreaterThan(0);
+  await expect(lmdProduction).toHaveAttribute("aria-label", "34,254");
+  await scheduleVariantTabs.getByRole("tab", { name: "调整练度方案", exact: true }).click();
+  expect(await lmdProduction.evaluate((element) => (
+    element.getAnimations({ subtree: true }).filter((animation) => animation.playState === "running").length
+  ))).toBeGreaterThan(0);
+  await expect(lmdProduction).toHaveAttribute("aria-label", "41,200");
+
+  await expect.poll(() => page.evaluate(() => {
+    const session = JSON.parse(window.localStorage.getItem("arknights-infra-calc-session-v5") ?? "{}");
+    return session.operbox?.find((operator: { name?: string }) => operator.name === "阿米娅")?.elite;
+  })).toBe(1);
+
+  await page.getByRole("button", { name: "配置Box与布局" }).first().click();
+  const setupDialog = page.getByRole("dialog");
+  await setupDialog.getByRole("button", { name: "更换", exact: true }).click();
+  await expect(setupDialog.getByRole("tab", { name: "手动选择", exact: true })).toHaveAttribute("aria-selected", "true");
+  const manualPicker = setupDialog.locator("[data-manual-operbox-picker]");
+  await manualPicker.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
+  await expect(manualPicker.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" }).getByRole("radio", { name: "精1", exact: true })).toBeChecked();
+  await setupDialog.getByRole("button", { name: "Close" }).click();
+
+  for (const width of [390, 320]) {
+    await page.setViewportSize({ width, height: 844 });
+    await expect(scheduleVariantTabs).toBeVisible();
+    await expect(scheduleLayoutTabs).toBeHidden();
+    const [mobileControlsBox, mobileVariantBox] = await Promise.all([
+      scheduleViewControls.boundingBox(),
+      scheduleVariantTabs.boundingBox(),
+    ]);
+    expect(mobileVariantBox?.width).toBeCloseTo(mobileControlsBox?.width ?? 0, 0);
+    for (const tab of await scheduleVariantTabs.getByRole("tab").all()) {
+      const box = await tab.boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44 - 0.01);
+    }
+  }
+});
+
 test("setup exposes and persists only worker-supported rotation profiles", async ({ page }) => {
   await mockApis(page);
   await seedV4Session(page);
@@ -196,7 +322,7 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   expect(dialogMaterial.texture).toContain("repeating-linear-gradient");
   expect(dialogMaterial.texture).toContain("60px");
   expect(dialogMaterial.shadow).toContain("0px 0px 44px");
-  await expect(dialog).toHaveCSS("width", "880px");
+  await expect(dialog).toHaveCSS("width", "960px");
   const setupPrimaryAction = dialog.getByRole("button", { name: "继续", exact: true });
   await expect(setupPrimaryAction).toHaveCSS("width", "196px");
   await expect(setupPrimaryAction).toHaveCSS("height", "46px");
@@ -213,14 +339,23 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   const stepList = dialog.getByRole("list", { name: "设置步骤" });
   await expect(stepList.locator(":scope > *")).toHaveCount(3);
   expect((await stepList.boundingBox())?.width ?? 0).toBeGreaterThan(600);
-  await expect(dialog).toHaveCSS("height", "660px");
+  await expect(dialog).toHaveCSS("height", "720px");
   const initialStepListBox = await stepList.boundingBox();
   await dialog.getByRole("button", { name: /第 1 步，共 3 步：干员数据/ }).click();
-  await dialog.getByRole("button", { name: "更换", exact: true }).click();
+  const changeBoxButton = dialog.getByRole("button", { name: "更换", exact: true });
+  await expectSetupAction(changeBoxButton);
+  await dialog.getByText("数据管理", { exact: true }).click();
+  await expectSetupAction(dialog.getByRole("button", { name: "清除本地数据", exact: true }));
+  await dialog.getByText("数据管理", { exact: true }).click();
+  await changeBoxButton.click();
   await expect(dialog.locator("#setup-import-options")).toBeVisible();
-  await expect(dialog).toHaveCSS("height", "660px");
+  await expect(dialog).toHaveCSS("height", "720px");
+  await dialog.getByRole("tab", { name: "MAA", exact: true }).click();
+  await dialog.getByRole("button", { name: "粘贴 JSON", exact: true }).click();
+  await expectSetupAction(dialog.getByRole("button", { name: "导入 JSON", exact: true }));
   await dialog.getByRole("tab", { name: "手动选择", exact: true }).click();
   const manualPicker = dialog.locator("[data-manual-operbox-picker]");
+  await expect(manualPicker).toHaveAttribute("data-density", "compact");
   const manualHeading = manualPicker.getByRole("heading", { name: "手动选择干员 Box" });
   await expect(manualHeading).toBeVisible();
   await expect(manualHeading.locator("svg")).toHaveCount(0);
@@ -234,6 +369,7 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   const manualActionBoxes = await Promise.all(manualActionButtons.map((button) => button.boundingBox()));
   expect(new Set(manualActionBoxes.map((box) => Math.round(box?.y ?? -1))).size).toBe(1);
   const manualStageGroup = manualPicker.getByRole("radiogroup").first();
+  await expect(manualStageGroup.locator('[role="radio"] span[aria-hidden="true"]')).toHaveCount(0);
   for (const status of [
     { name: "未拥有", color: "rgb(113, 113, 122)" },
     { name: "精0", color: "rgb(34, 187, 255)" },
@@ -250,14 +386,13 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   await manualPicker.getByRole("button", { name: "全选最高精英", exact: true }).click();
   await expect(manualPicker.getByText("已拥有 425 名", { exact: true })).toBeVisible();
   const manualApplyButtons = manualPicker.locator("[data-manual-operbox-apply]");
-  await expect(manualApplyButtons).toHaveCount(2);
+  await expect(manualApplyButtons).toHaveCount(1);
   for (const manualApplyButton of await manualApplyButtons.all()) {
     await expect(manualApplyButton).toBeEnabled();
-    await expect(manualApplyButton).toHaveCSS("height", "36px");
-    await expect(manualApplyButton).toHaveCSS("border-radius", "18px");
-    await expect(manualApplyButton).toHaveCSS("font-size", "12px");
+    await expectSetupAction(manualApplyButton);
   }
   await page.setViewportSize({ width: 390, height: 844 });
+  await expect(manualApplyButtons.first()).toHaveCSS("height", "44px");
   const narrowActionBoxes = await Promise.all(manualActionButtons.map((button) => button.boundingBox()));
   expect(new Set(narrowActionBoxes.map((box) => Math.round(box?.y ?? -1))).size).toBe(1);
   expect(narrowActionBoxes.every((box) => box !== null && box.x >= 0 && box.x + box.width <= 390)).toBe(true);
@@ -268,6 +403,15 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   expect(layoutStepListBox?.y ?? -1).toBeCloseTo(initialStepListBox?.y ?? -1, 0);
   const completedDataStep = dialog.getByRole("button", { name: /第 1 步，共 3 步：干员数据/ });
   await expect(completedDataStep.locator("svg")).toHaveCount(1);
+
+  await dialog.getByText("高级工具", { exact: true }).click();
+  const importLayoutButton = dialog.locator('[data-setup-action]').filter({ hasText: "导入布局" });
+  await expectSetupAction(importLayoutButton);
+  await expect(dialog.getByRole("button", { name: "导入布局", exact: true })).toHaveCount(1);
+  await expectSetupAction(dialog.getByRole("button", { name: "导出布局", exact: true }));
+  const fileChooserEvent = page.waitForEvent("filechooser");
+  await importLayoutButton.click();
+  await fileChooserEvent;
 
   const selectedPreset = dialog.getByRole("button", { name: /^243/ });
   await expect(selectedPreset).toHaveAttribute("aria-pressed", "true");

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -206,7 +206,7 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
   assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 96);
+  assert.equal(readinessTestCount, 97);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: true/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,6 +309,11 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const [upgradeComparison, setUpgradeComparison] = useState<{ baseline: PublicPlanData; trial: PublicPlanData } | null>(null);
   const [scheduleVariant, setScheduleVariant] = useState<"baseline" | "trial">("baseline");
   const [loading, setLoading] = useState(false);
+  const [progressionAdjustmentActivity, setProgressionAdjustmentActivity] = useState({
+    active: false,
+    loading: false,
+    completed: false,
+  });
   const [cliReady, setCliReady] = useState(false);
   const [taskQueueEnabled, setTaskQueueEnabled] = useState(false);
   const [apiError, setApiError] = useState<DisplayError | null>(null);
@@ -383,7 +388,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     setLoading(Boolean(planTask.taskId));
   }, [planTask.taskId]);
 
-  // 升级试算不覆盖原求解结果；两份完整班表在此处切换展示。
+  // 调整练度试算不覆盖原求解结果；两份完整班表在此处切换展示。
   const scheduleResult = scheduleVariant === "trial" && upgradeComparison?.baseline === result
     ? upgradeComparison.trial
     : result;
@@ -994,6 +999,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       boxSource,
     },
   ): Promise<boolean> {
+    setProgressionAdjustmentActivity({ active: false, loading: false, completed: false });
     if (!planInput.operbox) return false;
     if (planRetryCountdown > 0) return false;
     planClickAtRef.current = performance.now();
@@ -1054,18 +1060,30 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   async function handleSimulateUpgrades(trialOperbox: OperBoxEntry[]): Promise<PublicPlanData> {
     if (!operbox) throw new Error(locale === "en" ? "Import operator data first." : "请先导入干员数据。");
     if (!trialOperbox.some((entry) => entry.own)) throw new Error(locale === "en" ? "Select at least one operator for the simulation." : "请至少选择一名干员进行试算。");
+    const normalizedTrialOperbox = normalizeOperboxEntries(trialOperbox);
+    setProgressionAdjustmentActivity({ active: true, loading: true, completed: false });
     trackTelemetry({ type: "interaction", name: "upgrade_simulation_submit", page: "calculator" });
-    const response = await computePlan({
-      layout,
-      operbox: normalizeOperboxEntries(trialOperbox),
-      sourceName: locale === "en" ? "Upgrade simulation Box.json" : "升级试算 Box.json",
-      // 示例数据的替代 BOX 不能沿用 sample；森空岛来源则保留其数据归属标签。
-      boxSource: upgradeSimulationBoxSource(boxSource),
-      rotation: rotationProfile,
-      fiammetta_enable: effectiveFiammettaSetting(trialOperbox, rotationProfile, fiammettaEnabled),
-    });
-    trackTelemetry({ type: "interaction", name: "upgrade_simulation_response", page: "calculator" });
-    return response;
+    try {
+      const response = await computePlan({
+        layout,
+        operbox: normalizedTrialOperbox,
+        sourceName: locale === "en" ? "Progression adjustment Box.json" : "调整练度 Box.json",
+        // 示例数据的替代 BOX 不能沿用 sample；森空岛来源则保留其数据归属标签。
+        boxSource: upgradeSimulationBoxSource(boxSource),
+        rotation: rotationProfile,
+        fiammetta_enable: effectiveFiammettaSetting(trialOperbox, rotationProfile, fiammettaEnabled),
+      });
+      // 求解成功后再同步，避免失败的试算覆盖用户当前 BOX。
+      setOperbox(normalizedTrialOperbox);
+      setFileName(locale === "en" ? "Progression-adjusted Box" : "调整练度后的 Box");
+      setInputMode("manual");
+      setProgressionAdjustmentActivity({ active: true, loading: false, completed: true });
+      trackTelemetry({ type: "interaction", name: "upgrade_simulation_response", page: "calculator" });
+      return response;
+    } catch (error) {
+      setProgressionAdjustmentActivity({ active: true, loading: false, completed: false });
+      throw error;
+    }
   }
 
   async function handleRunSampleTrial(): Promise<boolean> {
@@ -1631,13 +1649,16 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     ? displayError(inputErrorCode, inputError)
     : apiError ?? storageNotice;
   const activity = usePlanActivity({
-    loading,
-    error: statusError,
-    completed: planTask.status === "done",
+    loading: progressionAdjustmentActivity.active ? progressionAdjustmentActivity.loading : loading,
+    error: progressionAdjustmentActivity.active ? null : statusError,
+    completed: progressionAdjustmentActivity.active ? progressionAdjustmentActivity.completed : planTask.status === "done",
+    kind: progressionAdjustmentActivity.active ? "progression-adjustment" : "schedule",
     queued: loading && (
-      planTask.status === "buffered"
-      || planTask.status === "pending"
-      || planTask.pollStopped
+      !progressionAdjustmentActivity.active && (
+        planTask.status === "buffered"
+        || planTask.status === "pending"
+        || planTask.pollStopped
+      )
     ),
     queuePosition: planTask.queuePosition,
     etaSeconds: planTask.etaSeconds,

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1581,8 +1581,8 @@ export function ScheduleBoard({
 
   return (
     <div className="flex flex-col gap-7">
-      <div className="flex flex-wrap items-center justify-between gap-3 max-sm:flex-col max-sm:items-stretch">
-        <div className="flex flex-wrap items-center gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-3 max-sm:flex-col max-sm:items-stretch" data-schedule-toolbar>
+        <div className="flex flex-wrap items-center gap-2 max-sm:w-full" data-schedule-view-controls>
           {supportsCompactLayout && viewMode ? (
             <Tabs
               className="hidden lg:block"
@@ -1594,7 +1594,7 @@ export function ScheduleBoard({
                 onViewModeChange?.(nextViewMode);
               }}
             >
-              <TabsList>
+              <TabsList aria-label={en ? "Schedule layout" : "排班布局切换"}>
                 <TabsTrigger value="compact">{en ? "Overview" : "一图流布局"}</TabsTrigger>
                 <TabsTrigger value="list">{en ? "List" : "列表式布局"}</TabsTrigger>
               </TabsList>

--- a/src/components/PlanResultSummary.tsx
+++ b/src/components/PlanResultSummary.tsx
@@ -88,6 +88,7 @@ export function PlanResultSummary({
   comparison,
   durationMs,
   planRevision,
+  animationRevision = planRevision,
   animateEntrance = true,
   onEntranceConsumed,
   onPerformanceIssue,
@@ -101,6 +102,7 @@ export function PlanResultSummary({
   comparison: ShiftComparison | null;
   durationMs: number;
   planRevision?: string;
+  animationRevision?: string;
   animateEntrance?: boolean;
   onEntranceConsumed?: (revision: string) => void;
   onPerformanceIssue: () => void;
@@ -164,7 +166,7 @@ export function PlanResultSummary({
         {animateOnMount ? (
           <motion.span key={`accent-${planRevision}`} className="pointer-events-none absolute inset-x-0 top-0 z-20 h-0.5 origin-left bg-[#FFD501]" aria-hidden="true" initial={{ scaleX: 0, opacity: 0 }} animate={{ scaleX: 1, opacity: [0, 1, 1, 0] }} transition={{ duration: shouldReduceMotion ? 0 : 0.62, delay: shouldReduceMotion ? 0 : 0.08, times: [0, 0.15, 0.82, 1], ease: MOTION_EASE_OUT }} />
         ) : null}
-        <div key={planRevision} className="grid min-h-[84px] grid-cols-[minmax(10rem,1.05fr)_minmax(0,5fr)] items-stretch max-[820px]:grid-cols-1">
+        <div key={animationRevision} className="grid min-h-[84px] grid-cols-[minmax(10rem,1.05fr)_minmax(0,5fr)] items-stretch max-[820px]:grid-cols-1">
           <motion.button type="button" className={cn("group relative flex min-w-0 items-center justify-between gap-3 overflow-hidden bg-[#272A2B] px-5 py-3 text-left text-white focus-visible:outline-2 focus-visible:outline-offset-[-3px] focus-visible:outline-[#FFD800] max-[820px]:row-span-1 max-sm:min-h-16", comparison && "row-span-2")} data-plan-details-trigger="efficiency" data-plan-primary-details-trigger whileHover={shouldReduceMotion ? undefined : { x: 2 }} whileTap={shouldReduceMotion ? undefined : { scale: 0.985 }} onClick={() => openDetails("efficiency")}>
             <motion.span className="min-w-0" data-plan-metric initial={animateOnMount ? { opacity: 0, x: shouldReduceMotion ? 0 : -10 } : false} animate={{ opacity: 1, x: 0 }} transition={{ duration: shouldReduceMotion ? MOTION_DURATION.feedback : 0.36, delay: shouldReduceMotion ? 0 : 0.1, ease: MOTION_EASE_OUT }}>
               <strong className="block truncate text-lg font-medium"><span className="font-number">{layout.template}</span> {en ? "Base Plan" : "基建方案"}</strong>

--- a/src/components/UpgradeSimulationDialog.tsx
+++ b/src/components/UpgradeSimulationDialog.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { FlaskConical, Loader2, TrendingUp } from "lucide-react";
-import { useRef, useState } from "react";
+import { FlaskConical, Loader2 } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
 
 import { ManualOperboxPicker } from "@/components/setup/ManualOperboxPicker";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { useLanguageDemo } from "@/language-demo";
 import { cn } from "@/lib/utils";
 import type { MaaRoom, OperBoxEntry, PublicPlanData } from "@/types";
@@ -51,11 +52,23 @@ export function UpgradeSimulationDialog({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const pendingRef = useRef(false);
-  const scheduledOperatorNames = baseline.maa.plans.flatMap((plan) => (
-    Object.values(plan.rooms) as Array<MaaRoom[] | undefined>
-  ).flatMap((rooms) => (rooms ?? []).flatMap((room) => room.operators.flatMap((operator) => (
-    typeof operator === "string" ? [operator] : operator?.name ? [operator.name] : []
-  )))));
+  const scheduledOperatorShifts = useMemo(() => {
+    const shiftsByName: Record<string, number[]> = {};
+    baseline.maa.plans.slice(0, 3).forEach((plan, planIndex) => {
+      const shift = planIndex + 1;
+      (Object.values(plan.rooms) as Array<MaaRoom[] | undefined>)
+        .flatMap((rooms) => rooms ?? [])
+        .flatMap((room) => room.operators)
+        .forEach((operator) => {
+          const name = typeof operator === "string" ? operator : operator?.name;
+          if (!name) return;
+          const shifts = shiftsByName[name] ?? [];
+          if (!shifts.includes(shift)) shiftsByName[name] = [...shifts, shift];
+        });
+    });
+    return shiftsByName;
+  }, [baseline.maa.plans]);
+  const scheduledOperatorNames = useMemo(() => Object.keys(scheduledOperatorShifts), [scheduledOperatorShifts]);
 
   const apply = async (nextBox: OperBoxEntry[]) => {
     if (pendingRef.current) return;
@@ -74,10 +87,11 @@ export function UpgradeSimulationDialog({
       const nextTrial = await onSimulate(nextBox);
       setTrial(nextTrial);
       onTrialReady?.(nextTrial);
+      setOpen(false);
     } catch (reason) {
       setError(reason instanceof Error
         ? reason.message
-        : en ? "Upgrade simulation failed. Please try again later." : "升级试算失败，请稍后重试。");
+        : en ? "Progression adjustment failed. Please try again later." : "调整练度试算失败，请稍后重试。");
     } finally {
       pendingRef.current = false;
       setPending(false);
@@ -86,67 +100,72 @@ export function UpgradeSimulationDialog({
 
   return (
     <>
-      <Button type="button" variant="outline" size="sm" className="min-h-11" disabled={disabled} onClick={() => setOpen(true)}>
-        <FlaskConical />{en ? "Upgrade simulation" : "升级试算"}
+      <Button type="button" variant="outline" size="sm" className="h-9 min-h-0 max-sm:h-11" disabled={disabled} onClick={() => setOpen(true)}>
+        <FlaskConical />{en ? "Adjust progression" : "调整练度"}
       </Button>
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100%-1rem)] max-w-[min(90rem,calc(100%-1rem))] overflow-y-auto p-0 sm:w-[calc(100%-2rem)] sm:max-w-[min(90rem,calc(100%-2rem))]" aria-describedby="upgrade-simulation-description">
-          <DialogHeader className="border-b border-border/70 px-5 py-5 sm:px-7">
-            <DialogTitle className="flex items-center gap-2 text-xl">
-              <TrendingUp className="size-5" />{en ? "Same-layout upgrade simulation" : "同布局升级试算"}
+        <DialogContent data-upgrade-simulation-dialog className="h-[min(720px,calc(100dvh-1rem))] max-w-[calc(100%-1rem)] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden rounded-[24px] p-0 sm:max-w-[min(1060px,calc(100%-2rem))] sm:rounded-[32px]" aria-describedby="upgrade-simulation-description">
+          <DialogHeader className="border-b border-border/70 px-4 py-3 pr-14 sm:flex-row sm:items-center sm:gap-5 sm:px-6 sm:py-4 sm:pr-16">
+            <DialogTitle className="shrink-0 text-lg">
+              {en ? "Same-layout progression adjustment" : "同布局调整练度"}
             </DialogTitle>
-            <DialogDescription id="upgrade-simulation-description" className="mt-2 leading-6">
+            <DialogDescription id="upgrade-simulation-description" className="max-w-3xl leading-5">
               {en
-                ? "Operators in this schedule are shown first. Switch to Not scheduled to search for any operator and change their elite stage. Unowned operators can be included as a hypothetical upgrade without changing your BOX or current schedule."
-                : "默认先看本次上岗干员。需要补人时切到“未进排班”，再搜索任意干员并调整精英化状态；未拥有干员会作为假设获得加入本次计算，不会改动 BOX 或当前班表。"}
+                ? "Adjust ownership or elite stage and solve with the same base layout. Successful changes sync to the manual BOX; the current schedule stays available for comparison."
+                : "调整干员持有或精英化状态，按当前布局重新求解；成功后同步到手动 BOX，当前班表保留用于对比。"}
             </DialogDescription>
           </DialogHeader>
-          <div className="px-5 py-5 sm:px-7">
-            <ManualOperboxPicker
-              operbox={operbox}
-              scheduledOperatorNames={scheduledOperatorNames}
-              title={en ? "Choose operators to simulate" : "选择要试算的干员"}
-              description={en
-                ? "Change at least one operator's ownership or elite stage. You can search for unowned operators and assign any available elite stage."
-                : "至少调整一名干员的精英化状态；可以搜索未拥有干员并设置任意精英化阶段。"}
-              applyLabel={pending
-                ? (en ? "Solving again…" : "正在重新求解…")
-                : (en ? "Run upgrade simulation" : "运行升级试算")}
-              applyDisabled={pending}
-              onApply={(entries) => void apply(entries)}
-            />
-            {pending ? (
-              <p className="mt-4 flex items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                {en ? "Solving again with the same layout…" : "正在按同一布局重新求解…"}
-              </p>
-            ) : null}
-            {error ? <p className="mt-4 border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{error}</p> : null}
-            {trial ? (
-              <section className="mt-5 border border-primary/25 bg-primary/5 p-4" aria-label={en ? "Upgrade simulation result" : "升级试算结果"}>
-                <h3 className="font-semibold">{en ? "Simulation complete" : "试算完成"}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {en
-                    ? "Use the Current plan / Upgrade simulation controls on the main screen to inspect both complete schedules."
-                    : "已在主界面新增“当前方案 / 升级试算方案”切换，可直接查看两份完整班表。"}
+          <ScrollArea className="min-h-0" viewportClassName="overflow-x-hidden">
+            <div className="px-4 py-3 sm:px-6 sm:py-4">
+              <ManualOperboxPicker
+                compact
+                operbox={operbox}
+                scheduledOperatorNames={scheduledOperatorNames}
+                scheduledOperatorShifts={scheduledOperatorShifts}
+                scheduledShiftCount={Math.min(3, baseline.maa.plans.length)}
+                title={en ? "Operators for this simulation" : "本次试算干员"}
+                description={en
+                  ? "Change at least one operator; this selection is shared with Schedule Settings."
+                  : "至少调整一名干员；这里的选择会与排班设置同步。"}
+                applyLabel={pending
+                  ? (en ? "Solving again…" : "正在重新求解…")
+                  : (en ? "Solve with adjustments" : "按调整重新试算")}
+                applyDisabled={pending}
+                onApply={(entries) => void apply(entries)}
+              />
+              {pending ? (
+                <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  {en ? "Solving again with the same layout…" : "正在按同一布局重新求解…"}
                 </p>
-                <dl className="mt-4 grid grid-cols-3 gap-2">
-                  {METRICS.map(({ key, en: englishLabel, zh }) => {
-                    const change = delta(baseline.rotation.daily[key], trial.rotation.daily[key], en);
-                    return (
-                      <div key={key} className="border border-primary/15 bg-background p-3">
-                        <dt className="text-xs text-muted-foreground">{en ? `${englishLabel} efficiency` : `${zh}效率`}</dt>
-                        <dd className="mt-1 font-number text-lg font-semibold">{metric(trial.rotation.daily[key])}</dd>
-                        <span className={cn("mt-1 block text-xs font-medium", change.startsWith("+") ? "text-emerald-700" : change.startsWith("-") ? "text-red-700" : "text-muted-foreground")}>
-                          {en ? `vs current ${change}` : `较当前 ${change}`}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </dl>
-              </section>
-            ) : null}
-          </div>
+              ) : null}
+              {error ? <p className="mt-3 border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{error}</p> : null}
+              {trial ? (
+                <section className="mt-3 flex flex-wrap items-center gap-3 border border-primary/25 bg-primary/5 px-3 py-2.5" aria-label={en ? "Progression adjustment result" : "调整练度结果"}>
+                  <div className="min-w-48 flex-1">
+                    <h3 className="font-semibold">{en ? "Simulation complete" : "试算完成"}</h3>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {en ? "The manual BOX is synced. Switch between both schedules on the main screen." : "手动 BOX 已同步，可在主界面切换当前方案与调整练度方案。"}
+                    </p>
+                  </div>
+                  <dl className="grid w-full grid-cols-3 divide-x divide-primary/15 border border-primary/15 bg-background sm:w-auto">
+                    {METRICS.map(({ key, en: englishLabel, zh }) => {
+                      const change = delta(baseline.rotation.daily[key], trial.rotation.daily[key], en);
+                      return (
+                        <div key={key} className="min-w-24 px-3 py-1.5">
+                          <dt className="text-[11px] text-muted-foreground">{en ? englishLabel : zh}</dt>
+                          <dd className="font-number text-base font-semibold">{metric(trial.rotation.daily[key])}</dd>
+                          <span className={cn("block text-[11px] font-medium", change.startsWith("+") ? "text-emerald-700" : change.startsWith("-") ? "text-red-700" : "text-muted-foreground")}>
+                            {en ? `vs current ${change}` : `较当前 ${change}`}
+                          </span>
+                        </div>
+                      );
+                    })}
+                  </dl>
+                </section>
+              ) : null}
+            </div>
+          </ScrollArea>
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, Ellipsis, FlaskConical, HeartPulse, Keyboard, Loader2, Play, RefreshCw, Search, Settings2, Sparkles, X } from "lucide-react";
+import { Download, Ellipsis, FlaskConical, HeartPulse, Keyboard, Loader2, Play, RefreshCw, Search, Settings2, X } from "lucide-react";
 import { lazy, Suspense, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { ScheduleBoard, ShiftTabs } from "@/components";
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PlanResultSummarySkeleton } from "@/components/PlanResultSummarySkeleton";
 
 import type { FactoryRecipe, TradeOrder } from "@/blueprint";
@@ -559,22 +560,21 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                       {en ? "Cancel task" : "取消任务"}
                     </Button>
                   </div>
-                ) : <RunButton canRun={canRun} hasBox={hasBox} plannerReady={plannerReady} requiresAccount={requiresAccount} runCooldownSeconds={runCooldownSeconds} onRun={onRun} />}
+                ) : (
+                  <div className="flex min-w-0 items-center justify-end gap-2 max-sm:justify-self-end">
+                    {operbox && scheduleResult ? (
+                      <Suspense fallback={<Button type="button" variant="outline" size="sm" className="h-9 min-h-0 max-sm:h-11" disabled><FlaskConical />{en ? "Adjust progression" : "调整练度"}</Button>}>
+                        <UpgradeSimulationDialog operbox={operbox} baseline={result ?? scheduleResult} onSimulate={onSimulateUpgrades} onTrialReady={onUpgradeTrialReady} />
+                      </Suspense>
+                    ) : null}
+                    <RunButton canRun={canRun} hasBox={hasBox} plannerReady={plannerReady} requiresAccount={requiresAccount} runCooldownSeconds={runCooldownSeconds} onRun={onRun} />
+                  </div>
+                )}
               </div>
             ) : null}
           >
             {scheduleResult ? (
               <>
-                <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-                  {upgradeComparison ? (
-                    <section className="flex min-h-11 flex-wrap items-center gap-1 rounded-lg border border-primary/20 bg-primary/5 p-1" aria-label={en ? "Schedule variant" : "排班方案切换"}>
-                      <Button type="button" size="sm" variant={scheduleVariant === "baseline" ? "default" : "ghost"} aria-pressed={scheduleVariant === "baseline"} onClick={() => onScheduleVariantChange("baseline")}>{en ? "Current plan" : "当前方案"}</Button>
-                      <Button type="button" size="sm" variant={scheduleVariant === "trial" ? "default" : "ghost"} aria-pressed={scheduleVariant === "trial"} onClick={() => onScheduleVariantChange("trial")}><Sparkles />{en ? "Upgrade simulation" : "升级试算方案"}</Button>
-                    </section>
-                  ) : <span />}
-                  {operbox ? <Suspense fallback={<Button type="button" variant="outline" size="sm" className="min-h-11" disabled><FlaskConical />{en ? "Upgrade simulation" : "升级试算"}</Button>}><UpgradeSimulationDialog operbox={operbox} baseline={result ?? scheduleResult} disabled={loading} onSimulate={onSimulateUpgrades} onTrialReady={onUpgradeTrialReady} /></Suspense> : null}
-                </div>
-                {upgradeComparison ? <p className="mb-4 text-sm text-muted-foreground" role="status">{en ? `Viewing the ${scheduleVariant === "trial" ? "upgrade simulation" : "current plan"}. You can switch between both schedules without changing your BOX.` : `正在查看${scheduleVariant === "trial" ? "升级试算方案" : "当前方案"}。两份班表可随时切换，不会改动你的 BOX。`}</p> : null}
                 <Suspense fallback={<DeferredResultLoading />}>
                   <PlanResultSummary
                     profile={scheduleResult.profile}
@@ -585,6 +585,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                     comparison={closestComparison}
                     durationMs={scheduleResult.durationMs}
                     planRevision={scheduleResult.diagnosticId}
+                    animationRevision={result?.diagnosticId ?? scheduleResult.diagnosticId}
                     animateEntrance={animatePlanEntrance}
                     onEntranceConsumed={onPlanEntranceConsumed}
                     onPerformanceIssue={onPerformanceIssue}
@@ -618,6 +619,18 @@ export function InfraCalculator(props: InfraCalculatorProps) {
               activePlan={activePlan}
               searchQuery={operatorQuery}
               animateInitialView={!scheduleResult && animateEmptyScheduleEntrance}
+              viewControlsSlot={upgradeComparison ? (
+                <Tabs
+                  className="w-full sm:w-auto"
+                  value={scheduleVariant}
+                  onValueChange={(value) => onScheduleVariantChange(value as "baseline" | "trial")}
+                >
+                  <TabsList className="grid w-full grid-cols-2 sm:inline-flex sm:w-fit" aria-label={en ? "Schedule variant" : "排班方案切换"}>
+                    <TabsTrigger value="baseline">{en ? "Current plan" : "当前方案"}</TabsTrigger>
+                    <TabsTrigger value="trial">{en ? "Adjusted progression" : "调整练度方案"}</TabsTrigger>
+                  </TabsList>
+                </Tabs>
+              ) : undefined}
               mobileActionsSlot={renderExportActions("mobile")}
               shiftInfoSlot={(
                 <div className="flex flex-wrap items-center justify-end gap-2 max-sm:w-full max-sm:justify-between" data-shift-actions>

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -8,6 +8,8 @@ import operatorCatalogJson from "../../generated/arkntools/operator-catalog.json
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LoadMore } from "@/components/ui/load-more";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import { demoOperatorName, useLanguageDemo, type DemoLocale } from "@/language-demo";
 import { cn } from "@/lib/utils";
 import {
@@ -19,8 +21,6 @@ import {
 import type { OperBoxEntry } from "@/types";
 
 const PAGE_SIZE = 48;
-const APPLY_BUTTON_CLASS = "h-9 min-w-[152px] px-4 text-xs font-semibold max-sm:min-h-9 max-sm:min-w-[152px] sm:h-9 sm:min-w-[152px] sm:px-4";
-const APPLY_BUTTON_STYLE = { borderRadius: 18 } as const;
 
 type CatalogOperator = {
   id: string;
@@ -54,6 +54,18 @@ const STAGE_COLOR: Record<ManualOperboxStage, string> = {
   e2: "#FFD800",
 };
 
+const SHIFT_BADGE_CLASS = [
+  "border-[#C7A600]/40 bg-[#FFD501]/18 text-[#695700] dark:text-[#FFE36B]",
+  "border-sky-500/35 bg-sky-500/10 text-sky-800 dark:text-sky-300",
+  "border-emerald-500/35 bg-emerald-500/10 text-emerald-800 dark:text-emerald-300",
+] as const;
+
+function shiftLabel(shift: number, en: boolean, short = false): string {
+  if (en) return short ? `S${shift}` : `Shift ${shift}`;
+  if (short) return `${shift}班`;
+  return ["第一班", "第二班", "第三班"][shift - 1] ?? `第${shift}班`;
+}
+
 function initialStages(operbox: OperBoxEntry[] | null): Record<string, ManualOperboxStage> {
   const byId = new Map(operbox?.map((entry) => [entry.id, entry]) ?? []);
   const byName = new Map(operbox?.map((entry) => [entry.name, entry]) ?? []);
@@ -81,11 +93,15 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
   operator,
   stage,
   locale,
+  compact = false,
+  scheduledShifts,
   onStageChange,
 }: {
   operator: ManualRosterOperator;
   stage: ManualOperboxStage;
   locale: DemoLocale;
+  compact?: boolean;
+  scheduledShifts?: readonly number[];
   onStageChange: (id: string, stage: ManualOperboxStage) => void;
 }) {
   const en = locale === "en";
@@ -93,9 +109,14 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
   const maxElite = maxEliteForRarity(operator.rarity);
 
   return (
-    <article className="grid gap-3 rounded-[4px] border border-border/80 bg-background p-3 [content-visibility:auto] [contain-intrinsic-size:8.5rem]">
-      <div className="flex min-w-0 items-center gap-3">
-        <div className="size-12 shrink-0 overflow-hidden border border-border bg-muted sm:size-14">
+    <article className={cn(
+      "rounded-[4px] border border-border/80 bg-background [content-visibility:auto]",
+      compact
+        ? "grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-2 p-2 [contain-intrinsic-size:4.5rem] sm:grid-cols-[2.5rem_minmax(6.5rem,0.72fr)_minmax(13rem,1.28fr)]"
+        : "grid gap-3 p-3 [contain-intrinsic-size:8.5rem]",
+    )}>
+      <div className={cn("flex min-w-0 items-center", compact ? "contents" : "gap-3")}>
+        <div className={cn("shrink-0 overflow-hidden border border-border bg-muted", compact ? "size-10" : "size-12 sm:size-14")}>
           {operator.portrait ? (
             <img
               src={operator.portrait}
@@ -108,16 +129,30 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
         </div>
         <div className="min-w-0">
           <h5 className="truncate text-sm font-semibold">{displayName}</h5>
-          <p className="font-number mt-1 text-xs text-muted-foreground">
-            {operator.rarity}★ · {en ? `Up to E${maxElite}` : `最高精${maxElite}`}
-          </p>
+          <div className={cn("flex min-w-0 flex-wrap items-center gap-1", compact ? "mt-0.5" : "mt-1")}>
+            <span className="font-number text-xs text-muted-foreground">
+              {operator.rarity}★ · {en ? `Up to E${maxElite}` : `最高精${maxElite}`}
+            </span>
+            {scheduledShifts?.map((shift) => (
+              <span
+                key={shift}
+                className={cn(
+                  "inline-flex h-4 items-center border px-1 text-[10px] font-semibold leading-none",
+                  SHIFT_BADGE_CLASS[(shift - 1) % SHIFT_BADGE_CLASS.length],
+                )}
+                title={shiftLabel(shift, en)}
+              >
+                {shiftLabel(shift, en, true)}
+              </span>
+            ))}
+          </div>
         </div>
       </div>
 
       <div
         role="radiogroup"
         aria-label={en ? `${displayName} ownership and elite stage` : `${displayName}持有与精英阶段`}
-        className="grid grid-cols-4 gap-1.5"
+        className={cn("grid grid-cols-4", compact ? "col-span-2 gap-1 sm:col-span-1" : "gap-1.5")}
       >
         {STAGES.map((option) => {
           const requestedElite = option === "e2" ? 2 : option === "e1" ? 1 : 0;
@@ -145,12 +180,7 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
                 disabled && "cursor-not-allowed border-border/50 bg-muted/30 text-muted-foreground/40",
               )}
             >
-              <span className="inline-flex items-center justify-center gap-1">
-                <span
-                  className={cn("size-2 shrink-0 rounded-[2px]", disabled && "opacity-30")}
-                  style={{ backgroundColor: STAGE_COLOR[option] }}
-                  aria-hidden="true"
-                />
+              <span className="inline-flex items-center justify-center">
                 {stageLabel(option, locale)}
               </span>
             </Button>
@@ -169,6 +199,9 @@ export function ManualOperboxPicker({
   applyLabel,
   applyDisabled = false,
   scheduledOperatorNames,
+  scheduledOperatorShifts,
+  scheduledShiftCount = 0,
+  compact = false,
 }: {
   operbox: OperBoxEntry[] | null;
   onApply: (entries: OperBoxEntry[]) => void;
@@ -177,17 +210,30 @@ export function ManualOperboxPicker({
   applyLabel?: string;
   applyDisabled?: boolean;
   scheduledOperatorNames?: readonly string[];
+  scheduledOperatorShifts?: Readonly<Record<string, readonly number[]>>;
+  scheduledShiftCount?: number;
+  compact?: boolean;
 }) {
   const { locale } = useLanguageDemo();
   const en = locale === "en";
   const [query, setQuery] = useState("");
   const [onlyOwned, setOnlyOwned] = useState(false);
   const [rosterScope, setRosterScope] = useState<"scheduled" | "other">("scheduled");
+  const [scheduledShift, setScheduledShift] = useState<"all" | number>("all");
   const [visibleLimit, setVisibleLimit] = useState(PAGE_SIZE);
   const [stages, setStages] = useState<Record<string, ManualOperboxStage>>(() => initialStages(operbox));
   const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase(locale === "en" ? "en-US" : "zh-CN"));
-  const scheduledNames = useMemo(() => new Set(scheduledOperatorNames ?? []), [scheduledOperatorNames]);
+  const scheduledNames = useMemo(() => new Set([
+    ...(scheduledOperatorNames ?? []),
+    ...Object.keys(scheduledOperatorShifts ?? {}),
+  ]), [scheduledOperatorNames, scheduledOperatorShifts]);
   const hasScheduledOperators = scheduledNames.size > 0;
+  const shiftCounts = useMemo(() => Array.from({ length: scheduledShiftCount }, (_, index) => {
+    const shift = index + 1;
+    return MANUAL_ROSTER.reduce((count, operator) => (
+      scheduledOperatorShifts?.[operator.name]?.includes(shift) ? count + 1 : count
+    ), 0);
+  }), [scheduledOperatorShifts, scheduledShiftCount]);
 
   const handleStageChange = useCallback((id: string, stage: ManualOperboxStage) => {
     setStages((current) => ({ ...current, [id]: stage }));
@@ -203,13 +249,14 @@ export function ManualOperboxPicker({
   const filteredOperators = useMemo(() => MANUAL_ROSTER.filter((operator) => {
     const stage = stages[operator.id] ?? "none";
     if (hasScheduledOperators && (rosterScope === "scheduled") !== scheduledNames.has(operator.name)) return false;
+    if (rosterScope === "scheduled" && scheduledShift !== "all" && !scheduledOperatorShifts?.[operator.name]?.includes(scheduledShift)) return false;
     if (onlyOwned && stage === "none") return false;
     if (!deferredQuery) return true;
     const displayName = demoOperatorName(operator.name, locale).toLocaleLowerCase(locale === "en" ? "en-US" : "zh-CN");
     return operator.name.toLocaleLowerCase("zh-CN").includes(deferredQuery)
       || displayName.includes(deferredQuery)
       || operator.id.toLocaleLowerCase("en-US").includes(deferredQuery);
-  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, rosterScope, scheduledNames, stages]);
+  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, stages]);
 
   function resetListView() {
     setVisibleLimit(PAGE_SIZE);
@@ -221,54 +268,61 @@ export function ManualOperboxPicker({
   }
 
   return (
-    <div className="grid gap-4" data-manual-operbox-picker>
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border/70 pb-4">
-        <div className="min-w-0">
-          <h4 className="text-sm font-semibold">{title ?? (en ? "Build your operator Box" : "手动选择干员 Box")}</h4>
-          <p className="mt-1 max-w-2xl text-xs leading-5 text-muted-foreground">
+    <div className={cn("grid", compact ? "gap-2.5" : "gap-4")} data-manual-operbox-picker data-density={compact ? "compact" : "comfortable"}>
+      <div className={cn("flex flex-wrap justify-between gap-3 border-b border-border/70", compact ? "items-center pb-2.5" : "items-start pb-4")}>
+        <div className={cn("min-w-0", compact && "flex flex-1 flex-wrap items-baseline gap-x-3 gap-y-1 max-sm:w-full max-sm:flex-none")}>
+          <h4 className="shrink-0 text-sm font-semibold">{title ?? (en ? "Build your operator Box" : "手动选择干员 Box")}</h4>
+          <p className={cn("max-w-2xl text-xs text-muted-foreground", compact ? "leading-4" : "mt-1 leading-5")}>
             {description ?? (en
               ? "Choose ownership and elite stage. Levels use each stage cap so level-gated infrastructure skills remain available."
               : "选择持有状态与精英阶段；等级按该阶段上限估算，避免漏掉有等级要求的基建技能。")}
           </p>
+          {compact ? (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs" aria-live="polite">
+              <strong className="font-number text-foreground">{en ? `${ownedCount} owned` : `已拥有 ${ownedCount} 名`}</strong>
+              <span className="font-number text-muted-foreground">{en ? `E0 ${summary.e0} · E1 ${summary.e1} · E2 ${summary.e2}` : `精0 ${summary.e0} · 精1 ${summary.e1} · 精2 ${summary.e2}`}</span>
+              <span className="font-number text-muted-foreground">{en ? `${summary.none} unowned` : `未拥有 ${summary.none} 名`}</span>
+            </div>
+          ) : null}
         </div>
-        <Button
+        <SetupActionButton
           type="button"
-          size="dialog"
-          className={APPLY_BUTTON_CLASS}
-          style={APPLY_BUTTON_STYLE}
+          className={cn(compact && "max-sm:w-full")}
           data-manual-operbox-apply
           disabled={!ownedCount || applyDisabled}
           onClick={applySelection}
         >
           <Check />{applyLabel ?? (en ? "Use this Box" : "使用这份 Box")}
-        </Button>
+        </SetupActionButton>
       </div>
 
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs" aria-live="polite">
-        <strong className="font-number text-foreground">{en ? `${ownedCount} owned` : `已拥有 ${ownedCount} 名`}</strong>
-        <span className="font-number text-muted-foreground">{en ? `E0 ${summary.e0} · E1 ${summary.e1} · E2 ${summary.e2}` : `精0 ${summary.e0} · 精1 ${summary.e1} · 精2 ${summary.e2}`}</span>
-        <span className="font-number text-muted-foreground">{en ? `${summary.none} unowned` : `未拥有 ${summary.none} 名`}</span>
-      </div>
+      {!compact ? (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs" aria-live="polite">
+          <strong className="font-number text-foreground">{en ? `${ownedCount} owned` : `已拥有 ${ownedCount} 名`}</strong>
+          <span className="font-number text-muted-foreground">{en ? `E0 ${summary.e0} · E1 ${summary.e1} · E2 ${summary.e2}` : `精0 ${summary.e0} · 精1 ${summary.e1} · 精2 ${summary.e2}`}</span>
+          <span className="font-number text-muted-foreground">{en ? `${summary.none} unowned` : `未拥有 ${summary.none} 名`}</span>
+        </div>
+      ) : null}
 
-      <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
+      <div className={cn("grid gap-2", compact ? "lg:grid-cols-[minmax(14rem,1fr)_auto]" : "sm:grid-cols-[minmax(0,1fr)_auto]")}>
         <label className="relative min-w-0">
-          <Search className="pointer-events-none absolute left-3 top-3.5 size-4 text-muted-foreground" aria-hidden="true" />
+          <Search className={cn("pointer-events-none absolute left-3 size-4 text-muted-foreground", compact ? "top-2.5 max-sm:top-3.5" : "top-3.5")} aria-hidden="true" />
           <Input
             value={query}
             onChange={(event) => {
               setQuery(event.target.value);
               resetListView();
             }}
-            className="h-11 pl-9"
+            className={cn("pl-9", compact ? "h-9 max-sm:h-11" : "h-11")}
             placeholder={en ? "Search operator" : "搜索干员"}
             aria-label={en ? "Search operator" : "搜索干员"}
           />
         </label>
-        <div className="grid grid-cols-3 gap-2" data-manual-operbox-actions>
+        <div className={cn("grid grid-cols-3", compact ? "gap-1.5" : "gap-2")} data-manual-operbox-actions>
           <Button
             type="button"
             variant={onlyOwned ? "default" : "outline"}
-            className="min-h-11 min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3 sm:text-sm"
+            className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
             aria-pressed={onlyOwned}
             onClick={() => {
               setOnlyOwned((current) => !current);
@@ -280,7 +334,7 @@ export function ManualOperboxPicker({
           <Button
             type="button"
             variant="outline"
-            className="min-h-11 min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3 sm:text-sm"
+            className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
             onClick={() => {
               setStages(Object.fromEntries(
                 MANUAL_ROSTER.map((operator) => [operator.id, maximumStageForRarity(operator.rarity)]),
@@ -294,7 +348,7 @@ export function ManualOperboxPicker({
           <Button
             type="button"
             variant="ghost"
-            className="min-h-11 min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3 sm:text-sm"
+            className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
             disabled={!ownedCount}
             onClick={() => {
               setStages(Object.fromEntries(MANUAL_ROSTER.map((operator) => [operator.id, "none"])));
@@ -308,31 +362,69 @@ export function ManualOperboxPicker({
       </div>
 
       {hasScheduledOperators ? (
-        <div className="grid grid-cols-2 gap-2" aria-label={en ? "Operator list scope" : "干员列表范围"}>
-          <Button type="button" variant={rosterScope === "scheduled" ? "default" : "outline"} className="min-h-11" aria-pressed={rosterScope === "scheduled"} onClick={() => { setRosterScope("scheduled"); resetListView(); }}>
-            {en ? "In this schedule" : "本次进入排班"}
-          </Button>
-          <Button type="button" variant={rosterScope === "other" ? "default" : "outline"} className="min-h-11" aria-pressed={rosterScope === "other"} onClick={() => { setRosterScope("other"); resetListView(); }}>
-            {en ? "Not scheduled" : "未进排班"}
-          </Button>
+        <div className={cn(compact ? "flex flex-wrap items-center gap-1.5" : "flex flex-wrap items-center gap-2")}>
+          <Tabs
+            value={rosterScope}
+            onValueChange={(value) => {
+              const nextScope = value as "scheduled" | "other";
+              setRosterScope(nextScope);
+              if (nextScope === "other") setScheduledShift("all");
+              resetListView();
+            }}
+          >
+            <TabsList aria-label={en ? "Operator list scope" : "干员列表范围"}>
+              <TabsTrigger value="scheduled">
+                {en ? "In schedule" : "进入排班"}<span className="font-number opacity-65">{scheduledNames.size}</span>
+              </TabsTrigger>
+              <TabsTrigger value="other">
+                {en ? "Not scheduled" : "未进排班"}<span className="font-number opacity-65">{MANUAL_ROSTER.length - scheduledNames.size}</span>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {compact && rosterScope === "scheduled" && scheduledShiftCount > 0 ? (
+            <div className="ml-1 flex flex-wrap items-center gap-1 border-l border-border/70 pl-2" aria-label={en ? "Schedule shift" : "排班班次"}>
+              <Button type="button" size="sm" variant={scheduledShift === "all" ? "secondary" : "ghost"} aria-pressed={scheduledShift === "all"} onClick={() => { setScheduledShift("all"); resetListView(); }}>
+                {en ? "All shifts" : "全部班次"}
+              </Button>
+              {shiftCounts.map((count, index) => {
+                const shift = index + 1;
+                return (
+                  <Button
+                    key={shift}
+                    type="button"
+                    size="sm"
+                    variant={scheduledShift === shift ? "secondary" : "ghost"}
+                    className={cn("border", scheduledShift === shift ? SHIFT_BADGE_CLASS[index % SHIFT_BADGE_CLASS.length] : "border-transparent")}
+                    aria-pressed={scheduledShift === shift}
+                    onClick={() => { setScheduledShift(shift); resetListView(); }}
+                  >
+                    {shiftLabel(shift, en)}<span className="font-number opacity-65">{count}</span>
+                  </Button>
+                );
+              })}
+            </div>
+          ) : null}
         </div>
       ) : null}
 
       {filteredOperators.length ? (
         <>
-          <div className="grid gap-3 md:grid-cols-2">
+          <div className={cn("grid md:grid-cols-2", compact ? "gap-2" : "gap-3")}>
             {filteredOperators.slice(0, visibleLimit).map((operator) => (
               <ManualOperatorCard
                 key={operator.id}
                 operator={operator}
                 stage={stages[operator.id] ?? "none"}
                 locale={locale}
+                compact={compact}
+                scheduledShifts={rosterScope === "scheduled" ? scheduledOperatorShifts?.[operator.name] : undefined}
                 onStageChange={handleStageChange}
               />
             ))}
           </div>
           <LoadMore
             auto={false}
+            className={compact ? "min-h-9" : undefined}
             hasMore={visibleLimit < filteredOperators.length}
             onLoad={() => {
               setVisibleLimit((current) => current + PAGE_SIZE);
@@ -350,19 +442,18 @@ export function ManualOperboxPicker({
               end: "已显示全部符合条件的干员",
             }}
           />
-          <div className="flex justify-end">
-            <Button
-              type="button"
-              size="dialog"
-              className={APPLY_BUTTON_CLASS}
-              style={APPLY_BUTTON_STYLE}
-              data-manual-operbox-apply
-              disabled={!ownedCount || applyDisabled}
-              onClick={applySelection}
-            >
-              <Check />{applyLabel ?? (en ? `Use this Box (${ownedCount})` : `使用这份 Box（${ownedCount} 名）`)}
-            </Button>
-          </div>
+          {!compact ? (
+            <div className="flex justify-end">
+              <SetupActionButton
+                type="button"
+                data-manual-operbox-apply
+                disabled={!ownedCount || applyDisabled}
+                onClick={applySelection}
+              >
+                <Check />{applyLabel ?? (en ? `Use this Box (${ownedCount})` : `使用这份 Box（${ownedCount} 名）`)}
+              </SetupActionButton>
+            </div>
+          ) : null}
         </>
       ) : (
         <div className="grid min-h-32 place-items-center border border-dashed border-border text-center text-sm text-muted-foreground">

--- a/src/components/setup/SetupActionButton.tsx
+++ b/src/components/setup/SetupActionButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ComponentProps } from "react";
+
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+type SetupActionButtonProps = Omit<ComponentProps<typeof Button>, "size"> & { asLabel?: false };
+type SetupActionLabelProps = Omit<ComponentProps<"label">, "size"> & { asLabel: true };
+
+const SETUP_ACTION_CLASS = "h-11 min-w-[152px] px-4 text-xs font-semibold max-sm:min-w-[152px] sm:h-9 sm:min-w-[152px] sm:px-4";
+
+/** Compact pill action shared by the schedule setup surfaces. */
+export function SetupActionButton(props: SetupActionButtonProps | SetupActionLabelProps) {
+  if (props.asLabel) {
+    const { asLabel, className, style, ...labelProps } = props;
+    return (
+      <Label
+        {...labelProps}
+        pressable
+        className={cn(
+          buttonVariants({ size: "dialog" }),
+          SETUP_ACTION_CLASS,
+          "has-[input:focus-visible]:border-ring has-[input:focus-visible]:ring-3 has-[input:focus-visible]:ring-ring/50",
+          className,
+        )}
+        style={{ borderRadius: 18, ...style }}
+        data-setup-action=""
+        data-setup-action-kind={asLabel ? "label" : "button"}
+      />
+    );
+  }
+
+  const { asLabel, className, style, ...buttonProps } = props;
+  return (
+    <Button
+      {...buttonProps}
+      size="dialog"
+      className={cn(SETUP_ACTION_CLASS, className)}
+      style={{ borderRadius: 18, ...style }}
+      data-setup-action=""
+      data-setup-action-kind={asLabel ? "label" : "button"}
+    />
+  );
+}

--- a/src/components/ui/live-activity.tsx
+++ b/src/components/ui/live-activity.tsx
@@ -15,9 +15,11 @@ import { useLanguageDemo } from "@/language-demo";
 const SUCCESS_SWEEP_COLOR = roomVisualFor("power").accent;
 
 export type ActivityPhase = "running" | "queued" | "success" | "error";
+export type ActivityKind = "schedule" | "progression-adjustment";
 
 export interface Activity {
   id: number;
+  kind: ActivityKind;
   phase: ActivityPhase;
   error: DisplayError | null;
   queuePosition?: number | null;
@@ -40,6 +42,7 @@ export function usePlanActivity({
   queuePosition = null,
   etaSeconds = null,
   buffered = false,
+  kind = "schedule",
 }: {
   loading: boolean;
   error: DisplayError | null;
@@ -49,6 +52,7 @@ export function usePlanActivity({
   queuePosition?: number | null;
   etaSeconds?: number | null;
   buffered?: boolean;
+  kind?: ActivityKind;
 }) {
   const [activity, setActivity] = useState<Activity | null>(null);
   const wasLoading = useRef(false);
@@ -59,6 +63,7 @@ export function usePlanActivity({
       sequence.current += 1;
       setActivity({
         id: sequence.current,
+        kind,
         phase: queued ? "queued" : "running",
         error: null,
         queuePosition,
@@ -75,13 +80,13 @@ export function usePlanActivity({
     } else if (!loading && wasLoading.current) {
       const id = sequence.current;
       setActivity(error
-        ? { id, phase: "error", error }
+        ? { id, kind, phase: "error", error }
         : completed
-          ? { id, phase: "success", error: null, queuePosition: null, etaSeconds: null }
+          ? { id, kind, phase: "success", error: null, queuePosition: null, etaSeconds: null }
           : null);
     }
     wasLoading.current = loading;
-  }, [buffered, completed, error, etaSeconds, loading, queued, queuePosition]);
+  }, [buffered, completed, error, etaSeconds, kind, loading, queued, queuePosition]);
 
   return activity;
 }
@@ -116,12 +121,17 @@ export function LiveActivity({ activity, onRetry, onCopyDiagnostic, retryCountdo
   }, [activity]);
 
   const diagnostic = activity?.error ? solverDiagnosticFor(activity.error, en) : null;
+  const progressionAdjustment = activity?.kind === "progression-adjustment";
   const label = activity?.phase === "running"
-    ? (en ? "Generating schedule" : "正在生成排班")
+    ? progressionAdjustment
+      ? (en ? "Adjusting progression" : "正在调整练度")
+      : (en ? "Generating schedule" : "正在生成排班")
     : activity?.phase === "queued"
       ? (en ? "Queued" : "正在排队")
     : activity?.phase === "success"
-      ? (en ? "Schedule generated" : "排班已生成")
+      ? progressionAdjustment
+        ? (en ? "Progression adjustment complete" : "调整练度已完成")
+        : (en ? "Schedule generated" : "排班已生成")
       : diagnostic?.title ?? activity?.error?.message ?? (en ? "Schedule generation failed" : "排班生成失败");
   const hidden = Boolean(
     activity && dismissed && dismissed.id === activity.id && dismissed.phase === activity.phase,
@@ -133,6 +143,7 @@ export function LiveActivity({ activity, onRetry, onCopyDiagnostic, retryCountdo
         <motion.aside
           key={activity.id}
           data-slot="live-activity"
+          data-activity-kind={activity.kind}
           data-activity-phase={activity.phase}
           data-activity-view="expanded"
           className={cn(
@@ -195,7 +206,9 @@ export function LiveActivity({ activity, onRetry, onCopyDiagnostic, retryCountdo
                   </span>
                 ) : activity.phase === "running" ? (
                   <span className="text-sm text-[#313131]/70">
-                    {en ? "Calling the scheduling service. Please wait." : "正在调用排班服务，请稍候。"}
+                    {progressionAdjustment
+                      ? (en ? "Re-solving with the adjusted operator roster. Please wait." : "正在使用调整后的干员练度重新求解，请稍候。")
+                      : (en ? "Calling the scheduling service. Please wait." : "正在调用排班服务，请稍候。")}
                     {activity.queuePosition != null ? (
                       <>
                         {en ? " Queue position: " : " 当前排队第 "}<strong className="font-semibold">{activity.queuePosition}</strong>{en ? ". Estimated wait: " : " 位，预计 "}<strong className="font-semibold">{formatDuration(activity.etaSeconds, en)}</strong>
@@ -204,7 +217,11 @@ export function LiveActivity({ activity, onRetry, onCopyDiagnostic, retryCountdo
                   </span>
                 ) : (
                   <span className={cn("text-xs", activity.phase === "error" ? "text-red-800/70" : "text-[#313131]/58")}>
-                    {activity.phase === "success" ? (en ? "The three-shift result is ready to view or export." : "三班结果已更新，可以查看或导出。") : `${activity.error?.code ?? "AIC-PLAN"}${activity.error?.requestId ? ` · ${activity.error.requestId}` : ""}`}
+                    {activity.phase === "success"
+                      ? progressionAdjustment
+                        ? (en ? "The adjusted schedule is ready for comparison." : "调整后的排班已生成，可以切换对比。")
+                        : (en ? "The three-shift result is ready to view or export." : "三班结果已更新，可以查看或导出。")
+                      : `${activity.error?.code ?? "AIC-PLAN"}${activity.error?.requestId ? ` · ${activity.error.requestId}` : ""}`}
                   </span>
                 )}
               </span>

--- a/src/server/skland/normalize.test.ts
+++ b/src/server/skland/normalize.test.ts
@@ -350,7 +350,7 @@ test("normalizes the complete public Skland dashboard without leaking raw respon
   }
 });
 
-test("maps Skland manufacture entries 3 and 4 to their in-game room numbers", () => {
+test("maps Skland manufacture entries to displayed rooms as 3, 1, 4, 2", () => {
   const info = playerInfo();
   const template = info.building.manufactures[0]!;
   info.building.manufactures = ["slot_14", "slot_5", "slot_6", "slot_7"].map((slotId) => ({
@@ -364,10 +364,10 @@ test("maps Skland manufacture entries 3 and 4 to their in-game room numbers", ()
   assert.deepEqual(
     manufactureRooms.map((room) => ({ key: room.key, index: room.index })),
     [
-      { key: "slot_14", index: 0 },
-      { key: "slot_5", index: 1 },
+      { key: "slot_6", index: 0 },
+      { key: "slot_14", index: 1 },
       { key: "slot_7", index: 2 },
-      { key: "slot_6", index: 3 },
+      { key: "slot_5", index: 3 },
     ]
   );
 });

--- a/src/server/skland/normalize.ts
+++ b/src/server/skland/normalize.ts
@@ -41,10 +41,11 @@ const CLUE_NAMES: Record<string, string> = {
 
 type FactoryProduct = SklandManufactureRoom["product"];
 
-// Skland's manufacture array reports rooms 3 and 4 opposite to the numbering shown in-game.
+// Match the in-game manufacture labels after swapping 4↔2, then 1↔2.
+// The first four upstream entries therefore map to displayed rooms as 3, 1, 4, 2.
 export function manufacturesInGameOrder<T>(rooms: readonly T[]): T[] {
   if (rooms.length < 4) return [...rooms];
-  return [rooms[0]!, rooms[1]!, rooms[3]!, rooms[2]!, ...rooms.slice(4)];
+  return [rooms[2]!, rooms[0]!, rooms[3]!, rooms[1]!, ...rooms.slice(4)];
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import { RotationSettings } from "@/components/RotationSettings";
 import { FiammettaSettings } from "@/components/FiammettaSettings";
 import { WizardSteps } from "@/components/interior/wizard-steps";
@@ -271,7 +272,7 @@ export function SetupDialog({
       }
       onOpenChange(nextOpen);
     }}>
-      <DialogContent data-setup-dialog className="h-[min(660px,calc(100dvh-1rem))] max-w-[calc(100%-1rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden rounded-[24px] p-0 sm:max-w-[min(880px,calc(100%-2rem))] sm:rounded-[32px]">
+      <DialogContent data-setup-dialog className="h-[min(720px,calc(100dvh-1rem))] max-w-[calc(100%-1rem)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden rounded-[24px] p-0 sm:max-w-[min(960px,calc(100%-2rem))] sm:rounded-[32px]">
         <Tabs
           value={step === "facilities" ? "layout" : step}
           onValueChange={(value) => {
@@ -330,16 +331,15 @@ export function SetupDialog({
                         </p>
                       </div>
                     </div>
-                    <Button
+                    <SetupActionButton
                       type="button"
-                      variant="ghost"
-                      className="h-10 shrink-0"
+                      className="shrink-0"
                       aria-expanded={showImportOptions}
                       aria-controls="setup-import-options"
                       onClick={() => setShowImportOptions((current) => !current)}
                     >
                       {showImportOptions ? (en ? "Collapse" : "收起") : (en ? "Change" : "更换")}
-                    </Button>
+                    </SetupActionButton>
                   </section>
                 ) : null}
 
@@ -436,9 +436,9 @@ export function SetupDialog({
                               aria-invalid={Boolean(inputError)}
                               aria-describedby={inputError ? "setup-box-error" : undefined}
                             />
-                            <Button type="button" variant="outline" className="h-10 w-full" disabled={!maaPaste.trim()} onClick={() => void importMaaPaste()}>
+                            <SetupActionButton type="button" className="w-full" disabled={!maaPaste.trim()} onClick={() => void importMaaPaste()}>
                               {en ? "Import JSON" : "导入 JSON"}
-                            </Button>
+                            </SetupActionButton>
                           </div>
                         ) : null}
                       </TabsContent>
@@ -454,7 +454,15 @@ export function SetupDialog({
                           </Alert>
                         ) : (
                           <Suspense fallback={<div className="grid min-h-40 place-items-center border border-dashed border-border text-sm text-muted-foreground">{en ? "Loading operator roster" : "正在加载干员列表"}</div>}>
-                            <ManualOperboxPicker operbox={boxSource === "sample" ? null : operbox} onApply={applyManualBox} />
+                            <ManualOperboxPicker
+                              compact
+                              operbox={operbox}
+                              title={en ? "Build your operator BOX" : "手动选择干员 Box"}
+                              description={en
+                                ? "Ownership and elite stages are shared with Adjust progression."
+                                : "持有与精英阶段会同步用于排班和调整练度。"}
+                              onApply={applyManualBox}
+                            />
                           </Suspense>
                         )}
                       </TabsContent>
@@ -475,9 +483,9 @@ export function SetupDialog({
                   <summary className="min-h-11 cursor-pointer py-3 text-sm font-medium">{en ? "Data management" : "数据管理"}</summary>
                   <div className="flex flex-wrap items-center justify-between gap-3 py-3">
                     <span className="text-xs text-muted-foreground">{en ? <>Data is stored in this browser for <span className="font-number">30</span> days.</> : <>数据在此浏览器保存 <span className="font-number">30</span> 天。</>}</span>
-                    <Button type="button" variant="outline" className="min-h-11" onClick={() => setClearConfirmOpen(true)}>
+                    <SetupActionButton type="button" variant="destructive" onClick={() => setClearConfirmOpen(true)}>
                       <Trash2 />{en ? "Clear local data" : "清除本地数据"}
-                    </Button>
+                    </SetupActionButton>
                   </div>
                 </details>
               </motion.div>
@@ -524,7 +532,10 @@ export function SetupDialog({
                     <details className="setup-quiet-details pt-1">
                       <summary className="min-h-11 cursor-pointer py-3 text-sm font-medium">{en ? "Advanced tools" : "高级工具"}</summary>
                       <div className="grid gap-2 py-3 sm:grid-cols-2">
-                        <Label pressable className="flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-[4px] border border-dashed text-sm font-medium text-muted-foreground transition-[color,border-color,background-color] duration-[var(--motion-duration-state)] ease-[var(--motion-ease-out)] hover:border-primary hover:bg-muted/40 hover:text-primary">
+                        <SetupActionButton
+                          asLabel
+                          className="w-full cursor-pointer"
+                        >
                           <Upload className="size-4" />{en ? "Import layout" : "导入布局"}
                           <input
                             className="sr-only"
@@ -536,10 +547,10 @@ export function SetupDialog({
                               event.currentTarget.value = "";
                             }}
                           />
-                        </Label>
-                        <Button type="button" variant="outline" className="min-h-11 w-full" onClick={onDownloadLayout}>
+                        </SetupActionButton>
+                        <SetupActionButton type="button" className="w-full" onClick={onDownloadLayout}>
                           <FileJson />{en ? "Export layout" : "导出布局"}
-                        </Button>
+                        </SetupActionButton>
                         {resultClearWarningDismissed ? (
                           <Button type="button" variant="ghost" className="min-h-11 w-fit" onClick={onRestoreResultClearWarning}>
                             {en ? "Restore change warning" : "恢复切换提示"}


### PR DESCRIPTION
## 变更内容

- 紧凑化同布局调整练度弹窗，区分前三班并内置滚动区域
- 调整练度与排班设置手动 BOX 共用数据；求解时显示 Live Activity，成功后自动关窗
- 复用排班布局 Tabs 展示当前方案与调整练度方案，并保留产出数字切换动画
- 统一排班设置操作按钮，放大设置弹窗，优化桌面与移动端布局
- 调整森空岛制造站显示顺序为 3、1、4、2

## 验证

- npx eslint . --ignore-pattern .gstack/**
- npx tsc --noEmit
- npm test：357 + 2 项通过
- npm run test:api-contract：66 项通过
- npm run test:shift-comparison：13 项通过
- npm run test:e2e -- e2e/production-readiness-interface.spec.ts --workers=1：15 项通过
- npm run build

## 关联

在 #111、#114、#132 已合并的 develop 基础上完成后续交互与 UI 调整。