### PR TITLE
fix: 修复调整练度未进入生产排班队列

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -167,7 +167,7 @@ test("setup with an empty BOX starts on operator data", async ({ page }) => {
 });
 
 test("progression adjustments sync back to the schedule settings manual BOX", async ({ page }) => {
-  await mockApis(page);
+  await mockApis(page, { taskQueueEnabled: true });
   const adjustedPlanData = {
     ...planData,
     rotation: {
@@ -186,12 +186,33 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   const adjustmentGate = new Promise<void>((resolve) => {
     releaseAdjustment = resolve;
   });
+  const taskId = "11111111-1111-4111-8111-111111111113";
+  let directPlanRequests = 0;
+  let taskSubmissions = 0;
+  let taskPolls = 0;
   await page.route("**/api/plan", async (route) => {
-    await adjustmentGate;
+    directPlanRequests += 1;
     await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ success: false, error: { code: "AIC-PLAN-3001", message: "排班服务暂不可用，请稍后重试。", retryable: true }, requestId }),
+    });
+  });
+  await page.route(/\/api\/tasks(?:\/[^/?]+)?$/, async (route) => {
+    if (route.request().method() === "POST") {
+      taskSubmissions += 1;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, data: { taskId, status: "pending", queuePosition: 1, etaSeconds: 3 }, requestId }),
+      });
+    }
+    taskPolls += 1;
+    await adjustmentGate;
+    return route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({ success: true, data: adjustedPlanData, requestId }),
+      body: JSON.stringify({ success: true, data: { taskId, status: "done", result: adjustedPlanData }, requestId }),
     });
   });
   await seedV4Session(page, planData, { boxSource: "maa" });
@@ -213,9 +234,12 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   await adjustmentStage.getByRole("radio", { name: "精1", exact: true }).click();
   await adjustmentDialog.getByRole("button", { name: "按调整重新试算", exact: true }).click();
   const activity = page.locator('[data-slot="live-activity"]');
-  await expect(activity).toHaveAttribute("data-activity-phase", "running");
+  await expect(activity).toHaveAttribute("data-activity-phase", "queued");
   await expect(activity).toBeVisible();
-  await expect(activity).toContainText("正在调整练度");
+  await expect(activity).toContainText("正在排队");
+  await expect(adjustmentDialog).toBeVisible();
+  await expect(adjustmentDialog.getByRole("button", { name: "正在重新求解…", exact: true })).toBeDisabled();
+  await expect.poll(() => ({ directPlanRequests, taskSubmissions, taskPolls })).toEqual({ directPlanRequests: 0, taskSubmissions: 1, taskPolls: 1 });
   releaseAdjustment();
   await expect(activity).toHaveAttribute("data-activity-phase", "success");
   await expect(activity).toContainText("调整练度已完成");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -309,10 +309,16 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const [upgradeComparison, setUpgradeComparison] = useState<{ baseline: PublicPlanData; trial: PublicPlanData } | null>(null);
   const [scheduleVariant, setScheduleVariant] = useState<"baseline" | "trial">("baseline");
   const [loading, setLoading] = useState(false);
-  const [progressionAdjustmentActivity, setProgressionAdjustmentActivity] = useState({
+  const [progressionAdjustmentActivity, setProgressionAdjustmentActivity] = useState<{
+    active: boolean;
+    loading: boolean;
+    completed: boolean;
+    error: DisplayError | null;
+  }>({
     active: false,
     loading: false,
     completed: false,
+    error: null,
   });
   const [cliReady, setCliReady] = useState(false);
   const [taskQueueEnabled, setTaskQueueEnabled] = useState(false);
@@ -378,6 +384,12 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       setLoading(false);
       setApiError(displayError("AIC-PLAN-3004", message));
     },
+  });
+  const progressionAdjustmentTask = usePlanTask({
+    // 调整练度依赖尚未同步的本地 BOX，刷新后缺少上下文，不能冒充普通排班恢复。
+    storageKey: null,
+    onDone: () => undefined,
+    onFailed: () => undefined,
   });
 
   useEffect(() => {
@@ -999,7 +1011,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       boxSource,
     },
   ): Promise<boolean> {
-    setProgressionAdjustmentActivity({ active: false, loading: false, completed: false });
+    setProgressionAdjustmentActivity({ active: false, loading: false, completed: false, error: null });
     if (!planInput.operbox) return false;
     if (planRetryCountdown > 0) return false;
     planClickAtRef.current = performance.now();
@@ -1061,10 +1073,10 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     if (!operbox) throw new Error(locale === "en" ? "Import operator data first." : "请先导入干员数据。");
     if (!trialOperbox.some((entry) => entry.own)) throw new Error(locale === "en" ? "Select at least one operator for the simulation." : "请至少选择一名干员进行试算。");
     const normalizedTrialOperbox = normalizeOperboxEntries(trialOperbox);
-    setProgressionAdjustmentActivity({ active: true, loading: true, completed: false });
+    setProgressionAdjustmentActivity({ active: true, loading: true, completed: false, error: null });
     trackTelemetry({ type: "interaction", name: "upgrade_simulation_submit", page: "calculator" });
     try {
-      const response = await computePlan({
+      const payload = {
         layout,
         operbox: normalizedTrialOperbox,
         sourceName: locale === "en" ? "Progression adjustment Box.json" : "调整练度 Box.json",
@@ -1072,16 +1084,26 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         boxSource: upgradeSimulationBoxSource(boxSource),
         rotation: rotationProfile,
         fiammetta_enable: effectiveFiammettaSetting(trialOperbox, rotationProfile, fiammettaEnabled),
-      });
+      };
+      const response = taskQueueEnabled
+        ? await progressionAdjustmentTask.run(await submitPlanTask(payload))
+        : await computePlan(payload);
       // 求解成功后再同步，避免失败的试算覆盖用户当前 BOX。
       setOperbox(normalizedTrialOperbox);
       setFileName(locale === "en" ? "Progression-adjusted Box" : "调整练度后的 Box");
       setInputMode("manual");
-      setProgressionAdjustmentActivity({ active: true, loading: false, completed: true });
+      setProgressionAdjustmentActivity({ active: true, loading: false, completed: true, error: null });
       trackTelemetry({ type: "interaction", name: "upgrade_simulation_response", page: "calculator" });
       return response;
     } catch (error) {
-      setProgressionAdjustmentActivity({ active: true, loading: false, completed: false });
+      const normalized = toDisplayError(error, locale === "en" ? "Progression adjustment failed. Please try again later." : "调整练度试算失败，请稍后重试。");
+      setProgressionAdjustmentActivity({
+        active: true,
+        loading: false,
+        completed: false,
+        // 弹窗保留原始错误并允许重新提交；Live Activity 不触发普通排班的重试入口。
+        error: { ...normalized, retryable: false },
+      });
       throw error;
     }
   }
@@ -1623,6 +1645,11 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
 
   async function handleRetry() {
     if (planRetryCountdown > 0) return;
+    if (progressionAdjustmentActivity.active && progressionAdjustmentTask.pollStopped) {
+      setProgressionAdjustmentActivity((current) => ({ ...current, loading: true, error: null }));
+      progressionAdjustmentTask.resume();
+      return;
+    }
     if (apiError?.code === "AIC-PLAN-3001") {
       await runPlanForLayout(layout, true);
       return;
@@ -1648,21 +1675,33 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const statusError = inputError && !setupOpen
     ? displayError(inputErrorCode, inputError)
     : apiError ?? storageNotice;
+  const progressionAdjustmentPollError = progressionAdjustmentActivity.active
+    && progressionAdjustmentTask.pollStopped
+    && progressionAdjustmentTask.error
+    ? displayError("AIC-PLAN-3004", progressionAdjustmentTask.error, true)
+    : null;
   const activity = usePlanActivity({
-    loading: progressionAdjustmentActivity.active ? progressionAdjustmentActivity.loading : loading,
-    error: progressionAdjustmentActivity.active ? null : statusError,
+    loading: progressionAdjustmentActivity.active
+      ? progressionAdjustmentActivity.loading && !progressionAdjustmentTask.pollStopped
+      : loading,
+    error: progressionAdjustmentActivity.active
+      ? progressionAdjustmentPollError ?? progressionAdjustmentActivity.error
+      : statusError,
     completed: progressionAdjustmentActivity.active ? progressionAdjustmentActivity.completed : planTask.status === "done",
     kind: progressionAdjustmentActivity.active ? "progression-adjustment" : "schedule",
-    queued: loading && (
-      !progressionAdjustmentActivity.active && (
+    queued: progressionAdjustmentActivity.active
+      ? progressionAdjustmentActivity.loading && (
+          progressionAdjustmentTask.status === "buffered"
+          || progressionAdjustmentTask.status === "pending"
+        )
+      : loading && (
         planTask.status === "buffered"
         || planTask.status === "pending"
         || planTask.pollStopped
-      )
-    ),
-    queuePosition: planTask.queuePosition,
-    etaSeconds: planTask.etaSeconds,
-    buffered: planTask.status === "buffered",
+      ),
+    queuePosition: progressionAdjustmentActivity.active ? progressionAdjustmentTask.queuePosition : planTask.queuePosition,
+    etaSeconds: progressionAdjustmentActivity.active ? progressionAdjustmentTask.etaSeconds : planTask.etaSeconds,
+    buffered: progressionAdjustmentActivity.active ? progressionAdjustmentTask.status === "buffered" : planTask.status === "buffered",
   });
   useEffect(() => {
     if (page !== "calculator" || !result?.maa) return;

--- a/src/hooks/use-plan-task.test.ts
+++ b/src/hooks/use-plan-task.test.ts
@@ -72,11 +72,13 @@ test("usePlanTask owns polling timers and resumable storage across terminal and 
   const { usePlanTask } = await import("./use-plan-task.ts");
   const doneResults: unknown[] = [];
   const failureMessages: string[] = [];
+  let hookStorageKey: string | null | undefined = undefined;
   let hook: ReturnType<typeof usePlanTask> | null = null;
   function Harness() {
     hook = usePlanTask({
       onDone: (result) => doneResults.push(result),
       onFailed: (message) => failureMessages.push(message),
+      ...(hookStorageKey === null ? { storageKey: null } : {}),
     });
     return null;
   }
@@ -113,6 +115,14 @@ test("usePlanTask owns polling timers and resumable storage across terminal and 
   assert.equal(timeouts.size, 0);
   assert.equal(storage.has("aic-plan-task-v1"), false);
   assert.deepEqual(doneResults, [result]);
+
+  pollOutcomes.push({ taskId: "task-awaited", status: "done", result });
+  let awaitedResult: unknown;
+  await act(async () => {
+    awaitedResult = await current().run({ taskId: "task-awaited", status: "pending", queuePosition: 1 });
+  });
+  assert.equal((awaitedResult as typeof result).diagnosticId, result.diagnosticId);
+  assert.deepEqual(doneResults, [result, result]);
 
   await begin("task-failed", [{ taskId: "task-failed", status: "failed", error: "solver failed" }]);
   assert.equal(storage.has("aic-plan-task-v1"), false);
@@ -156,5 +166,15 @@ test("usePlanTask owns polling timers and resumable storage across terminal and 
   await act(async () => { renderer.unmount(); });
   assert.equal(timeouts.size, 0);
   assert.equal(intervals.size, 0);
+
+  storage.clear();
+  hookStorageKey = null;
+  hook = null;
+  await act(async () => { renderer = create(React.createElement(Harness)); });
+  await begin("task-nonpersistent", [{ taskId: "task-nonpersistent", status: "pending", queuePosition: 2 }]);
+  assert.equal(storage.size, 0);
+  assert.equal(timeouts.size, 1);
+  await act(async () => { renderer.unmount(); });
+  assert.equal(timeouts.size, 0);
   delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
 });

--- a/src/hooks/use-plan-task.ts
+++ b/src/hooks/use-plan-task.ts
@@ -31,11 +31,14 @@ export type PlanTaskUiState = {
 type PlanTaskOptions = {
   onDone: (result: PublicPlanData) => void;
   onFailed: (message: string) => void;
+  /** Disable persistence for secondary task flows that cannot be restored without their local context. */
+  storageKey?: string | null;
 };
 
-function readStoredTaskId(): string | null {
+function readStoredTaskId(storageKey: string | null): string | null {
+  if (!storageKey) return null;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(storageKey);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as { taskId?: unknown };
     return typeof parsed.taskId === "string" && parsed.taskId ? parsed.taskId : null;
@@ -44,23 +47,26 @@ function readStoredTaskId(): string | null {
   }
 }
 
-function writeStoredTaskId(taskId: string) {
+function writeStoredTaskId(storageKey: string | null, taskId: string) {
+  if (!storageKey) return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ taskId, savedAt: Date.now() }));
+    localStorage.setItem(storageKey, JSON.stringify({ taskId, savedAt: Date.now() }));
   } catch {
     // localStorage 不可用时降级为纯内存轮询。
   }
 }
 
-function clearStoredTaskId() {
+function clearStoredTaskId(storageKey: string | null) {
+  if (!storageKey) return;
   try {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(storageKey);
   } catch {
     // ignore
   }
 }
 
-export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
+export function usePlanTask({ onDone, onFailed, storageKey }: PlanTaskOptions) {
+  const taskStorageKey = storageKey === undefined ? STORAGE_KEY : storageKey;
   const [state, setState] = useState<PlanTaskUiState>({
     taskId: null,
     status: null,
@@ -78,6 +84,10 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
   const cooldownRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const onDoneRef = useRef(onDone);
   const onFailedRef = useRef(onFailed);
+  const waiterRef = useRef<{
+    resolve: (result: PublicPlanData) => void;
+    reject: (reason: Error) => void;
+  } | null>(null);
   const restoredRef = useRef(false);
 
   useEffect(() => {
@@ -120,10 +130,22 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
     }, 1_000);
   }, []);
 
+  const resolveWaiter = useCallback((result: PublicPlanData) => {
+    const waiter = waiterRef.current;
+    waiterRef.current = null;
+    waiter?.resolve(result);
+  }, []);
+
+  const rejectWaiter = useCallback((message: string) => {
+    const waiter = waiterRef.current;
+    waiterRef.current = null;
+    waiter?.reject(new Error(message));
+  }, []);
+
   const finish = useCallback((next: Partial<PlanTaskUiState> & { status: PlanTaskStatus }) => {
     clearTimer();
     stopResumeCooldown();
-    clearStoredTaskId();
+    clearStoredTaskId(taskStorageKey);
     taskIdRef.current = null;
     setState((current) => ({
       ...current,
@@ -135,7 +157,7 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
       error: null,
       ...next,
     }));
-  }, [clearTimer, stopResumeCooldown]);
+  }, [clearTimer, stopResumeCooldown, taskStorageKey]);
 
   const pollOnceRef = useRef<(taskId: string, attempt: number) => Promise<void>>(async () => undefined);
   const schedulePoll = useCallback((taskId: string, attempt: number, delayMs: number) => {
@@ -148,12 +170,21 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
       isCurrent: (candidate) => taskIdRef.current === candidate,
       errorCode: (error) => error instanceof ApiClientError ? error.code : null,
       finishDone: (result) => {
+        if (!result) {
+          const message = "排班任务已完成，但没有返回可用结果。";
+          finish({ status: "failed", error: message });
+          onFailedRef.current(message);
+          rejectWaiter(message);
+          return;
+        }
         finish({ status: "done", result, error: null });
-        if (result) onDoneRef.current(result);
+        onDoneRef.current(result);
+        resolveWaiter(result);
       },
       finishTerminal: (status, message, notifyFailure) => {
         finish({ status, error: message });
         if (notifyFailure) onFailedRef.current(message);
+        rejectWaiter(message);
       },
       continueActive: (decision) => setState((current) => ({
         ...current,
@@ -172,7 +203,7 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
         startResumeCooldown();
       },
     });
-  }, [clearTimer, finish, schedulePoll, startResumeCooldown]);
+  }, [clearTimer, finish, rejectWaiter, resolveWaiter, schedulePoll, startResumeCooldown]);
   useEffect(() => {
     pollOnceRef.current = pollOnce;
   }, [pollOnce]);
@@ -185,7 +216,7 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
     clearTimer();
     stopResumeCooldown();
     taskIdRef.current = taskId;
-    writeStoredTaskId(taskId);
+    writeStoredTaskId(taskStorageKey, taskId);
     setState({
       taskId,
       status: initial.status,
@@ -196,12 +227,26 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
       error: null,
     });
     void pollOnce(taskId, 0);
-  }, [clearTimer, pollOnce, stopResumeCooldown]);
+  }, [clearTimer, pollOnce, stopResumeCooldown, taskStorageKey]);
 
   const complete = useCallback((result: PublicPlanData) => {
     finish({ status: "done", result, error: null });
     onDoneRef.current(result);
   }, [finish]);
+
+  const run = useCallback((submitted: PlanTaskSubmitData): Promise<PublicPlanData> => {
+    if (submitted.status === "done") {
+      complete(submitted.result);
+      return Promise.resolve(submitted.result);
+    }
+    if (waiterRef.current || taskIdRef.current) {
+      return Promise.reject(new Error("已有排班任务正在查询，请等待完成后再试。"));
+    }
+    return new Promise<PublicPlanData>((resolve, reject) => {
+      waiterRef.current = { resolve, reject };
+      begin(submitted);
+    });
+  }, [begin, complete]);
 
   const resume = useCallback(() => {
     const taskId = taskIdRef.current;
@@ -223,6 +268,7 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
       const decision = planTaskCancellationDecision(response);
       if (decision.clearTask) {
         finish({ status: "cancelled", error: null });
+        rejectWaiter("任务已取消。");
         return true;
       }
       setState((current) => ({
@@ -240,16 +286,16 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
     }
     void pollOnceRef.current(taskId, 0);
     return false;
-  }, [clearTimer, finish, stopResumeCooldown]);
+  }, [clearTimer, finish, rejectWaiter, stopResumeCooldown]);
 
   // 只在真正挂载（刷新/重新打开）时从 localStorage 恢复轮询；
   // 切换侧边栏子页面不触发恢复。
   useEffect(() => {
     if (restoredRef.current) return;
     restoredRef.current = true;
-    const stored = readStoredTaskId();
+    const stored = readStoredTaskId(taskStorageKey);
     if (stored) begin(stored);
-  }, [begin]);
+  }, [begin, taskStorageKey]);
 
   // 卸载清理。
   useEffect(() => () => {
@@ -262,6 +308,7 @@ export function usePlanTask({ onDone, onFailed }: PlanTaskOptions) {
     resumeDisabled,
     resumeCountdown,
     begin,
+    run,
     complete,
     resume,
     cancel,

--- a/src/plan-task-cancellation.test.ts
+++ b/src/plan-task-cancellation.test.ts
@@ -29,7 +29,8 @@ test("running and unavailable cancellation responses preserve polling", () => {
 
 test("buffered and pending tasks stay visibly queued during continuous polling", async () => {
   const source = await readFile(new URL("./App.tsx", import.meta.url), "utf8");
-  assert.match(source, /queued: loading && \([\s\S]*status === "buffered"[\s\S]*status === "pending"[\s\S]*pollStopped/);
+  assert.match(source, /queued: progressionAdjustmentActivity\.active[\s\S]*progressionAdjustmentTask\.status === "buffered"[\s\S]*progressionAdjustmentTask\.status === "pending"/);
+  assert.match(source, /: loading && \([\s\S]*planTask\.status === "buffered"[\s\S]*planTask\.status === "pending"[\s\S]*planTask\.pollStopped/);
 });
 
 test("plan task polling backs off only for failures and polls active states responsively", async () => {


### PR DESCRIPTION
## 修复内容
- 调整练度在生产任务队列开启时改用 `/api/tasks` 提交并轮询，不再调用会被拒绝的同步 `/api/plan`
- 使用独立队列状态，排队/求解期间保持弹窗与 Live Activity，完成后才同步 Box、关闭弹窗并切换对比方案
- 轮询中断时允许从 Live Activity 恢复查询，且不污染普通排班的可恢复任务

## 回归保护
- E2E 强制启用生产队列，并让 `/api/plan` 返回 503；断言调整练度只调用 `/api/tasks`
- 覆盖任务 Promise 完成、独立非持久化状态及普通/调整练度排队展示

## 本地验证
- `npx tsc --noEmit`
- `npm run check`（357 + 2 单元测试、66 API 契约、13 排班比较）
- `npm run build`
- 调整练度生产队列 E2E：通过
- UI E2E 文件：关键修复用例通过；其余 14 项通过，1 项冷路由首次超时后隔离重跑通过