### PR TITLE
ci: 自动发布受管资源更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,11 @@ on:
         description: Immutable release artifact produced by the post-merge build job
         required: true
         type: string
+      allow_workflow_dispatch:
+        description: Allow an explicitly requested post-merge workflow dispatch to deploy
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -14,7 +19,8 @@ permissions:
 jobs:
   deploy:
     if: >-
-      github.event_name == 'push' &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.allow_workflow_dispatch)) &&
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
       github.repository == 'KnightCodeSquareMatrix/RIIC-Web'

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -8,6 +8,16 @@ on:
         required: false
         default: true
         type: boolean
+      deploy:
+        description: Deploy the verified main or develop ref after all required checks pass
+        required: false
+        default: false
+        type: boolean
+      expected_sha:
+        description: Exact ref commit required when deploy is requested by workflow dispatch
+        required: false
+        default: ""
+        type: string
   push:
     branches: [main, develop]
   schedule:
@@ -51,6 +61,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate requested deployment identity
+        if: github.event_name == 'workflow_dispatch' && inputs.deploy
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$GITHUB_SHA" = "$EXPECTED_SHA"
+          [[ "$GITHUB_REF_NAME" == "main" || "$GITHUB_REF_NAME" == "develop" ]]
 
       - name: Classify changed paths
         id: scope
@@ -324,7 +345,10 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release for deployment
-        if: github.event_name == 'push' && needs.changes.outputs.deploy_required == 'true'
+        if: >-
+          needs.changes.outputs.deploy_required == 'true' &&
+          (github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && inputs.deploy))
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: riic-web-release-${{ github.sha }}
@@ -524,8 +548,9 @@ jobs:
   deploy:
     needs: [changes, quality, release_artifact]
     if: >-
-      github.event_name == 'push' &&
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.deploy)) &&
       needs.quality.result == 'success' &&
       needs.release_artifact.result == 'success' &&
       needs.changes.outputs.deploy_required == 'true' &&
@@ -534,4 +559,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       artifact_name: riic-web-release-${{ github.sha }}
+      allow_workflow_dispatch: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
     secrets: inherit

--- a/.github/workflows/sync-arkntools-assets.yml
+++ b/.github/workflows/sync-arkntools-assets.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout frontend without credentials
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
           persist-credentials: false
 
@@ -160,20 +160,23 @@ jobs:
     needs: generate
     if: needs.generate.result == 'success' && needs.generate.outputs.changed == 'true' && github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
+    outputs:
+      merged_sha: ${{ steps.merge.outputs.merged_sha }}
     permissions:
       actions: write
       contents: write
+      issues: write
       pull-requests: write
     env:
-      BASE_BRANCH: develop
-      UPDATE_BRANCH: automation/arkntools-assets
+      BASE_BRANCH: main
+      UPDATE_BRANCH: release/automation/arkntools-assets
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout publication base
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          ref: develop
+          ref: main
           fetch-depth: 0
 
       - name: Download reviewed publication artifact
@@ -215,19 +218,25 @@ jobs:
           fi
 
       - name: Commit and push managed update branch
+        id: commit
         shell: bash
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH"
+          test "$(git rev-parse HEAD)" = "$(git rev-parse "refs/remotes/origin/$BASE_BRANCH")"
           git fetch origin "$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH" || true
           git switch -C "$UPDATE_BRANCH"
           git commit -m "chore: 同步 arkntools 干员资源"
           git push --force-with-lease origin "HEAD:$UPDATE_BRANCH"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Create or refresh pull request
+      - name: Create or refresh direct main pull request
         id: pull-request
         shell: bash
         run: |
+          set -euo pipefail
           body="$RUNNER_TEMP/arkntools-publication/pull-request-body.md"
           number="$(gh pr list --base "$BASE_BRANCH" --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
           if [[ -z "$number" ]]; then
@@ -235,16 +244,236 @@ jobs:
               --base "$BASE_BRANCH" \
               --head "$UPDATE_BRANCH" \
               --title "chore: 同步 arkntools 干员素材与基建技能" \
-              --body-file "$body"
+              --body-file "$body" \
+              --label "direct-main-release"
+            number="$(gh pr list --base "$BASE_BRANCH" --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
           else
             gh pr edit "$number" \
               --title "chore: 同步 arkntools 干员素材与基建技能" \
-              --body-file "$body"
+              --body-file "$body" \
+              --add-label "direct-main-release"
           fi
+          [[ "$number" =~ ^[1-9][0-9]*$ ]]
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and merge reviewed resource pull request
+        id: merge
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.commit.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -r '.state' <<< "$pr_json")" = "open"
+          test "$(jq -r '.draft' <<< "$pr_json")" = "false"
+          test "$(jq -r '.base.ref' <<< "$pr_json")" = "$BASE_BRANCH"
+          test "$(jq -r '.head.ref' <<< "$pr_json")" = "$UPDATE_BRANCH"
+          test "$(jq -r '.head.repo.full_name' <<< "$pr_json")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.head.sha' <<< "$pr_json")" = "$EXPECTED_HEAD_SHA"
+          test "$(jq '[.labels[].name | select(. == "direct-main-release")] | length' <<< "$pr_json")" = "1"
+
+          changed_count=0
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              public/images/operator-portraits/*|public/images/building-skills/*|public/images/products/*|src/generated/arkntools/*) ;;
+              *) echo "Resource pull request changed a forbidden path: $changed_path" >&2; exit 1 ;;
+            esac
+            changed_count=$((changed_count + 1))
+          done < <(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+          (( changed_count > 0 ))
+
+          pull_request_base_sha="$(jq -r '.base.sha' <<< "$pr_json")"
+          remote_base_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_BRANCH" --jq '.object.sha')"
+          test "$pull_request_base_sha" = "$remote_base_sha"
+
+          merge_json="$(gh api --method PUT "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/merge" \
+            -f merge_method=squash \
+            -f sha="$EXPECTED_HEAD_SHA" \
+            -f commit_title="chore: 同步 arkntools 干员资源" \
+            -f commit_message="Automated managed-resource release after isolated generation and validation.")"
+          test "$(jq -r '.merged' <<< "$merge_json")" = "true"
+          merged_sha="$(jq -r '.sha' <<< "$merge_json")"
+          [[ "$merged_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "merged_sha=$merged_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger verified main release
+        shell: bash
+        env:
+          MERGED_SHA: ${{ steps.merge.outputs.merged_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$MERGED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          remote_main_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_BRANCH" --jq '.object.sha')"
+          test "$remote_main_sha" = "$MERGED_SHA"
+          gh workflow run frontend-quality.yml \
+            --ref "$BASE_BRANCH" \
+            -f run_webkit=false \
+            -f deploy=true \
+            -f expected_sha="$MERGED_SHA"
+          {
+            echo "## arkntools 资源已自动合并"
+            echo
+            echo "- PR: #${{ steps.pull-request.outputs.number }}"
+            echo "- main: \`$MERGED_SHA\`"
+            echo "- 已触发完整 main 质量门禁和 production 部署；生产环境审批规则保持生效。"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report publication failure
         if: failure()
         shell: bash
         run: |
           echo "## arkntools 资源发布失败" >> "$GITHUB_STEP_SUMMARY"
-          echo "未创建或刷新自动资源 PR；develop 中最后一次已验证资源保持不变。" >> "$GITHUB_STEP_SUMMARY"
+          echo "自动 main 资源 PR 未完成合并或发布；production 保持上一个已验证 release。" >> "$GITHUB_STEP_SUMMARY"
+
+  develop_parity:
+    needs: publish
+    if: needs.publish.result == 'success' && github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    env:
+      BASE_BRANCH: develop
+      SOURCE_BRANCH: main
+      UPDATE_BRANCH: automation/arkntools-assets
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout development branch
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Copy the released managed resources into develop
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "$SOURCE_BRANCH:refs/remotes/origin/$SOURCE_BRANCH"
+          git fetch origin "$BASE_BRANCH:refs/remotes/origin/$BASE_BRANCH"
+          git fetch origin "$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH" || true
+          git switch -C "$UPDATE_BRANCH" "refs/remotes/origin/$BASE_BRANCH"
+          git restore --source "refs/remotes/origin/$SOURCE_BRANCH" --staged --worktree -- \
+            public/images/operator-portraits \
+            public/images/building-skills \
+            public/images/products \
+            src/generated/arkntools
+
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "develop already contains the released arkntools resources." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          changed_count=0
+          while IFS= read -r -d '' changed_path; do
+            case "$changed_path" in
+              public/images/operator-portraits/*|public/images/building-skills/*|public/images/products/*|src/generated/arkntools/*) ;;
+              *) echo "Resource pull request changed a forbidden path: $changed_path" >&2; exit 1 ;;
+            esac
+            changed_count=$((changed_count + 1))
+          done < <(git diff --cached --name-only -z)
+          (( changed_count > 0 ))
+          if git ls-files -s -- public/images/operator-portraits public/images/building-skills public/images/products src/generated/arkntools \
+            | awk '$1 != "100644" { found = 1 } END { exit found ? 0 : 1 }'; then
+            echo "Managed asset paths must contain only regular non-executable files." >&2
+            exit 1
+          fi
+
+          git commit -m "chore: 同步 main 的 arkntools 干员资源"
+          git push --force-with-lease origin "HEAD:$UPDATE_BRANCH"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create or refresh develop parity pull request
+        if: steps.changes.outputs.changed == 'true'
+        id: pull-request
+        shell: bash
+        run: |
+          set -euo pipefail
+          number="$(gh pr list --base "$BASE_BRANCH" --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
+          if [[ -z "$number" ]]; then
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$UPDATE_BRANCH" \
+              --title "chore: 同步 main 的 arkntools 干员资源" \
+              --body "自动保持 develop 与已发布 main 的受管 arkntools 资源一致。"
+            number="$(gh pr list --base "$BASE_BRANCH" --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // empty')"
+          else
+            gh pr edit "$number" \
+              --title "chore: 同步 main 的 arkntools 干员资源" \
+              --body "自动保持 develop 与已发布 main 的受管 arkntools 资源一致。"
+          fi
+          [[ "$number" =~ ^[1-9][0-9]*$ ]]
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Validate and merge develop parity pull request
+        if: steps.changes.outputs.changed == 'true'
+        id: merge
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ steps.changes.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          test "$(jq -r '.state' <<< "$pr_json")" = "open"
+          test "$(jq -r '.draft' <<< "$pr_json")" = "false"
+          test "$(jq -r '.base.ref' <<< "$pr_json")" = "$BASE_BRANCH"
+          test "$(jq -r '.head.ref' <<< "$pr_json")" = "$UPDATE_BRANCH"
+          test "$(jq -r '.head.repo.full_name' <<< "$pr_json")" = "$GITHUB_REPOSITORY"
+          test "$(jq -r '.head.sha' <<< "$pr_json")" = "$EXPECTED_HEAD_SHA"
+
+          changed_count=0
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              public/images/operator-portraits/*|public/images/building-skills/*|public/images/products/*|src/generated/arkntools/*) ;;
+              *) echo "Resource pull request changed a forbidden path: $changed_path" >&2; exit 1 ;;
+            esac
+            changed_count=$((changed_count + 1))
+          done < <(gh api --paginate "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files?per_page=100" --jq '.[].filename')
+          (( changed_count > 0 ))
+
+          pull_request_base_sha="$(jq -r '.base.sha' <<< "$pr_json")"
+          remote_base_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_BRANCH" --jq '.object.sha')"
+          test "$pull_request_base_sha" = "$remote_base_sha"
+          merge_json="$(gh api --method PUT "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/merge" \
+            -f merge_method=squash \
+            -f sha="$EXPECTED_HEAD_SHA" \
+            -f commit_title="chore: 同步 main 的 arkntools 干员资源" \
+            -f commit_message="Automated develop parity for the released managed resources.")"
+          test "$(jq -r '.merged' <<< "$merge_json")" = "true"
+          merged_sha="$(jq -r '.sha' <<< "$merge_json")"
+          [[ "$merged_sha" =~ ^[0-9a-f]{40}$ ]]
+          echo "merged_sha=$merged_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger verified development release
+        if: steps.changes.outputs.changed == 'true'
+        shell: bash
+        env:
+          MERGED_SHA: ${{ steps.merge.outputs.merged_sha }}
+        run: |
+          set -euo pipefail
+          remote_develop_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_BRANCH" --jq '.object.sha')"
+          test "$remote_develop_sha" = "$MERGED_SHA"
+          gh workflow run frontend-quality.yml \
+            --ref "$BASE_BRANCH" \
+            -f run_webkit=false \
+            -f deploy=true \
+            -f expected_sha="$MERGED_SHA"
+          echo "develop parity PR #${{ steps.pull-request.outputs.number }} merged at \`$MERGED_SHA\`." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report develop parity failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "## develop 资源对齐失败" >> "$GITHUB_STEP_SUMMARY"
+          echo "main 的已验证资源不受影响；请处理本次 workflow failure 后重新运行同步。" >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## 分支与 PR
 
 1. 从最新的 `develop` 创建功能分支。
-2. 将功能、修复、文档和资源同步 PR 的 base branch 设为 `develop`。
+2. 将功能、修复、文档和人工资源变更 PR 的 base branch 设为 `develop`。唯一例外是仓库内置的 arkntools 受管资源同步：它在隔离生成、路径白名单、完整检查和构建全部通过后，从固定的 `release/automation/arkntools-assets` 分支创建带 `direct-main-release` 标签的审计 PR，自动合并到 `main` 并触发完整发布流程，随后用独立 PR 对齐 `develop`。
 3. 不要向 `main` 直接提交普通 PR。`main` 只接受维护者从本仓库 `release/**` 分支发起的发布 PR；确需跳过 `develop` 的特批发布，必须由维护者添加 `direct-main-release` 标签。
 4. 普通 PR 不运行远程质量检查；PR 合并到 `develop` 或 `main` 后，目标分支才并行执行质量检查、生成一次发布产物，并在全部检查通过后部署。通过 development 验收的变更再经 release PR 晋级 `main`。
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ npm run db:generate
 npm run db:migrate
 ```
 
-所有普通功能和修复 PR 都应提交到 `develop`；`main` 只接收维护者从同仓库 `release/**` 分支发起的发布 PR。特批的直接发布还必须带有维护者设置的 `direct-main-release` 标签，并通过其余全部质量门禁。完整流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。不要把本地环境文件、求解器二进制、运行记录、用户数据或浏览器自动化产物加入提交。
+所有普通功能、修复和人工资源 PR 都应提交到 `develop`；`main` 只接收维护者从同仓库 `release/**` 分支发起的发布 PR。仓库内置的 arkntools 受管资源同步是严格白名单化的例外：隔离生成和本地质量门禁通过后，它会从固定 release 分支创建带 `direct-main-release` 标签的审计 PR，自动合并、触发完整 main 发布，并将同一批资源对齐回 `develop`。其他特批直接发布仍必须由维护者设置该标签并通过其余全部质量门禁。完整流程见 [CONTRIBUTING.md](./CONTRIBUTING.md)。不要把本地环境文件、求解器二进制、运行记录、用户数据或浏览器自动化产物加入提交。
 
 ## 第三方素材
 

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -263,7 +263,13 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(policyWorkflow, /types: \[opened, synchronize, reopened, labeled, unlabeled\]/);
   assert.match(policyWorkflow, /DIRECT_MAIN_RELEASE: \$\{\{ contains\(github\.event\.pull_request\.labels\.\*\.name, 'direct-main-release'\)[\s\S]+"\$DIRECT_MAIN_RELEASE" == "1"[\s\S]+develop ancestry is intentionally skipped/);
   assert.match(policyWorkflow, /git merge-base --is-ancestor refs\/remotes\/origin\/develop "\$HEAD_SHA"/);
+  assert.match(qualityWorkflow, /workflow_dispatch:[\s\S]+deploy:[\s\S]+expected_sha:[\s\S]+type: string/);
+  assert.match(qualityWorkflow, /Validate requested deployment identity[\s\S]+test "\$GITHUB_SHA" = "\$EXPECTED_SHA"/);
+  assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
+  assert.match(qualityWorkflow, /deploy:[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
   assert.match(qualityWorkflow, /github\.event_name == 'push'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.match(deployWorkflow, /allow_workflow_dispatch:[\s\S]+type: boolean/);
+  assert.match(deployWorkflow, /github\.event_name == 'workflow_dispatch' && inputs\.allow_workflow_dispatch/);
   assert.match(deployWorkflow, /github\.event_name == 'push'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release/);
@@ -297,8 +303,13 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.doesNotMatch(deployWorkflow, /'\$DEPLOY_PUBLIC_HEALTH_URL'/);
   assert.match(deployWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);
   assert.match(deployWorkflow, /Verify public response compression[\s\S]+DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}[\s\S]+node scripts\/verify-public-compression\.mjs/);
-  assert.match(assetWorkflow, /BASE_BRANCH: develop/);
+  assert.match(assetWorkflow, /BASE_BRANCH: main/);
+  assert.match(assetWorkflow, /UPDATE_BRANCH: release\/automation\/arkntools-assets/);
   assert.match(assetWorkflow, /gh pr (?:list|create)[\s\S]+--base "\$BASE_BRANCH"/);
+  assert.match(assetWorkflow, /--label "direct-main-release"/);
+  assert.match(assetWorkflow, /gh api --method PUT[\s\S]+pulls\/\$PR_NUMBER\/merge/);
+  assert.match(assetWorkflow, /gh workflow run frontend-quality\.yml[\s\S]+--ref "\$BASE_BRANCH"[\s\S]+deploy=true[\s\S]+expected_sha="\$MERGED_SHA"/);
+  assert.match(assetWorkflow, /develop_parity:[\s\S]+BASE_BRANCH: develop[\s\S]+SOURCE_BRANCH: main/);
 
   for (const workflow of workflows) {
     assert.doesNotMatch(workflow, /^\s*pull_request_target\s*:/m);
@@ -347,13 +358,15 @@ test("asset synchronization isolates untrusted generation from repository write 
   assert.match(generate, /persist-credentials: false/);
   assert.doesNotMatch(generate, /contents: write|pull-requests: write|actions: write|GH_TOKEN:/);
   assert.match(generate, /actions\/upload-artifact@[0-9a-f]{40}/);
-  assert.match(publish, /permissions:\n {6}actions: write\n {6}contents: write\n {6}pull-requests: write/);
+  assert.match(publish, /permissions:\n {6}actions: write\n {6}contents: write\n {6}issues: write\n {6}pull-requests: write/);
   assert.match(publish, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(publish, /actions\/download-artifact@[0-9a-f]{40}/);
   assert.match(publish, /git apply --check --index "\$publication\/managed\.patch"/);
   assert.match(publish, /patch_bytes > 0 && patch_bytes <= 104857600/);
   assert.match(publish, /awk '\$1 != "100644"/);
   assert.match(publish, /Publication artifact changed a forbidden path/);
+  assert.match(publish, /Resource pull request changed a forbidden path/);
+  assert.match(publish, /git restore --source "refs\/remotes\/origin\/\$SOURCE_BRANCH" --staged --worktree --/);
   assert.doesNotMatch(publish, /npm (?:ci|run)|node scripts\//);
 });
 


### PR DESCRIPTION
## 改动

- arkntools 同步改为在 main 基线隔离生成、校验受管路径，并从固定 release 分支创建带审计标签的 PR
- 自动校验 PR 来源、head SHA、base SHA、文件白名单和标签后 squash 合并
- 使用精确 expected SHA 显式触发完整 main 质量门禁与 production 部署
- 自动将已发布资源对齐回 develop，并显式触发 development 质量与部署
- 保留 production Environment 审批，不扩大到其他机器人或普通 PR

## 验证

- `node --test scripts/build-tooling.test.mjs`（21/21）
- 三个工作流通过 YAML 解析
- `npm run check`（357 + 2 + 66 + 13 tests）
- `npm run audit:security`（0 vulnerabilities）
- `npm run build`
- `git diff --check`

## 影响范围

影响 GitHub Actions 发布与受管资源同步；不修改 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。