### PR TITLE
fix: 修复自动资源发布部署授权

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,11 +7,6 @@ on:
         description: Immutable release artifact produced by the post-merge build job
         required: true
         type: string
-      allow_workflow_dispatch:
-        description: Allow an explicitly requested post-merge workflow dispatch to deploy
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   contents: read
@@ -19,8 +14,6 @@ permissions:
 jobs:
   deploy:
     if: >-
-      (github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.allow_workflow_dispatch)) &&
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
       github.repository == 'KnightCodeSquareMatrix/RIIC-Web'

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -559,5 +559,4 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       artifact_name: riic-web-release-${{ github.sha }}
-      allow_workflow_dispatch: ${{ github.event_name == 'workflow_dispatch' && inputs.deploy }}
     secrets: inherit

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -268,9 +268,10 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
   assert.match(qualityWorkflow, /deploy:[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
   assert.match(qualityWorkflow, /github\.event_name == 'push'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
-  assert.match(deployWorkflow, /allow_workflow_dispatch:[\s\S]+type: boolean/);
-  assert.match(deployWorkflow, /github\.event_name == 'workflow_dispatch' && inputs\.allow_workflow_dispatch/);
-  assert.match(deployWorkflow, /github\.event_name == 'push'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.match(deployWorkflow, /^on:\r?\n {2}workflow_call:/m);
+  assert.doesNotMatch(deployWorkflow, /^ {2}(?:push|workflow_dispatch):/m);
+  assert.doesNotMatch(deployWorkflow, /allow_workflow_dispatch|github\.event_name/);
+  assert.match(deployWorkflow, /github\.ref_name == 'main'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release/);
   assert.match(deployWorkflow, /DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}/);


### PR DESCRIPTION
## 改动\n- 将 push / 显式 workflow_dispatch 的部署授权统一保留在顶层质量工作流\n- 复用部署工作流只接受 workflow_call，并继续校验固定仓库、main/develop 与部署开关\n- 添加防止复用工作流暴露独立触发入口的回归断言\n\n## 原因\nPR #138 合入 develop 后，检查和制品构建成功，但复用工作流误读调用事件，导致部署 Job 被跳过。\n\n## 验证\n- node --test scripts/build-tooling.test.mjs\n- 三个 workflow YAML 解析通过\n- npm run check\n- git diff --check\n\n注：仓库当前没有 package.json 中的 test:deploy 脚本，尝试执行时 npm 报 Missing script；部署脚本契约由 build-tooling 测试覆盖。\n\n## 影响\n仅影响 GitHub Actions 发布授权与回归测试；不修改 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。