### PR TITLE
fix: 固化自动发布事件授权

### DIFF
--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -55,6 +55,7 @@ jobs:
       run_core: ${{ steps.scope.outputs.run_core }}
       run_browser: ${{ steps.scope.outputs.run_browser }}
       deploy_required: ${{ steps.scope.outputs.deploy_required }}
+      deployment_authorized: ${{ steps.deploy_authorization.outputs.authorized }}
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -62,16 +63,25 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate requested deployment identity
-        if: github.event_name == 'workflow_dispatch' && inputs.deploy
+      - name: Authorize deployment trigger
+        id: deploy_authorization
         shell: bash
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEPLOY_REQUESTED: ${{ inputs.deploy }}
           EXPECTED_SHA: ${{ inputs.expected_sha }}
         run: |
           set -euo pipefail
-          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
-          test "$GITHUB_SHA" = "$EXPECTED_SHA"
-          [[ "$GITHUB_REF_NAME" == "main" || "$GITHUB_REF_NAME" == "develop" ]]
+          authorized=false
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            authorized=true
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$DEPLOY_REQUESTED" == "true" ]]; then
+            [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+            test "$GITHUB_SHA" = "$EXPECTED_SHA"
+            [[ "$GITHUB_REF_NAME" == "main" || "$GITHUB_REF_NAME" == "develop" ]]
+            authorized=true
+          fi
+          printf 'authorized=%s\n' "$authorized" >> "$GITHUB_OUTPUT"
 
       - name: Classify changed paths
         id: scope
@@ -347,8 +357,7 @@ jobs:
       - name: Upload release for deployment
         if: >-
           needs.changes.outputs.deploy_required == 'true' &&
-          (github.event_name == 'push' ||
-          (github.event_name == 'workflow_dispatch' && inputs.deploy))
+          needs.changes.outputs.deployment_authorized == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: riic-web-release-${{ github.sha }}
@@ -549,8 +558,7 @@ jobs:
     needs: [changes, quality, release_artifact]
     if: >-
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.deploy)) &&
+      needs.changes.outputs.deployment_authorized == 'true' &&
       needs.quality.result == 'success' &&
       needs.release_artifact.result == 'success' &&
       needs.changes.outputs.deploy_required == 'true' &&

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -264,10 +264,10 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(policyWorkflow, /DIRECT_MAIN_RELEASE: \$\{\{ contains\(github\.event\.pull_request\.labels\.\*\.name, 'direct-main-release'\)[\s\S]+"\$DIRECT_MAIN_RELEASE" == "1"[\s\S]+develop ancestry is intentionally skipped/);
   assert.match(policyWorkflow, /git merge-base --is-ancestor refs\/remotes\/origin\/develop "\$HEAD_SHA"/);
   assert.match(qualityWorkflow, /workflow_dispatch:[\s\S]+deploy:[\s\S]+expected_sha:[\s\S]+type: string/);
-  assert.match(qualityWorkflow, /Validate requested deployment identity[\s\S]+test "\$GITHUB_SHA" = "\$EXPECTED_SHA"/);
-  assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
-  assert.match(qualityWorkflow, /deploy:[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+inputs\.deploy/);
-  assert.match(qualityWorkflow, /github\.event_name == 'push'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.match(qualityWorkflow, /deployment_authorized: \$\{\{ steps\.deploy_authorization\.outputs\.authorized \}\}/);
+  assert.match(qualityWorkflow, /Authorize deployment trigger[\s\S]+EVENT_NAME: \$\{\{ github\.event_name \}\}[\s\S]+DEPLOY_REQUESTED: \$\{\{ inputs\.deploy \}\}[\s\S]+test "\$GITHUB_SHA" = "\$EXPECTED_SHA"[\s\S]+authorized=true[\s\S]+printf 'authorized=%s\\n'/);
+  assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'/);
+  assert.match(qualityWorkflow, /deploy:[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /^on:\r?\n {2}workflow_call:/m);
   assert.doesNotMatch(deployWorkflow, /^ {2}(?:push|workflow_dispatch):/m);
   assert.doesNotMatch(deployWorkflow, /allow_workflow_dispatch|github\.event_name/);


### PR DESCRIPTION
## 改动\n- 由 Change scope 明确输出 deployment_authorized\n- push 自动授权；手动 deploy 继续校验 expected SHA 和 main/develop 分支\n- 制品上传和可复用部署 Job 只消费该布尔输出\n- 添加对应回归断言\n\n## 原因\nPR #139 合入后的运行 33797182509 显示，包含 workflow_dispatch inputs 的表达式在可复用工作流调用 Job 层被判为 false，普通步骤却可正常执行。改为上游显式输出，避免该上下文差异。\n\n## 验证\n- node --test scripts/build-tooling.test.mjs（21/21）\n- frontend-quality.yml YAML 解析通过\n- git diff --check\n\n## 影响\n仅影响 GitHub Actions 发布授权；不修改 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。