### PR TITLE
fix: 将自动发布门禁传入复用工作流

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,14 @@ on:
         description: Immutable release artifact produced by the post-merge build job
         required: true
         type: string
+      deployment_authorized:
+        description: The caller validated that this event may deploy the verified ref
+        required: true
+        type: boolean
+      deploy_required:
+        description: The verified change scope requires an application release
+        required: true
+        type: boolean
 
 permissions:
   contents: read
@@ -14,6 +22,8 @@ permissions:
 jobs:
   deploy:
     if: >-
+      inputs.deployment_authorized &&
+      inputs.deploy_required &&
       (github.ref_name == 'main' || github.ref_name == 'develop') &&
       vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
       github.repository == 'KnightCodeSquareMatrix/RIIC-Web'

--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -556,15 +556,9 @@ jobs:
 
   deploy:
     needs: [changes, quality, release_artifact]
-    if: >-
-      (github.ref_name == 'main' || github.ref_name == 'develop') &&
-      needs.changes.outputs.deployment_authorized == 'true' &&
-      needs.quality.result == 'success' &&
-      needs.release_artifact.result == 'success' &&
-      needs.changes.outputs.deploy_required == 'true' &&
-      vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
-      github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
     uses: ./.github/workflows/deploy.yml
     with:
       artifact_name: riic-web-release-${{ github.sha }}
+      deployment_authorized: ${{ needs.changes.outputs.deployment_authorized == 'true' }}
+      deploy_required: ${{ needs.changes.outputs.deploy_required == 'true' }}
     secrets: inherit

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -267,11 +267,12 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(qualityWorkflow, /deployment_authorized: \$\{\{ steps\.deploy_authorization\.outputs\.authorized \}\}/);
   assert.match(qualityWorkflow, /Authorize deployment trigger[\s\S]+EVENT_NAME: \$\{\{ github\.event_name \}\}[\s\S]+DEPLOY_REQUESTED: \$\{\{ inputs\.deploy \}\}[\s\S]+test "\$GITHUB_SHA" = "\$EXPECTED_SHA"[\s\S]+authorized=true[\s\S]+printf 'authorized=%s\\n'/);
   assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'/);
-  assert.match(qualityWorkflow, /deploy:[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.match(qualityWorkflow, /deploy:\r?\n {4}needs: \[changes, quality, release_artifact\][\s\S]+uses: \.\/\.github\/workflows\/deploy\.yml[\s\S]+deployment_authorized: \$\{\{ needs\.changes\.outputs\.deployment_authorized == 'true' \}\}[\s\S]+deploy_required: \$\{\{ needs\.changes\.outputs\.deploy_required == 'true' \}\}/);
   assert.match(deployWorkflow, /^on:\r?\n {2}workflow_call:/m);
   assert.doesNotMatch(deployWorkflow, /^ {2}(?:push|workflow_dispatch):/m);
   assert.doesNotMatch(deployWorkflow, /allow_workflow_dispatch|github\.event_name/);
-  assert.match(deployWorkflow, /github\.ref_name == 'main'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
+  assert.match(deployWorkflow, /deployment_authorized:[\s\S]+type: boolean[\s\S]+deploy_required:[\s\S]+type: boolean/);
+  assert.match(deployWorkflow, /inputs\.deployment_authorized &&[\s\S]+inputs\.deploy_required &&[\s\S]+github\.ref_name == 'main'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
   assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release/);
   assert.match(deployWorkflow, /DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}/);


### PR DESCRIPTION
## 改动\n- 顶层 deploy 调用 Job 只依赖已成功的 changes、quality 和 release_artifact\n- 将 deployment_authorized 与 deploy_required 作为强类型布尔输入传入复用工作流\n- 复用工作流内部同时校验两个输入、固定仓库、main/develop 和部署开关\n\n## 原因\n运行 33797516788 证明授权输出和制品上传均成功，但 GitHub 仍在 reusable-workflow 调用 Job 的 if 层跳过调用。本改动移除该特殊求值点。\n\n## 验证\n- node --test scripts/build-tooling.test.mjs（21/21）\n- deploy.yml、frontend-quality.yml YAML 解析通过\n- git diff --check\n\n## 影响\n仅影响 GitHub Actions 发布门禁；不修改 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。