### PR TITLE
fix: 允许发布汇总已跳过检查

### DIFF
--- a/.github/workflows/frontend-quality.yml
+++ b/.github/workflows/frontend-quality.yml
@@ -556,6 +556,16 @@ jobs:
 
   deploy:
     needs: [changes, quality, release_artifact]
+    if: >-
+      always() &&
+      needs.changes.result == 'success' &&
+      needs.quality.result == 'success' &&
+      needs.release_artifact.result == 'success' &&
+      needs.changes.outputs.deployment_authorized == 'true' &&
+      needs.changes.outputs.deploy_required == 'true' &&
+      (github.ref_name == 'main' || github.ref_name == 'develop') &&
+      vars.DEPLOY_AUTOMATION_ENABLED == '1' &&
+      github.repository == 'KnightCodeSquareMatrix/RIIC-Web'
     uses: ./.github/workflows/deploy.yml
     with:
       artifact_name: riic-web-release-${{ github.sha }}

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -267,7 +267,7 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(qualityWorkflow, /deployment_authorized: \$\{\{ steps\.deploy_authorization\.outputs\.authorized \}\}/);
   assert.match(qualityWorkflow, /Authorize deployment trigger[\s\S]+EVENT_NAME: \$\{\{ github\.event_name \}\}[\s\S]+DEPLOY_REQUESTED: \$\{\{ inputs\.deploy \}\}[\s\S]+test "\$GITHUB_SHA" = "\$EXPECTED_SHA"[\s\S]+authorized=true[\s\S]+printf 'authorized=%s\\n'/);
   assert.match(qualityWorkflow, /Upload release for deployment[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'/);
-  assert.match(qualityWorkflow, /deploy:\r?\n {4}needs: \[changes, quality, release_artifact\][\s\S]+uses: \.\/\.github\/workflows\/deploy\.yml[\s\S]+deployment_authorized: \$\{\{ needs\.changes\.outputs\.deployment_authorized == 'true' \}\}[\s\S]+deploy_required: \$\{\{ needs\.changes\.outputs\.deploy_required == 'true' \}\}/);
+  assert.match(qualityWorkflow, /deploy:\r?\n {4}needs: \[changes, quality, release_artifact\][\s\S]+always\(\) &&[\s\S]+needs\.changes\.result == 'success'[\s\S]+needs\.quality\.result == 'success'[\s\S]+needs\.release_artifact\.result == 'success'[\s\S]+needs\.changes\.outputs\.deployment_authorized == 'true'[\s\S]+needs\.changes\.outputs\.deploy_required == 'true'[\s\S]+uses: \.\/\.github\/workflows\/deploy\.yml[\s\S]+deployment_authorized: \$\{\{ needs\.changes\.outputs\.deployment_authorized == 'true' \}\}[\s\S]+deploy_required: \$\{\{ needs\.changes\.outputs\.deploy_required == 'true' \}\}/);
   assert.match(deployWorkflow, /^on:\r?\n {2}workflow_call:/m);
   assert.doesNotMatch(deployWorkflow, /^ {2}(?:push|workflow_dispatch):/m);
   assert.doesNotMatch(deployWorkflow, /allow_workflow_dispatch|github\.event_name/);


### PR DESCRIPTION
## 改动\n- deploy 调用条件显式以 always() 开头\n- 逐项要求 changes、quality、release_artifact 成功\n- 继续要求事件授权、发布范围、固定分支、固定仓库和部署开关\n\n## 原因\n运行 33797849390 中三个直接依赖均成功，但 quality 汇总任务包含按范围正确跳过的浏览器上游，GitHub 将 skipped 状态传播给下游，未写 always() 的 deploy 调用不会求值而直接跳过。\n\n## 验证\n- node --test scripts/build-tooling.test.mjs（21/21）\n- frontend-quality.yml YAML 解析通过\n- git diff --check\n\n## 影响\n仅影响 GitHub Actions 发布依赖处理；不修改 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。