### PR TITLE
ci: 每日八点同步 arkntools 资源

### DIFF
--- a/.github/workflows/sync-arkntools-assets.yml
+++ b/.github/workflows/sync-arkntools-assets.yml
@@ -2,7 +2,8 @@ name: Sync arkntools assets
 
 on:
   schedule:
-    - cron: "17 2 * * *"
+    # 00:00 UTC = 08:00 Asia/Shanghai (UTC+8).
+    - cron: "0 0 * * *"
   workflow_dispatch:
     inputs:
       allow_removals:

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -356,6 +356,7 @@ test("asset synchronization isolates untrusted generation from repository write 
   const generate = workflow.slice(workflow.indexOf("  generate:"), workflow.indexOf("  publish:"));
   const publish = workflow.slice(workflow.indexOf("  publish:"));
 
+  assert.match(workflow, /schedule:\n {4}# 00:00 UTC = 08:00 Asia\/Shanghai \(UTC\+8\)\.\n {4}- cron: "0 0 \* \* \*"/);
   assert.match(workflow, /^permissions:\n {2}contents: read$/m);
   assert.match(generate, /persist-credentials: false/);
   assert.doesNotMatch(generate, /contents: write|pull-requests: write|actions: write|GH_TOKEN:/);


### PR DESCRIPTION
## 改动\n- 将 arkntools 每日同步从 UTC 02:17 调整为 UTC 00:00，即北京时间 08:00\n- 在 workflow 内标注时区换算\n- 添加构建工具回归断言，防止 cron 和时区说明漂移\n\n## 验证\n- node --test scripts/build-tooling.test.mjs（21/21）\n- npm run check（357 unit + 2 module mocks + 66 API contract + 15 shift）\n- workflow YAML 解析通过\n- git diff --check\n\n## 影响\n只修改资源同步时间与测试；不影响 CLI、公共 API、森空岛会话、存储、反馈 JSON 或 MAA JSON。