### PR TITLE
feat: 为自选 Box 与调整练度增加星级筛选

### DIFF
--- a/e2e/manual-operbox-rarity.spec.ts
+++ b/e2e/manual-operbox-rarity.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import roster from "../fixtures/operbox_full_e2.json" with { type: "json" };
+import { SESSION_KEY_V5, type PersistedSessionV5 } from "../src/persistence";
+import { gotoStable, mockApis, planData, requestId, seedV4Session } from "./production-readiness.fixture";
+
+const ownedBox = roster.filter((operator) => ["阿米娅", "银灰"].includes(operator.name))
+  .map((operator) => ({ ...operator, elite: 1, level: 70 }));
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/auth/get-session", (route) => route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      session: { expiresAt: new Date(Date.now() + 3_600_000).toISOString() },
+      user: { id: "rarity-test-user", name: "测试用户", email: "test@example.com", emailVerified: true },
+    }),
+  }));
+});
+
+async function openPicker(page: Page, mode: "manual" | "upgrade", mobile: boolean) {
+  await mockApis(page);
+  await seedV4Session(page, planData, { operbox: ownedBox, boxSource: "maa" });
+  await gotoStable(page, "/");
+  if (mode === "upgrade") {
+    await page.getByRole("button", { name: "调整练度", exact: true }).click();
+  } else {
+    if (mobile) await page.locator("[data-calculator-more-tools] summary").click();
+    await page.getByRole("button", { name: "配置Box与布局", exact: true }).filter({ visible: true }).click();
+    await page.getByRole("button", { name: "第 1 步，共 3 步：干员数据", exact: true }).click();
+    await page.getByRole("button", { name: "更换", exact: true }).click();
+    await page.getByRole("tab", { name: "手动选择", exact: true }).click();
+  }
+  const picker = page.locator("[data-manual-operbox-picker]");
+  await expect(picker).toBeVisible();
+  return picker;
+}
+
+async function chooseRarity(picker: Locator, rarity: number | "all") {
+  const button = picker.getByRole("button", { name: rarity === "all" ? "全部" : `${rarity} 星干员`, exact: true });
+  await button.click();
+  await expect(button).toHaveAttribute("aria-pressed", "true");
+}
+
+async function assertFilterGeometry(picker: Locator) {
+  const filter = picker.getByRole("group", { name: "星级筛选", exact: true });
+  await filter.scrollIntoViewIfNeeded();
+  const geometry = await filter.evaluate((element) => {
+    const bounds = element.getBoundingClientRect();
+    return Array.from(element.querySelectorAll("button")).map((button) => {
+      const rect = button.getBoundingClientRect();
+      return { width: rect.width, height: rect.height, contained: rect.left >= bounds.left - 1 && rect.right <= bounds.right + 1 };
+    });
+  });
+  expect(geometry).toHaveLength(7);
+  for (const button of geometry) {
+    expect(button.width).toBeGreaterThanOrEqual(44);
+    expect(button.height).toBeGreaterThanOrEqual(44);
+    expect(button.contained).toBe(true);
+  }
+}
+
+for (const mobile of [false, true]) {
+  const device = mobile ? "mobile" : "desktop";
+  test.describe(device, () => {
+    test.use({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
+
+    test("manual Box combines rarity, search and ownership without losing hidden selections", async ({ page }, testInfo) => {
+      const picker = await openPicker(page, "manual", mobile);
+      for (const rarity of [1, 2, 3, 4, 5, 6]) {
+        await chooseRarity(picker, rarity);
+        const count = Math.min(48, roster.filter((operator) => operator.rarity === rarity).length);
+        await expect(picker.locator("article")).toHaveCount(count);
+        expect(await picker.locator("article span.font-number").filter({ hasText: "★" }).allTextContents()).toEqual(Array(count).fill(`${rarity}★ · 最高精${rarity <= 2 ? 0 : rarity === 3 ? 1 : 2}`));
+      }
+      await picker.getByRole("button", { name: /显示更多干员/ }).click();
+      await expect(picker.locator("article")).toHaveCount(96);
+      await chooseRarity(picker, 5);
+      await expect(picker.locator("article")).toHaveCount(48);
+      await picker.getByRole("button", { name: "只看已拥有", exact: true }).click();
+      await expect(picker.locator("article")).toHaveCount(1);
+      await expect(picker.getByRole("heading", { name: "阿米娅", exact: true })).toBeVisible();
+      await chooseRarity(picker, 6);
+      await expect(picker.locator("article")).toHaveCount(1);
+      await picker.getByRole("radiogroup", { name: "银灰持有与精英阶段", exact: true }).getByRole("radio", { name: "精2", exact: true }).click();
+      await chooseRarity(picker, 5);
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("银灰");
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("");
+      await chooseRarity(picker, "all");
+      await expect(picker.locator("article")).toHaveCount(2);
+      await expect(picker.getByRole("radiogroup", { name: "银灰持有与精英阶段", exact: true }).getByRole("radio", { name: "精2", exact: true })).toHaveAttribute("aria-checked", "true");
+      await chooseRarity(picker, 5);
+      await assertFilterGeometry(picker);
+      await page.screenshot({ path: testInfo.outputPath(`manual-rarity-${device}.png`) });
+      await picker.locator("[data-manual-operbox-apply]").first().click();
+      await expect.poll(() => page.evaluate((key) => {
+        const saved = JSON.parse(localStorage.getItem(key) ?? "{}");
+        return saved.operbox?.filter((operator: { own: boolean }) => operator.own).map((operator: { name: string; elite: number }) => [operator.name, operator.elite]);
+      }, SESSION_KEY_V5)).toEqual([["银灰", 2], ["阿米娅", 1]]);
+    });
+
+    test("upgrade simulation combines rarity and schedule scope and submits the complete Box", async ({ page }, testInfo) => {
+      const picker = await openPicker(page, "upgrade", mobile);
+      await chooseRarity(picker, 6);
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await picker.getByRole("tab", { name: /未进排班/ }).click();
+      await picker.getByRole("button", { name: "只看已拥有", exact: true }).click();
+      await expect(picker.locator("article")).toHaveCount(1);
+      await picker.getByRole("radiogroup", { name: "银灰持有与精英阶段", exact: true }).getByRole("radio", { name: "精2", exact: true }).click();
+      await chooseRarity(picker, 5);
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await picker.getByRole("tab", { name: /进入排班/ }).click();
+      await expect(picker.locator("article")).toHaveCount(1);
+      await expect(picker.getByRole("heading", { name: "阿米娅", exact: true })).toBeVisible();
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("银灰");
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("");
+      await picker.getByRole("button", { name: /^第一班/ }).click();
+      await expect(picker.locator("article")).toHaveCount(1);
+      await chooseRarity(picker, 6);
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await chooseRarity(picker, 5);
+      await expect(picker.getByRole("button", { name: /^第一班/ })).toHaveAttribute("aria-pressed", "true");
+      await assertFilterGeometry(picker);
+      await page.screenshot({ path: testInfo.outputPath(`upgrade-rarity-${device}.png`) });
+
+      let releasePlan = () => {};
+      const pending = new Promise<void>((resolve) => { releasePlan = resolve; });
+      let submitted: typeof ownedBox = [];
+      await page.route("**/api/plan", async (route) => {
+        submitted = route.request().postDataJSON().operbox;
+        await pending;
+        await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true, data: planData, requestId }) });
+      });
+      await picker.getByRole("button", { name: "按调整重新试算", exact: true }).first().click();
+      try {
+        await expect.poll(() => submitted.length).toBe(roster.length);
+        expect(submitted.filter((operator) => operator.own).map((operator) => [operator.name, operator.elite])).toEqual([["银灰", 2], ["阿米娅", 1]]);
+        for (const button of await picker.getByRole("group", { name: "星级筛选", exact: true }).getByRole("button").all()) {
+          await expect(button).toBeDisabled();
+        }
+      } finally {
+        releasePlan();
+      }
+      await expect(page.locator("[data-upgrade-simulation-dialog]")).toBeHidden();
+      await expect(page.locator('[data-slot="live-activity"]')).toContainText("调整练度已完成");
+      const saved: PersistedSessionV5 = await page.evaluate((key) => JSON.parse(localStorage.getItem(key) ?? "{}"), SESSION_KEY_V5);
+      expect(saved.operbox?.find((operator) => operator.name === "银灰")?.elite).toBe(2);
+    });
+  });
+}
+
+
+for (const mode of ["manual", "upgrade"] as const) {
+  test(`${mode} rarity filter supports English labels and keyboard selection`, async ({ page }) => {
+    await mockApis(page);
+    await seedV4Session(page, planData, { operbox: ownedBox, boxSource: "maa" });
+    await page.addInitScript(() => localStorage.setItem("infra-demo-locale", "en"));
+    await gotoStable(page, "/");
+    if (mode === "upgrade") {
+      await page.getByRole("button", { name: "Adjust progression", exact: true }).click();
+    } else {
+      await page.getByRole("button", { name: "Configure BOX and base", exact: true }).filter({ visible: true }).click();
+      await page.getByRole("button", { name: "Change", exact: true }).click();
+      await page.getByRole("tab", { name: "Manual", exact: true }).click();
+    }
+    const picker = page.locator("[data-manual-operbox-picker]");
+    const filter = picker.getByRole("group", { name: "Filter by rarity", exact: true });
+    const all = filter.getByRole("button", { name: "All", exact: true });
+    await all.focus();
+    await all.press("ArrowRight");
+    const sixStar = filter.getByRole("button", { name: "6-star operators", exact: true });
+    await expect(sixStar).toBeFocused();
+    await sixStar.press("Space");
+    await expect(sixStar).toHaveAttribute("aria-pressed", "true");
+    if (mode === "upgrade") await expect(picker.getByText("No matching operators.", { exact: true })).toBeVisible();
+    else await expect(picker.locator("article")).toHaveCount(48);
+    await sixStar.press("Space");
+    await expect(all).toHaveAttribute("aria-pressed", "true");
+  });
+}

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -8,6 +8,7 @@ import operatorCatalogJson from "../../generated/arkntools/operator-catalog.json
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LoadMore } from "@/components/ui/load-more";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import { demoOperatorName, useLanguageDemo, type DemoLocale } from "@/language-demo";
@@ -21,6 +22,8 @@ import {
 import type { OperBoxEntry } from "@/types";
 
 const PAGE_SIZE = 48;
+const RARITIES = [6, 5, 4, 3, 2, 1] as const;
+const RARITY_BUTTON_CLASS = "min-h-11 min-w-11 font-number aria-pressed:border-[#FFD800] aria-pressed:bg-[#FFD800] aria-pressed:text-[#313131] aria-pressed:hover:bg-[#FFD800] aria-pressed:hover:text-[#313131]";
 
 type CatalogOperator = {
   id: string;
@@ -218,6 +221,7 @@ export function ManualOperboxPicker({
   const en = locale === "en";
   const [query, setQuery] = useState("");
   const [onlyOwned, setOnlyOwned] = useState(false);
+  const [rarity, setRarity] = useState("all");
   const [rosterScope, setRosterScope] = useState<"scheduled" | "other">("scheduled");
   const [scheduledShift, setScheduledShift] = useState<"all" | number>("all");
   const [visibleLimit, setVisibleLimit] = useState(PAGE_SIZE);
@@ -251,12 +255,13 @@ export function ManualOperboxPicker({
     if (hasScheduledOperators && (rosterScope === "scheduled") !== scheduledNames.has(operator.name)) return false;
     if (rosterScope === "scheduled" && scheduledShift !== "all" && !scheduledOperatorShifts?.[operator.name]?.includes(scheduledShift)) return false;
     if (onlyOwned && stage === "none") return false;
+    if (rarity !== "all" && operator.rarity !== Number(rarity)) return false;
     if (!deferredQuery) return true;
     const displayName = demoOperatorName(operator.name, locale).toLocaleLowerCase(locale === "en" ? "en-US" : "zh-CN");
     return operator.name.toLocaleLowerCase("zh-CN").includes(deferredQuery)
       || displayName.includes(deferredQuery)
       || operator.id.toLocaleLowerCase("en-US").includes(deferredQuery);
-  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, stages]);
+  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, rarity, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, stages]);
 
   function resetListView() {
     setVisibleLimit(PAGE_SIZE);
@@ -359,6 +364,37 @@ export function ManualOperboxPicker({
             <RotateCcw />{en ? "Clear" : "清空选择"}
           </Button>
         </div>
+      </div>
+
+      <div className="grid gap-2">
+        <div className="text-xs font-medium text-muted-foreground">{en ? "Rarity" : "星级"}</div>
+        <ToggleGroup
+          value={[rarity]}
+          onValueChange={(next) => {
+            setRarity(next[0] ?? "all");
+            resetListView();
+          }}
+          disabled={applyDisabled}
+          variant="outline"
+          size="sm"
+          spacing={2}
+          aria-label={en ? "Filter by rarity" : "星级筛选"}
+          className="w-full flex-wrap justify-start"
+        >
+          <ToggleGroupItem value="all" className={RARITY_BUTTON_CLASS}>
+            {en ? "All" : "全部"}
+          </ToggleGroupItem>
+          {RARITIES.map((value) => (
+            <ToggleGroupItem
+              key={value}
+              value={String(value)}
+              aria-label={en ? `${value}-star operators` : `${value} 星干员`}
+              className={RARITY_BUTTON_CLASS}
+            >
+              {value}★
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
       </div>
 
       {hasScheduledOperators ? (


### PR DESCRIPTION
## 改动

- 手动选择 Box、同布局调整练度共用星级筛选：全部、6★～1★。
- 星级与搜索、只看已拥有、进入排班/未进排班、班次筛选叠加，不清空已选干员；应用时仍提交完整 Box。
- 切换星级重置分页，保留最新 develop 的紧凑布局及练度调整流程。
- 复用现有 ToggleGroup，支持中英文标签、键盘操作和手机端换行；试算请求期间禁用星级切换。
- 增加端到端回归，覆盖两个入口、六个星级、组合筛选、隐藏选择保留、完整请求、英文键盘操作及手机触摸尺寸。

## 验证

- 8 项 Chromium 回归通过（6 项新增 + 2 项现有设置/练度调整回归）。
- 7 项手动 Box / 升级试算单测通过。
- ESLint、TypeScript、公开仓库敏感内容检查通过。
- 按发布参数完成 Next.js build；JS/预加载体积预算、构建追踪、生产浏览器开关校验通过（森空岛及账号云同步开启）。

基于最新 `develop`，仅包含共享选择器与测试两个文件；不包含本地免登录、旧版试算流程或其他未提交修改。
