### PR TITLE
fix: 修复布局选择被异步恢复覆盖

### DIFF
--- a/e2e/manual-operbox-rarity.spec.ts
+++ b/e2e/manual-operbox-rarity.spec.ts
@@ -65,6 +65,7 @@ for (const mobile of [false, true]) {
     test.use({ viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 } });
 
     test("manual Box combines rarity, search and ownership without losing hidden selections", async ({ page }, testInfo) => {
+      test.slow();
       const picker = await openPicker(page, "manual", mobile);
       for (const rarity of [1, 2, 3, 4, 5, 6]) {
         await chooseRarity(picker, rarity);
@@ -100,6 +101,7 @@ for (const mobile of [false, true]) {
     });
 
     test("upgrade simulation combines rarity and schedule scope and submits the complete Box", async ({ page }, testInfo) => {
+      test.slow();
       const picker = await openPicker(page, "upgrade", mobile);
       await chooseRarity(picker, 6);
       await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();

--- a/e2e/production-readiness-skland.spec.ts
+++ b/e2e/production-readiness-skland.spec.ts
@@ -739,6 +739,62 @@ test("an in-flight Skland restore cannot replace a newly imported MAA BOX", asyn
   await expect(reopenedDialog.getByText("1 名干员 · 1 名可用", { exact: true })).toBeVisible();
 });
 
+test("an in-flight Skland restore cannot replace a locally selected layout", async ({ page }) => {
+  let releaseFullRestore!: () => void;
+  let markFullRestoreStarted!: () => void;
+  const fullRestoreGate = new Promise<void>((resolve) => { releaseFullRestore = resolve; });
+  const fullRestoreStarted = new Promise<void>((resolve) => { markFullRestoreStarted = resolve; });
+
+  await mockApis(page, {
+    sklandConfigured: true,
+    sklandSnapshot: authenticatedSklandSnapshot,
+  });
+  await page.route(/\/api\/skland\/accounts(?:[/?]|$)/, async (route) => {
+    const url = new URL(route.request().url());
+    const isFullRestore = route.request().method() === "GET" && !url.searchParams.has("mode");
+    if (isFullRestore) {
+      markFullRestoreStarted();
+      await fullRestoreGate;
+    }
+    await route.fallback();
+  });
+  await seedV4Session(page, undefined, {
+    boxSource: "skland",
+    operbox: [authenticatedSklandSnapshot.operbox[0]],
+  });
+  await page.goto("/");
+  await fullRestoreStarted;
+
+  await page.getByRole("button", { name: "配置Box与布局" }).first().click();
+  const dialog = page.getByRole("dialog", { name: "排班设置" });
+  await dialog.getByRole("button", { name: "继续", exact: true }).click();
+  const selectedLayout = dialog.getByRole("button", { name: /^252/ });
+  await selectedLayout.click();
+  await expect(selectedLayout).toHaveAttribute("aria-pressed", "true");
+
+  const fullRestoreResponse = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return response.request().method() === "GET"
+      && url.pathname === "/api/skland/accounts"
+      && !url.searchParams.has("mode");
+  });
+  releaseFullRestore();
+  await fullRestoreResponse;
+  await page.waitForTimeout(100);
+
+  await expect(selectedLayout).toHaveAttribute("aria-pressed", "true");
+  await dialog.getByRole("button", { name: "检查设施", exact: true }).click();
+  await dialog.getByRole("button", { name: "完成", exact: true }).click();
+
+  const planRequest = page.waitForRequest((request) => (
+    request.method() === "POST" && new URL(request.url()).pathname === "/api/plan"
+  ));
+  await page.getByRole("button", { name: "生成排班", exact: true }).click();
+  const submitted = await planRequest;
+  const payload = submitted.postDataJSON() as { layout?: { template?: string } };
+  expect(payload.layout?.template).toBe("252");
+});
+
 test("Skland status center loads full status on demand and deletion preserves non-Skland data", async ({ page }) => {
   const statusMethods: string[] = [];
   let fullSessionRequests = 0;

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -206,7 +206,7 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
   assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 97);
+  assert.equal(readinessTestCount, 98);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: true/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -263,7 +263,15 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     currentBoxSourceRef.current = resolvedSource;
     setBoxSourceState(resolvedSource);
   }, []);
-  const [layoutDirty, setLayoutDirty] = useState(false);
+  const [layoutDirty, setLayoutDirtyState] = useState(false);
+  const currentLayoutDirtyRef = useRef(layoutDirty);
+  const setLayoutDirty = useCallback<Dispatch<SetStateAction<boolean>>>((nextDirty) => {
+    const resolvedDirty = typeof nextDirty === "function"
+      ? nextDirty(currentLayoutDirtyRef.current)
+      : nextDirty;
+    currentLayoutDirtyRef.current = resolvedDirty;
+    setLayoutDirtyState(resolvedDirty);
+  }, []);
   const [layoutSource, setLayoutSource] = useState<"local" | "skland">("local");
   const [localLayoutBackup, setLocalLayoutBackup] = useState<BaseBlueprint | null>(null);
   const [rotationProfile, setRotationProfile] = useState<RotationProfile>(DEFAULT_ROTATION_PROFILE);
@@ -288,7 +296,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const initialLayoutForRestore = useRef(defaultLayout);
   const initialBoxSource = useRef(boxSource);
   const initialOperbox = useRef(operbox);
-  const initialLayoutDirty = useRef(layoutDirty);
   const initialLayoutSource = useRef<"local" | "skland">("local");
   const initialLocalLayoutBackup = useRef<BaseBlueprint | null>(null);
   const skipNextPersistence = useRef(false);
@@ -625,7 +632,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         initialLayoutForRestore.current = restoredLayout;
         initialBoxSource.current = restoredBoxSource;
         initialOperbox.current = restoredOperbox;
-        initialLayoutDirty.current = restored.layoutDirty;
         initialLayoutSource.current = restoredLayoutSource;
         initialLocalLayoutBackup.current = CLIENT_SKLAND_ENABLED ? restored.localLayoutBackup : null;
       }
@@ -634,7 +640,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     } finally {
       setHasRestoredSession(true);
     }
-  }, [locale, setBoxSource, setOperbox]);
+  }, [locale, setBoxSource, setLayoutDirty, setOperbox]);
 
   useEffect(() => {
     if (!hasRestoredSession || typeof window === "undefined") return;
@@ -797,7 +803,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
             setBoxSource("skland");
           }
           if (
-            !initialLayoutDirty.current
+            !currentLayoutDirtyRef.current
             && (initialBoxSource.current === "skland" || !initialOperbox.current)
             && session.scheduleSnapshot.infrastructure.layoutSuggestion
           ) {


### PR DESCRIPTION
## 修改内容

- 修复森空岛恢复请求晚返回时覆盖用户刚选择布局的问题
- 增加布局竞态端到端回归测试，验证选择 252 后提交仍为 252
- 加固 PR #148 的稀有度筛选端到端用例，避免冷启动编译造成误超时

## 验证

- npm test
- npm run test:api-contract
- npm run test:shift-comparison
- npm run check:public-repository
- npm run assets:check
- npx eslint . --ignore-pattern .gstack/**
- npm run audit:security
- npm run build
- Chromium 相关 E2E：7 passed