### PR TITLE
v0.4.7 fix: 调整新干员数据的构建预算

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -157,7 +157,7 @@ test("CI enforces route and document preload JavaScript budgets after building",
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 422_000/);
   assert.match(budgetCheck, /const sklandEnabled = sklandRoute\.firstLoadChunkPaths\.some/);
-  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_572_000/);
+  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_582_000/);
   assert.match(budgetCheck, /MAX_DOCUMENT_INITIAL_JS_FILES = 18/);
   assert.match(budgetCheck, /WORKBENCH_ROUTES = \["\/", "\/training", "\/skills", "\/skland", "\/account"\]/);
   assert.match(budgetCheck, /firstLoadUncompressedJsBytes/);

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -11,9 +11,9 @@ const MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_167_000;
 // full-page translation catalogs stay in their on-demand route chunks. Keep roughly
 // 8 KB of raw headroom over the verified disabled and enabled production builds.
 const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000;
-// Task progress UI and training tooltips add intentional code to secondary workbench routes.
-// Keep the ceiling narrow enough to flag unrelated bundle growth.
-const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_572_000;
+// Task progress UI, training tooltips, and the shared operator catalog add intentional code
+// to secondary workbench routes. Keep roughly 8 KB of raw headroom over the verified build.
+const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_582_000;
 const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_632_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000;
 const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000;


### PR DESCRIPTION
## 问题

PR #150 合并后的 Linux 生产构建成功，但 `/training` 初始 JavaScript 为 1,573,230 字节，比原 1,572,000 字节预算高 1,230 字节，阻止了部署。

## 修复

- 将二级工作台路由预算调整为 1,582,000 字节，为已验证构建保留约 8 KB 余量。
- 同步更新构建工具回归断言。

## 验证

- `npm run build`
- `npm run check:bundle-budget`
- `node --test scripts/build-tooling.test.mjs`（21/21）
- `git diff --check`