### PR TITLE
v0.4.7 fix: 补齐 Skland 新目录构建预算

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -151,7 +151,7 @@ test("CI enforces route and document preload JavaScript budgets after building",
   assert.match(workflow, /Build standalone application and worker[\s\S]+Release output checks[\s\S]+npm run check:bundle-budget/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_167_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000/);
-  assert.match(budgetCheck, /MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_632_000/);
+  assert.match(budgetCheck, /MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_642_000/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000/);

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -14,7 +14,7 @@ const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000;
 // Task progress UI, training tooltips, and the shared operator catalog add intentional code
 // to secondary workbench routes. Keep roughly 8 KB of raw headroom over the verified build.
 const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_582_000;
-const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_632_000;
+const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_642_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000;
 const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000;


### PR DESCRIPTION
## 问题

Linux 生产复现显示新干员目录还使 `/skland` 初始 JavaScript 达到 1,632,698 字节，比原 1,632,000 字节预算高 698 字节。

## 修复

- 将 Skland 路由预算调整为 1,642,000 字节，为实测构建保留约 9 KB 余量。
- 同步更新构建工具回归断言。
- 其余路由与首屏 raw/gzip 预算保持不变。

## 验证

- Docker Linux / Node 22 生产构建通过。
- 完整体积统计：`/training` 1,573,135、`/skills` 1,566,609、`/skland` 1,632,698、`/` 1,189,734；文档 raw 1,302,328、gzip 416,380。
- `npm run check:bundle-budget`
- `node --test scripts/build-tooling.test.mjs`（21/21）
- `git diff --check`