### PR TITLE
v0.4.7 test: 同步新干员总数断言

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test, type Locator } from "@playwright/test";
+import arkntoolsSource from "../src/generated/arkntools/source.json" with { type: "json" };
 import { requestId, diagnosticId, waitForOwnAnimations, gotoStable, expectVisibleNumbersUseNumberFont, profile, planData, scheduleVisualPlanData, sampleData, authenticatedSklandSnapshot, mockApis, openSklandOverview, seedPreferences, seedV4Session } from "./production-readiness.fixture";
+
+const fullOperatorCount = arkntoolsSource.counts.operators;
 
 test.beforeEach(async ({ page }) => {
   await page.route("**/api/auth/get-session", (route) => route.fulfill({
@@ -408,7 +411,7 @@ test("setup exposes and persists only worker-supported rotation profiles", async
     await expect(stageButton).toHaveCSS("border-radius", "4px");
   }
   await manualPicker.getByRole("button", { name: "全选最高精英", exact: true }).click();
-  await expect(manualPicker.getByText("已拥有 425 名", { exact: true })).toBeVisible();
+  await expect(manualPicker.getByText(`已拥有 ${fullOperatorCount} 名`, { exact: true })).toBeVisible();
   const manualApplyButtons = manualPicker.locator("[data-manual-operbox-apply]");
   await expect(manualApplyButtons).toHaveCount(1);
   for (const manualApplyButton of await manualApplyButtons.all()) {
@@ -481,8 +484,8 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   expect(requestedSourceName).toBe("手动选择的 Box");
   expect(requestedBoxSource).toBe("maa");
   expect(Array.isArray(requestedOperbox)).toBe(true);
-  expect(requestedOperbox).toHaveLength(425);
-  expect(new Set((requestedOperbox as Array<{ id: string }>).map((operator) => operator.id)).size).toBe(425);
+  expect(requestedOperbox).toHaveLength(fullOperatorCount);
+  expect(new Set((requestedOperbox as Array<{ id: string }>).map((operator) => operator.id)).size).toBe(fullOperatorCount);
   expect((requestedOperbox as Array<{ own: boolean }>).every((operator) => operator.own)).toBe(true);
   const persisted = await page.evaluate(() => JSON.parse(
     window.localStorage.getItem("arknights-infra-calc-session-v5") ?? "{}"
@@ -490,7 +493,7 @@ test("setup exposes and persists only worker-supported rotation profiles", async
   expect(persisted.rotationProfile).toBe("abc_12_12_12");
   expect(persisted.sourceName).toBe("手动选择的 Box");
   expect(persisted.boxSource).toBe("maa");
-  expect(persisted.operbox).toHaveLength(425);
+  expect(persisted.operbox).toHaveLength(fullOperatorCount);
 });
 
 test("layout level controls clamp edits and expose the power-safe 342 defaults", async ({ page }) => {


### PR DESCRIPTION
## 问题

上游目录从 425 名增长到 429 名后，Chromium E2E 仍硬编码旧数量，导致发布质量门禁失败。

## 修复

- 从已生成的 arkntools 来源清单动态读取干员总数。
- 界面计数、API 请求和本地持久化断言共用同一来源，后续上游增员不再需要手改数量。

## 验证

- 全新 Next.js 开发服务上运行目标 Chromium E2E：1/1 通过。
- 验证界面显示 429、请求提交 429、持久化 429。
- ESLint 通过。
- TypeScript `--noEmit` 通过。
- `git diff --check` 通过。