### PR TITLE
fix: 修复手动排班首屏包预算回归

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -150,16 +150,17 @@ test("CI enforces route and document preload JavaScript budgets after building",
   assert.equal(packageJson.scripts["check:bundle-budget"], "node scripts/check-bundle-budget.mjs");
   assert.match(workflow, /Build standalone application and worker[\s\S]+Release output checks[\s\S]+npm run check:bundle-budget/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_167_000/);
-  assert.match(budgetCheck, /MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000/);
-  assert.match(budgetCheck, /MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_632_000/);
+  assert.match(budgetCheck, /MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_203_000/);
+  assert.match(budgetCheck, /MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_642_000/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000/);
-  assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000/);
+  assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_316_000/);
   assert.match(budgetCheck, /MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000/);
   assert.match(budgetCheck, /MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 422_000/);
   assert.match(budgetCheck, /const sklandEnabled = sklandRoute\.firstLoadChunkPaths\.some/);
-  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_572_000/);
+  assert.match(budgetCheck, /MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_582_000/);
+  assert.match(budgetCheck, /MAX_MANUAL_ROUTE_INITIAL_JS_BYTES = 1_602_000/);
   assert.match(budgetCheck, /MAX_DOCUMENT_INITIAL_JS_FILES = 18/);
-  assert.match(budgetCheck, /WORKBENCH_ROUTES = \["\/", "\/training", "\/skills", "\/skland", "\/account"\]/);
+  assert.match(budgetCheck, /WORKBENCH_ROUTES = \["\/", "\/manual", "\/training", "\/skills", "\/skland", "\/account"\]/);
   assert.match(budgetCheck, /firstLoadUncompressedJsBytes/);
   assert.match(budgetCheck, /\.next\/server\/app\/index\.html/);
   assert.match(budgetCheck, /gzipSync/);
@@ -486,6 +487,9 @@ test("heavy account, operator, and scrollbar modules stay behind runtime boundar
 
   assert.match(app, /useWebsiteSession/);
   assert.doesNotMatch(app, /authClient\.useSession/);
+  assert.match(app, /await import\("\.\/manual-schedule"\)/);
+  assert.match(app, /from "\.\/manual-schedule-config"/);
+  assert.doesNotMatch(app, /import \{\s*createManualScheduleDraftFromCalculator/);
   assert.doesNotMatch(schedule, /operatorPresentationFor/);
   assert.doesNotMatch(components, /from "@\/operatorPortraits"/);
   assert.match(scrollbar, /import\("overlayscrollbars"\)/);

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -7,20 +7,22 @@ import { gzipSync } from "node:zlib";
 // The calculator keeps its always-visible board in the initial graph. Secondary workbench
 // views have independent route chunks and may carry their own datasets without joining `/`.
 const MAX_SKLAND_DISABLED_ROUTE_INITIAL_JS_BYTES = 1_167_000;
-// The language switch and compact bilingual shell copy are part of the initial graph;
-// full-page translation catalogs stay in their on-demand route chunks. Keep roughly
-// 8 KB of raw headroom over the verified disabled and enabled production builds.
-const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_191_000;
+// The language switch, protected manual-scheduling entry, and compact bilingual shell copy
+// are part of the initial graph; the full editor and schedule conversion logic stay in
+// on-demand chunks. Keep roughly 8 KB of raw headroom over the verified enabled build.
+const MAX_SKLAND_ENABLED_ROUTE_INITIAL_JS_BYTES = 1_203_000;
 // Task progress UI and training tooltips add intentional code to secondary workbench routes.
-// Keep the ceiling narrow enough to flag unrelated bundle growth.
-const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_572_000;
-const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_632_000;
+// The manual editor owns a larger independent page chunk, so track it separately while
+// keeping each ceiling narrow enough to flag unrelated bundle growth.
+const MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES = 1_582_000;
+const MAX_MANUAL_ROUTE_INITIAL_JS_BYTES = 1_602_000;
+const MAX_SKLAND_ROUTE_INITIAL_JS_BYTES = 1_642_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_JS_BYTES = 1_280_000;
-const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_304_000;
+const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_JS_BYTES = 1_316_000;
 const MAX_SKLAND_DISABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 416_000;
 const MAX_SKLAND_ENABLED_DOCUMENT_INITIAL_GZIP_JS_BYTES = 422_000;
 const MAX_DOCUMENT_INITIAL_JS_FILES = 18;
-const WORKBENCH_ROUTES = ["/", "/training", "/skills", "/skland", "/account"];
+const WORKBENCH_ROUTES = ["/", "/manual", "/training", "/skills", "/skland", "/account"];
 const statsUrl = new URL("../.next/diagnostics/route-bundle-stats.json", import.meta.url);
 const documentUrl = new URL("../.next/server/app/index.html", import.meta.url);
 const buildRootUrl = new URL("../.next/", import.meta.url);
@@ -53,7 +55,9 @@ for (const route of WORKBENCH_ROUTES.slice(1)) {
   assert.ok(routeStats, `route bundle stats do not contain the ${route} route`);
   const maxSecondaryRouteInitialJsBytes = route === "/skland" && sklandEnabled
     ? MAX_SKLAND_ROUTE_INITIAL_JS_BYTES
-    : MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES;
+    : route === "/manual"
+      ? MAX_MANUAL_ROUTE_INITIAL_JS_BYTES
+      : MAX_SECONDARY_ROUTE_INITIAL_JS_BYTES;
   assert.ok(
     routeStats.firstLoadUncompressedJsBytes <= maxSecondaryRouteInitialJsBytes,
     `${route} initial uncompressed JavaScript is ${routeStats.firstLoadUncompressedJsBytes} bytes, exceeding the ${maxSecondaryRouteInitialJsBytes} byte budget`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,13 +67,10 @@ import {
 import { normalizeOperboxEntries } from "./operbox-normalization";
 import { upgradeSimulationBoxSource } from "./upgrade-simulation";
 import {
-  createManualScheduleDraftFromCalculator,
   DEFAULT_MANUAL_SHIFT_DURATIONS,
   MANUAL_SCHEDULE_STORAGE_KEY,
-  persistManualScheduleDraft,
-  reconcileManualScheduleDraft,
-  type ManualScheduleDraft,
-} from "./manual-schedule";
+} from "./manual-schedule-config";
+import type { ManualScheduleDraft } from "./manual-schedule";
 import { effectiveFiammettaSetting, resolvePlanPresentationLayout } from "./plan-presentation";
 import {
   applyLocalLayoutPatch,
@@ -1166,11 +1163,16 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     downloadJson("arknights-infra-schedule-maa.json", result.maa);
   }
 
-  function handleEditManualSchedule() {
+  async function handleEditManualSchedule() {
     if (!scheduleResult) {
       navigateToPage("manual");
       return;
     }
+    const {
+      createManualScheduleDraftFromCalculator,
+      persistManualScheduleDraft,
+      reconcileManualScheduleDraft,
+    } = await import("./manual-schedule");
     const resultDurations = scheduleResult.rotation.shifts
       .map((shift) => shift.duration_hours)
       .filter((duration) => Number.isFinite(duration) && duration > 0);

--- a/src/manual-schedule-config.ts
+++ b/src/manual-schedule-config.ts
@@ -1,0 +1,4 @@
+export const MANUAL_SCHEDULE_STORAGE_KEY = "arknights-infra-manual-schedule-v1";
+export const DEFAULT_MANUAL_SHIFT_DURATIONS = [12, 6, 6] as const;
+export const MIN_MANUAL_SHIFT_COUNT = 1;
+export const MAX_MANUAL_SHIFT_COUNT = 12;

--- a/src/manual-schedule.ts
+++ b/src/manual-schedule.ts
@@ -9,11 +9,19 @@ import type {
   RoomKind,
   TrainingRoomShift,
 } from "./types.ts";
+import {
+  DEFAULT_MANUAL_SHIFT_DURATIONS,
+  MANUAL_SCHEDULE_STORAGE_KEY,
+  MAX_MANUAL_SHIFT_COUNT,
+  MIN_MANUAL_SHIFT_COUNT,
+} from "./manual-schedule-config.ts";
 
-export const MANUAL_SCHEDULE_STORAGE_KEY = "arknights-infra-manual-schedule-v1";
-export const DEFAULT_MANUAL_SHIFT_DURATIONS = [12, 6, 6] as const;
-export const MIN_MANUAL_SHIFT_COUNT = 1;
-export const MAX_MANUAL_SHIFT_COUNT = 12;
+export {
+  DEFAULT_MANUAL_SHIFT_DURATIONS,
+  MANUAL_SCHEDULE_STORAGE_KEY,
+  MAX_MANUAL_SHIFT_COUNT,
+  MIN_MANUAL_SHIFT_COUNT,
+} from "./manual-schedule-config.ts";
 
 export interface ManualRoomAssignment {
   operators: Array<string | null>;


### PR DESCRIPTION
## Summary

- move manual-schedule conversion and persistence helpers behind the existing click-time dynamic import boundary
- keep only the small storage key and default-duration constants in the shared workbench shell
- update the intentional bundle ceilings with about 8 KB of raw headroom for the new protected manual-scheduling entry
- add `/manual` to the route budget audit with its own narrow ceiling and lock the lazy-loading boundary in the build-tooling test

## Root cause

The #154 post-merge build compiled successfully, but the Skland-enabled `/` route reached 1,200,445 uncompressed JavaScript bytes against the previous 1,191,000-byte ceiling. The manual-schedule conversion module had joined the shared initial graph.

After splitting the heavy logic, `/` is 1,194,446 bytes. The remaining increase is the intentional protected entry and shared navigation state. The adjusted 1,203,000-byte ceiling retains roughly 8 KB of headroom rather than masking future unrelated growth.

## Verification

- `npm test` — 364 main tests + 2 module-mock tests passed
- targeted ESLint and `git diff --check` passed
- Skland-enabled production build passed
- `npm run check:bundle-budget` passed:
  - `/`: 1,194,446 / 1,203,000 raw bytes
  - document preload: 17 / 18 files, 1,307,040 / 1,316,000 raw bytes
  - gzip: 417,965 / 422,000 bytes
  - manual editor/conversion remains outside the initial application graph
- `npx playwright test e2e/manual-schedule.spec.ts --project=chromium --workers=1` — 6/6 passed
- public repository hygiene passed

Follow-up to #154 and the failed build job in workflow run 33842452842.
