### PR TITLE
feat: clarify schedule editing and unify manual controls

### DIFF
--- a/e2e/manual-operbox-rarity.spec.ts
+++ b/e2e/manual-operbox-rarity.spec.ts
@@ -22,7 +22,14 @@ async function openPicker(page: Page, mode: "manual" | "upgrade", mobile: boolea
   await seedV4Session(page, planData, { operbox: ownedBox, boxSource: "maa" });
   await gotoStable(page, "/");
   if (mode === "upgrade") {
-    await page.getByRole("button", { name: "调整练度", exact: true }).click();
+    if (mobile) {
+      await page.getByRole("button", { name: "调整方案", exact: true }).click();
+      await page.getByRole("dialog", { name: "调整当前方案" })
+        .getByRole("button", { name: /修改练度并重新计算/ })
+        .click();
+    } else {
+      await page.getByRole("button", { name: "修改练度并重算", exact: true }).click();
+    }
   } else {
     if (mobile) await page.locator("[data-calculator-more-tools] summary").click();
     await page.getByRole("button", { name: "配置Box与布局", exact: true }).filter({ visible: true }).click();
@@ -36,21 +43,23 @@ async function openPicker(page: Page, mode: "manual" | "upgrade", mobile: boolea
 }
 
 async function chooseRarity(picker: Locator, rarity: number | "all") {
-  const button = picker.getByRole("button", { name: rarity === "all" ? "全部" : `${rarity} 星干员`, exact: true });
-  await button.click();
-  await expect(button).toHaveAttribute("aria-pressed", "true");
+  const tab = picker.getByRole("tablist", { name: "星级筛选", exact: true })
+    .getByRole("tab", { name: rarity === "all" ? "全部" : `${rarity} 星干员`, exact: true });
+  await tab.click();
+  await expect(tab).toHaveAttribute("aria-selected", "true");
 }
 
 async function assertFilterGeometry(picker: Locator) {
-  const filter = picker.getByRole("group", { name: "星级筛选", exact: true });
+  const filter = picker.getByRole("tablist", { name: "星级筛选", exact: true });
   await filter.scrollIntoViewIfNeeded();
   const geometry = await filter.evaluate((element) => {
     const row = element.closest<HTMLElement>("[data-manual-operbox-rarity-filter]");
     const label = row?.querySelector<HTMLElement>(":scope > div:first-child");
     return {
+      viewportWidth: window.innerWidth,
       labelCenter: label ? label.getBoundingClientRect().top + label.getBoundingClientRect().height / 2 : null,
-      options: Array.from(element.querySelectorAll("button")).map((button) => {
-        const rect = button.getBoundingClientRect();
+      options: Array.from(element.querySelectorAll('[role="tab"]')).map((tab) => {
+        const rect = tab.getBoundingClientRect();
         return { width: rect.width, height: rect.height, top: rect.top, center: rect.top + rect.height / 2 };
       }),
     };
@@ -59,10 +68,22 @@ async function assertFilterGeometry(picker: Locator) {
   expect(new Set(geometry.options.map((button) => Math.round(button.top))).size).toBe(1);
   expect(geometry.labelCenter).not.toBeNull();
   expect(geometry.options[0]?.center).toBeCloseTo(geometry.labelCenter ?? 0, 0);
-  for (const button of geometry.options) {
-    expect(button.width).toBeGreaterThanOrEqual(44);
-    expect(button.height).toBeGreaterThanOrEqual(44);
+  for (const tab of geometry.options) {
+    expect(tab.width).toBeGreaterThanOrEqual(geometry.viewportWidth < 640 ? 44 : 28);
+    expect(tab.height).toBeGreaterThanOrEqual(geometry.viewportWidth < 640 ? 44 : 24);
   }
+}
+
+async function assertUpgradeFilterBar(picker: Locator) {
+  const filterBar = picker.locator("[data-upgrade-operbox-filters]");
+  const geometry = await filterBar.getByRole("tablist").evaluateAll((tablists) => tablists.map((tablist) => ({
+    label: tablist.getAttribute("aria-label"),
+    top: Math.round(tablist.getBoundingClientRect().top),
+  })));
+  expect(geometry.map(({ label }) => label)).toEqual(["干员列表范围", "排班班次", "星级筛选", "职业筛选"]);
+  expect(geometry[0]?.top).toBe(geometry[1]?.top);
+  expect(geometry[2]?.top).toBe(geometry[3]?.top);
+  expect(geometry[2]?.top).toBeGreaterThan(geometry[0]?.top ?? 0);
 }
 
 for (const mobile of [false, true]) {
@@ -73,6 +94,15 @@ for (const mobile of [false, true]) {
     test("manual Box combines rarity, search and ownership without losing hidden selections", async ({ page }, testInfo) => {
       test.slow();
       const picker = await openPicker(page, "manual", mobile);
+      await expect(picker).not.toContainText("持有与精英阶段会同步用于排班和调整练度。");
+      const professionFilter = picker.getByRole("tablist", { name: "职业筛选", exact: true });
+      await professionFilter.getByRole("tab", { name: "术师", exact: true }).click();
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
+      await expect(picker.getByRole("heading", { name: "阿米娅", exact: true })).toBeVisible();
+      await professionFilter.getByRole("tab", { name: "近卫", exact: true }).click();
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await professionFilter.getByRole("tab", { name: "全部", exact: true }).click();
+      await picker.getByRole("textbox", { name: "搜索干员" }).fill("");
       for (const rarity of [1, 2, 3, 4, 5, 6]) {
         await chooseRarity(picker, rarity);
         const count = Math.min(48, roster.filter((operator) => operator.rarity === rarity).length);
@@ -109,6 +139,13 @@ for (const mobile of [false, true]) {
     test("upgrade simulation combines rarity and schedule scope and submits the complete Box", async ({ page }, testInfo) => {
       test.slow();
       const picker = await openPicker(page, "upgrade", mobile);
+      await assertUpgradeFilterBar(picker);
+      const professionFilter = picker.getByRole("tablist", { name: "职业筛选", exact: true });
+      await professionFilter.getByRole("tab", { name: "术师", exact: true }).click();
+      await expect(picker.getByRole("heading", { name: "阿米娅", exact: true })).toBeVisible();
+      await professionFilter.getByRole("tab", { name: "近卫", exact: true }).click();
+      await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
+      await professionFilter.getByRole("tab", { name: "全部", exact: true }).click();
       await chooseRarity(picker, 6);
       await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
       await picker.getByRole("tab", { name: /未进排班/ }).click();
@@ -123,14 +160,14 @@ for (const mobile of [false, true]) {
       await picker.getByRole("textbox", { name: "搜索干员" }).fill("银灰");
       await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
       await picker.getByRole("textbox", { name: "搜索干员" }).fill("");
-      await picker.getByRole("button", { name: /^第一班/ }).click();
+      await picker.getByRole("tab", { name: /^第一班/ }).click();
       await expect(picker.locator("article")).toHaveCount(1);
-      await expect(picker.getByRole("button", { name: /^第一班/ })).toHaveAttribute("data-manual-operbox-filter-option", "");
+      await expect(picker.getByRole("tab", { name: /^第一班/ })).toHaveAttribute("data-slot", "tabs-trigger");
       await chooseRarity(picker, 6);
-      await expect(picker.getByRole("button", { name: "6 星干员", exact: true })).toHaveAttribute("data-manual-operbox-filter-option", "");
+      await expect(picker.getByRole("tab", { name: "6 星干员", exact: true })).toHaveAttribute("data-slot", "tabs-trigger");
       await expect(picker.getByText("没有符合条件的干员。", { exact: true })).toBeVisible();
       await chooseRarity(picker, 5);
-      await expect(picker.getByRole("button", { name: /^第一班/ })).toHaveAttribute("aria-pressed", "true");
+      await expect(picker.getByRole("tab", { name: /^第一班/ })).toHaveAttribute("aria-selected", "true");
       await assertFilterGeometry(picker);
       await page.screenshot({ path: testInfo.outputPath(`upgrade-rarity-${device}.png`) });
 
@@ -142,12 +179,12 @@ for (const mobile of [false, true]) {
         await pending;
         await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ success: true, data: planData, requestId }) });
       });
-      await picker.getByRole("button", { name: "按调整重新试算", exact: true }).first().click();
+      await picker.getByRole("button", { name: "保存练度并重新计算", exact: true }).first().click();
       try {
         await expect.poll(() => submitted.length).toBe(roster.length);
         expect(submitted.filter((operator) => operator.own).map((operator) => [operator.name, operator.elite])).toEqual([["银灰", 2], ["阿米娅", 1]]);
-        for (const button of await picker.getByRole("group", { name: "星级筛选", exact: true }).getByRole("button").all()) {
-          await expect(button).toBeDisabled();
+        for (const tab of await picker.getByRole("tablist", { name: "星级筛选", exact: true }).getByRole("tab").all()) {
+          await expect(tab).toBeDisabled();
         }
       } finally {
         releasePlan();
@@ -168,24 +205,25 @@ for (const mode of ["manual", "upgrade"] as const) {
     await page.addInitScript(() => localStorage.setItem("infra-demo-locale", "en"));
     await gotoStable(page, "/");
     if (mode === "upgrade") {
-      await page.getByRole("button", { name: "Adjust progression", exact: true }).click();
+      await page.getByRole("button", { name: "Modify progression & recalculate", exact: true }).click();
     } else {
       await page.getByRole("button", { name: "Configure BOX and base", exact: true }).filter({ visible: true }).click();
       await page.getByRole("button", { name: "Change", exact: true }).click();
       await page.getByRole("tab", { name: "Manual", exact: true }).click();
     }
     const picker = page.locator("[data-manual-operbox-picker]");
-    const filter = picker.getByRole("group", { name: "Filter by rarity", exact: true });
-    const all = filter.getByRole("button", { name: "All", exact: true });
+    const filter = picker.getByRole("tablist", { name: "Filter by rarity", exact: true });
+    const all = filter.getByRole("tab", { name: "All", exact: true });
     await all.focus();
     await all.press("ArrowRight");
-    const sixStar = filter.getByRole("button", { name: "6-star operators", exact: true });
+    const sixStar = filter.getByRole("tab", { name: "6-star operators", exact: true });
     await expect(sixStar).toBeFocused();
     await sixStar.press("Space");
-    await expect(sixStar).toHaveAttribute("aria-pressed", "true");
+    await expect(sixStar).toHaveAttribute("aria-selected", "true");
     if (mode === "upgrade") await expect(picker.getByText("No matching operators.", { exact: true })).toBeVisible();
     else await expect(picker.locator("article")).toHaveCount(48);
-    await sixStar.press("Space");
-    await expect(all).toHaveAttribute("aria-pressed", "true");
+    await sixStar.press("ArrowLeft");
+    await all.press("Space");
+    await expect(all).toHaveAttribute("aria-selected", "true");
   });
 }

--- a/e2e/manual-schedule.spec.ts
+++ b/e2e/manual-schedule.spec.ts
@@ -37,7 +37,7 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test("calculator result toolbar keeps manual editing next to MAA export", async ({ page }) => {
+test("sidebar resumes an existing manual draft without invoking the solver", async ({ page }) => {
   let planRequests = 0;
   await page.route("**/api/plan", (route) => {
     planRequests += 1;
@@ -59,12 +59,10 @@ test("calculator result toolbar keeps manual editing next to MAA export", async 
       }],
     }));
   });
-  const desktopActions = page.locator('[data-calculator-export-actions="desktop"]');
-  await expect(desktopActions.getByRole("button", { name: "手动修改排班" })).toBeEnabled();
-  await expect(desktopActions.getByRole("button", { name: "导出到 MAA" })).toBeDisabled();
-  await desktopActions.getByRole("button", { name: "手动修改排班" }).click();
+  await expect(page.locator('[data-calculator-export-actions="desktop"]')).toHaveCount(0);
+  await page.getByRole("button", { name: "手动排班", exact: true }).click();
   await expect(page).toHaveURL(/\/manual$/);
-  await expect(page.getByRole("tab", { name: /班次 1.*9h/ })).toBeVisible();
+  await expect(page.getByRole("tab", { name: /第 1 班.*9h/ })).toBeVisible();
   await expect(page.locator('[data-room-title="贸易站 1"] [data-operator-identity="阿米娅"]')).toBeVisible();
   expect(planRequests).toBe(0);
 });
@@ -107,7 +105,7 @@ test("calculator onboarding does not expose manual editing", async ({ page }) =>
   await page.goto("/");
   const startPanel = page.locator("[data-calculator-start-panel]");
   await expect(startPanel).toBeVisible();
-  await expect(startPanel.getByRole("button", { name: "手动修改排班" })).toHaveCount(0);
+  await expect(startPanel.getByRole("button", { name: "基于当前方案编辑" })).toHaveCount(0);
 });
 
 test("calculator converts a solved schedule into editable manual assignments", async ({ page }) => {
@@ -131,11 +129,68 @@ test("calculator converts a solved schedule into editable manual assignments", a
   });
   const desktopActions = page.locator('[data-calculator-export-actions="desktop"]');
   await expect(desktopActions.getByRole("button", { name: "导出到 MAA" })).toBeEnabled();
-  await desktopActions.getByRole("button", { name: "手动修改排班" }).click();
+  await desktopActions.getByRole("button", { name: "基于当前方案编辑" }).click();
 
   await expect(page).toHaveURL(/\/manual$/);
-  await expect(page.getByRole("tab", { name: /班次 1.*12h/ })).toBeVisible();
+  await expect(page.locator('[data-manual-draft-source="baseline"]')).toContainText("基于「原方案」创建");
+  await expect(page.getByRole("tab", { name: /第 1 班.*12h/ })).toBeVisible();
   await expect(page.locator('[data-room-title="加工站"] [data-operator-identity="阿米娅"]')).toBeVisible();
+});
+
+test("calculator protects a different manual draft before replacing it from a result", async ({ page }) => {
+  await page.addInitScript((result) => {
+    const key = "arknights-infra-calc-session-v5";
+    const session = JSON.parse(window.localStorage.getItem(key) ?? "null");
+    window.localStorage.setItem(key, JSON.stringify({ ...session, result }));
+  }, planData);
+
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  await page.goto("/");
+  await expect(page.locator('[data-workbench-hydrated="true"]')).toBeVisible();
+  await page.evaluate(() => {
+    window.localStorage.setItem("arknights-infra-manual-schedule-v1", JSON.stringify({
+      version: 2,
+      activeShift: 0,
+      fiammettaEnabled: false,
+      shifts: [{
+        durationHours: 9,
+        fiammettaTarget: null,
+        rooms: { trade_1: { operators: ["阿米娅", null, null] } },
+      }],
+    }));
+  });
+
+  const editCurrentPlan = page.locator('[data-calculator-plan-actions="desktop"]').getByRole("button", { name: "基于当前方案编辑" });
+  await editCurrentPlan.click();
+  const confirmation = page.getByRole("dialog", { name: "替换现有手动草稿？" });
+  await expect(confirmation).toContainText("基于「原方案」创建手动排班");
+  await confirmation.getByRole("button", { name: "保留现有草稿" }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect.poll(() => page.evaluate(() => JSON.parse(
+    window.localStorage.getItem("arknights-infra-manual-schedule-v1") ?? "null",
+  )?.shifts?.[0]?.durationHours)).toBe(9);
+
+  await editCurrentPlan.click();
+  await confirmation.getByRole("button", { name: "替换并进入" }).click();
+  await expect(page).toHaveURL(/\/manual$/);
+  await expect(page.locator('[data-manual-draft-source="baseline"]')).toContainText("基于「原方案」创建");
+});
+
+test("mobile result actions explain both adjustment paths", async ({ page }) => {
+  await page.addInitScript((result) => {
+    const key = "arknights-infra-calc-session-v5";
+    const session = JSON.parse(window.localStorage.getItem(key) ?? "null");
+    window.localStorage.setItem(key, JSON.stringify({ ...session, result }));
+  }, planData);
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await expect(page.locator('[data-workbench-hydrated="true"]')).toBeVisible();
+  await page.getByRole("button", { name: "调整方案", exact: true }).click();
+  const actions = page.getByRole("dialog", { name: "调整当前方案" });
+  await expect(actions).toContainText("当前正在查看「原方案」");
+  await expect(actions.getByRole("button", { name: /修改练度并重新计算/ })).toBeVisible();
+  await expect(actions.getByRole("button", { name: /基于当前方案手动编辑/ })).toBeVisible();
 });
 
 test("manual scheduling configures independent shifts, moves conflicts and enables dorm autofill", async ({ page }) => {
@@ -158,6 +213,15 @@ test("manual scheduling configures independent shifts, moves conflicts and enabl
   await expect(page.getByRole("tab", { name: /Shift 1.*12h/ })).toBeVisible();
   await page.getByRole("button", { name: "中文", exact: true }).click();
 
+  const scheduleToolbar = page.locator("[data-schedule-toolbar]");
+  const layoutTabs = scheduleToolbar.getByRole("tablist", { name: "排班布局切换" });
+  const shiftTabs = scheduleToolbar.locator("[data-manual-shift-actions] [data-shift-tabs]");
+  await expect(layoutTabs).toHaveAttribute("data-slot", "tabs-list");
+  await expect(shiftTabs).toHaveAttribute("data-slot", "tabs-list");
+  const [layoutTabsBox, shiftTabsBox] = await Promise.all([layoutTabs.boundingBox(), shiftTabs.boundingBox()]);
+  expect(shiftTabsBox?.y).toBeCloseTo(layoutTabsBox?.y ?? 0, 0);
+  await expect(shiftTabs.getByRole("tab", { name: /第 1 班.*12h/ })).toBeVisible();
+
   await page.getByRole("button", { name: "配置 Box 与布局" }).first().click();
   const setup = page.getByRole("dialog");
   await setup.getByRole("button", { name: "继续", exact: true }).click();
@@ -170,9 +234,18 @@ test("manual scheduling configures independent shifts, moves conflicts and enabl
   await setup.getByRole("button", { name: "继续", exact: true }).click();
   await setup.getByRole("button", { name: "完成", exact: true }).click();
 
-  await expect(page.getByRole("tab", { name: /班次 1.*10.5h/ })).toBeVisible();
-  await expect(page.locator("[data-manual-shift-tabs]").getByRole("tab")).toHaveCount(2);
-  await page.getByRole("button", { name: "选择换心情目标" }).click();
+  await expect(page.getByRole("tab", { name: /第 1 班.*10.5h/ })).toBeVisible();
+  await expect(page.locator("[data-manual-shift-actions] [data-shift-tabs]").getByRole("tab")).toHaveCount(2);
+  const manualShiftActions = page.locator("[data-manual-shift-actions]");
+  const moraleTarget = manualShiftActions.getByRole("button", { name: "选择换心情目标" });
+  const [moraleTargetBox, configuredShiftTabsBox] = await Promise.all([
+    moraleTarget.boundingBox(),
+    manualShiftActions.locator("[data-shift-tabs]").boundingBox(),
+  ]);
+  expect(moraleTargetBox?.x).toBeLessThan(configuredShiftTabsBox?.x ?? 0);
+  expect((moraleTargetBox?.y ?? 0) + (moraleTargetBox?.height ?? 0) / 2)
+    .toBeCloseTo((configuredShiftTabsBox?.y ?? 0) + (configuredShiftTabsBox?.height ?? 0) / 2, 0);
+  await moraleTarget.click();
   const fiammettaPicker = page.getByRole("dialog");
   await expect(fiammettaPicker.locator("[data-manual-operator-choice]").first().locator("img")).toBeVisible();
   await expect(fiammettaPicker.getByText(/精2 Lv\.60/).first()).toBeVisible();
@@ -190,7 +263,8 @@ test("manual scheduling configures independent shifts, moves conflicts and enabl
   await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toHaveCount(0);
   await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toBeVisible({ timeout: 2_000 });
   await fiammettaPicker.getByRole("button", { name: /锡兰/ }).click();
-  await expect(page.getByRole("button", { name: "换心情：锡兰" })).toBeVisible();
+  await expect(manualShiftActions.getByRole("button", { name: "换心情 锡兰" })).toBeVisible();
+  await expect(manualShiftActions.locator("[data-fiammetta-target-chip] img")).toBeVisible();
 
   const trade = page.locator('[data-room-title="贸易站 1"]');
   const factory = page.locator('[data-room-title="制造站 1"]');
@@ -232,7 +306,7 @@ test("manual scheduling configures independent shifts, moves conflicts and enabl
   await page.getByRole("dialog").getByRole("button", { name: "自动补位" }).click();
   await expect(dorm.locator('[data-operator-identity="autofill"]')).toHaveCount(5);
 
-  await page.getByRole("tab", { name: /班次 2.*6h/ }).click();
+  await page.getByRole("tab", { name: /第 2 班.*6h/ }).click();
   await expect(factory.locator('[data-operator-identity="阿米娅"]')).toHaveCount(0);
   expect(planRequests).toBe(0);
 

--- a/e2e/production-readiness-foundation.spec.ts
+++ b/e2e/production-readiness-foundation.spec.ts
@@ -118,7 +118,7 @@ test("the anonymous sample trial fetches and solves once before showing the sche
   await expect(page.locator("[data-anonymous-sample-trial]")).toHaveCount(0);
   await expect.poll(() => page.evaluate(() => window.localStorage.getItem("arknights-infra-calc-beta-onboarding-v1"))).toBe("completed");
 
-  const adjustmentTrigger = page.getByRole("button", { name: "调整练度", exact: true });
+  const adjustmentTrigger = page.getByRole("button", { name: "修改练度并重算", exact: true });
   await adjustmentTrigger.click();
   await expect(page.getByRole("dialog", { name: "登录网站账号" })).toBeVisible();
   await expect(page.locator("[data-upgrade-simulation-dialog]")).toHaveCount(0);

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -225,7 +225,7 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   await seedV4Session(page, planData, { boxSource: "maa" });
   await page.goto("/");
 
-  await page.getByRole("button", { name: "调整练度", exact: true }).click();
+  await page.getByRole("button", { name: "修改练度并重算", exact: true }).click();
   const adjustmentDialog = page.getByRole("dialog");
   const rosterScopeTabs = adjustmentDialog.getByRole("tablist", { name: "干员列表范围" });
   const scheduledTab = rosterScopeTabs.getByRole("tab", { name: /进入排班/ });
@@ -239,7 +239,7 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   await adjustmentDialog.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
   const adjustmentStage = adjustmentDialog.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" });
   await adjustmentStage.getByRole("radio", { name: "精1", exact: true }).click();
-  await adjustmentDialog.getByRole("button", { name: "按调整重新试算", exact: true }).click();
+  await adjustmentDialog.getByRole("button", { name: "保存练度并重新计算", exact: true }).click();
   const activity = page.locator('[data-slot="live-activity"]');
   await expect(activity).toHaveAttribute("data-activity-phase", "queued");
   await expect(activity).toBeVisible();
@@ -254,27 +254,27 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
 
   const scheduleVariantTabs = page.getByRole("tablist", { name: "排班方案切换" });
   await expect(scheduleVariantTabs).toHaveAttribute("data-slot", "tabs-list");
-  await expect(scheduleVariantTabs.getByRole("tab", { name: "调整练度方案", exact: true })).toHaveAttribute("aria-selected", "true");
+  await expect(scheduleVariantTabs.getByRole("tab", { name: "练度调整后", exact: true })).toHaveAttribute("aria-selected", "true");
   const scheduleViewControls = page.locator("[data-schedule-view-controls]");
   const scheduleLayoutTabs = scheduleViewControls.getByRole("tablist", { name: "排班布局切换" });
-  await expect(scheduleViewControls).toContainText("当前方案");
+  await expect(scheduleViewControls).toContainText("原方案");
   await expect(scheduleViewControls).toContainText("一图流布局");
   const [variantTabsBox, layoutTabsBox] = await Promise.all([
     scheduleVariantTabs.boundingBox(),
     scheduleLayoutTabs.boundingBox(),
   ]);
   expect(variantTabsBox?.y).toBeCloseTo(layoutTabsBox?.y ?? 0, 0);
-  await expect(page.getByText(/正在查看调整练度方案/)).toHaveCount(0);
+  await expect(page.getByText(/正在查看练度调整后方案/)).toHaveCount(0);
 
   const lmdProduction = page.locator('[data-daily-product="lmd-orders"] [data-animated-value="number"]');
   await expect(lmdProduction).toHaveAttribute("aria-label", "41,200");
   const lmdCalligraph = lmdProduction.locator("[data-calligraph]");
   await expect(lmdCalligraph).toBeVisible();
   await lmdCalligraph.evaluate((element) => element.setAttribute("data-animation-sentinel", "stable"));
-  await scheduleVariantTabs.getByRole("tab", { name: "当前方案", exact: true }).click();
+  await scheduleVariantTabs.getByRole("tab", { name: "原方案", exact: true }).click();
   await expect(lmdCalligraph).toHaveAttribute("data-animation-sentinel", "stable");
   await expect(lmdProduction).toHaveAttribute("aria-label", "34,254");
-  await scheduleVariantTabs.getByRole("tab", { name: "调整练度方案", exact: true }).click();
+  await scheduleVariantTabs.getByRole("tab", { name: "练度调整后", exact: true }).click();
   await expect(lmdCalligraph).toHaveAttribute("data-animation-sentinel", "stable");
   await expect(lmdProduction).toHaveAttribute("aria-label", "41,200");
 
@@ -308,8 +308,9 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   }
 
   await page.setViewportSize({ width: 1440, height: 1000 });
-  await page.locator('[data-calculator-export-actions="desktop"]').getByRole("button", { name: "手动修改排班" }).click();
+  await page.locator('[data-calculator-export-actions="desktop"]').getByRole("button", { name: "基于当前方案编辑" }).click();
   await expect(page).toHaveURL(/\/manual$/);
+  await expect(page.locator('[data-manual-draft-source="progression-adjusted"]')).toContainText("基于「练度调整后方案」创建");
   await expect(page.locator('[data-room-title="加工站"] [data-operator-identity="阿米娅"]')).toHaveCount(0);
 });
 
@@ -401,7 +402,15 @@ test("setup exposes and persists only worker-supported rotation profiles", async
     manualPicker.getByRole("button", { name: "全选最高精英", exact: true }),
     manualPicker.getByRole("button", { name: "清空选择", exact: true }),
   ];
-  await expect(manualActions).toHaveCSS("grid-template-columns", /.+ .+ .+/);
+  await expectSetupAction(manualActionButtons[0]);
+  await expectSetupAction(manualActionButtons[1]);
+  await expect(manualActionButtons[0]).toHaveAttribute("aria-pressed", "false");
+  await manualActionButtons[0].click();
+  await expect(manualActionButtons[0]).toHaveAttribute("aria-pressed", "true");
+  await manualActionButtons[0].click();
+  await expect(manualActionButtons[0]).toHaveAttribute("aria-pressed", "false");
+  await expect(manualActions).toHaveCSS("display", "flex");
+  await expect(manualActions).toHaveCSS("flex-wrap", "nowrap");
   const manualActionBoxes = await Promise.all(manualActionButtons.map((button) => button.boundingBox()));
   expect(new Set(manualActionBoxes.map((box) => Math.round(box?.y ?? -1))).size).toBe(1);
   const manualStageGroup = manualPicker.getByRole("radiogroup").first();
@@ -419,8 +428,22 @@ test("setup exposes and persists only worker-supported rotation profiles", async
     await expect(stageButton).toHaveCSS("height", "28px");
     await expect(stageButton).toHaveCSS("border-radius", "4px");
   }
-  await manualPicker.getByRole("button", { name: "全选最高精英", exact: true }).click();
-  await expect(manualPicker.getByText("已拥有 425 名", { exact: true })).toBeVisible();
+  const stagesBeforeAllMaximum = await manualPicker.getByRole("radiogroup").evaluateAll((groups) => groups.map((group) => {
+    const selected = group.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]');
+    return [group.getAttribute("aria-label"), selected?.textContent?.trim() ?? null];
+  }));
+  const ownedSummaryBeforeAllMaximum = await manualPicker.getByText(/^已拥有 \d+ 名$/).textContent();
+  await manualActionButtons[1].click();
+  await expect(manualActionButtons[1]).toHaveAttribute("aria-pressed", "true");
+  await expect(manualPicker.getByText(`已拥有 ${fullOperatorCount} 名`, { exact: true })).toBeVisible();
+  await manualActionButtons[1].click();
+  await expect(manualActionButtons[1]).toHaveAttribute("aria-pressed", "false");
+  await expect(manualPicker.getByText(ownedSummaryBeforeAllMaximum ?? "", { exact: true })).toBeVisible();
+  await expect.poll(() => manualPicker.getByRole("radiogroup").evaluateAll((groups) => groups.map((group) => {
+    const selected = group.querySelector<HTMLElement>('[role="radio"][aria-checked="true"]');
+    return [group.getAttribute("aria-label"), selected?.textContent?.trim() ?? null];
+  }))).toEqual(stagesBeforeAllMaximum);
+  await manualActionButtons[1].click();
   const manualApplyButtons = manualPicker.locator("[data-manual-operbox-apply]");
   await expect(manualApplyButtons).toHaveCount(1);
   for (const manualApplyButton of await manualApplyButtons.all()) {
@@ -634,9 +657,10 @@ test("calculator owns scheduling controls and training advice uses a single tech
   expect(controlOrder.some((label) => label.includes("全角色导入"))).toBe(false);
   const exportOrder = await page.locator("[data-calculator-export-actions]").locator("button").allTextContents();
   expect(exportOrder).toEqual([
-    expect.stringContaining("手动修改排班"),
+    expect.stringContaining("调整方案"),
     expect.stringContaining("导出到 MAA"),
-    expect.stringContaining("手动修改排班"),
+    expect.stringContaining("修改练度并重算"),
+    expect.stringContaining("基于当前方案编辑"),
     expect.stringContaining("导出到 MAA"),
   ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,9 @@ const IssueNoteModal = lazy(() => loadComponents().then((module) => ({ default: 
 const ProductChangeConfirmModal = lazy(() => loadComponents().then((module) => ({
   default: module.ProductChangeConfirmModal,
 })));
+const ManualDraftReplaceDialog = lazy(() => import("@/components/ManualDraftReplaceDialog").then((module) => ({
+  default: module.ManualDraftReplaceDialog,
+})));
 type ProductChange =
   | { type: "factory"; roomId: string; recipe: FactoryRecipe }
   | { type: "trade"; roomId: string; order: TradeOrder };
@@ -284,6 +287,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const [manualFiammettaEnabled, setManualFiammettaEnabled] = useState(false);
   const [manualShiftDurations, setManualShiftDurations] = useState<number[]>([...DEFAULT_MANUAL_SHIFT_DURATIONS]);
   const [manualDraftHandoff, setManualDraftHandoff] = useState<ManualScheduleDraft | null>(null);
+  const [pendingManualDraftReplacement, setPendingManualDraftReplacement] = useState<ManualScheduleDraft | null>(null);
   const [inputMode, setInputMode] = useState<"skland" | "maa" | "manual">(CLIENT_SKLAND_ENABLED ? "skland" : "maa");
   const [maaPaste, setMaaPaste] = useState("");
   const [sklandScheduleSnapshot, setSklandScheduleSnapshot] = useState<SklandScheduleSnapshot | null>(null);
@@ -1154,6 +1158,24 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     downloadJson("arknights-infra-schedule-maa.json", result.maa);
   }
 
+  function openManualScheduleDraft(draft: ManualScheduleDraft) {
+    setPendingManualDraftReplacement(null);
+    setManualShiftDurations(draft.shifts.map((shift) => shift.durationHours));
+    setManualFiammettaEnabled(draft.fiammettaEnabled);
+    setManualDraftHandoff(draft);
+    try {
+      window.localStorage.setItem(MANUAL_SCHEDULE_STORAGE_KEY, JSON.stringify(draft));
+    } catch {
+      // The manual page remains usable; it will surface its existing storage warning.
+    }
+    navigateToPage("manual");
+  }
+
+  function confirmManualDraftReplacement() {
+    if (!pendingManualDraftReplacement) return;
+    openManualScheduleDraft(pendingManualDraftReplacement);
+  }
+
   async function handleEditManualSchedule() {
     if (!scheduleResult) {
       navigateToPage("manual");
@@ -1161,7 +1183,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     }
     const {
       createManualScheduleDraftFromCalculator,
-      persistManualScheduleDraft,
+      loadManualScheduleDraft,
+      manualScheduleDraftContentEqual,
       reconcileManualScheduleDraft,
     } = await import("./manual-schedule");
     const resultDurations = scheduleResult.rotation.shifts
@@ -1174,17 +1197,27 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       fallbackDurations: durations,
       fiammettaEnabled: effectiveFiammettaEnabled,
       trainingRoomShifts: scheduleResult.trainingRoom?.shifts,
+      source: {
+        kind: "calculator",
+        variant: scheduleVariant === "trial" && upgradeComparison?.baseline === result
+          ? "progression-adjusted"
+          : "baseline",
+        createdAt: new Date().toISOString(),
+      },
     }), layout, operbox);
 
-    setManualShiftDurations(draft.shifts.map((shift) => shift.durationHours));
-    setManualFiammettaEnabled(draft.fiammettaEnabled);
-    setManualDraftHandoff(draft);
+    let existingDraft: ManualScheduleDraft | null = null;
     try {
-      persistManualScheduleDraft(window.localStorage, draft);
+      existingDraft = loadManualScheduleDraft(window.localStorage);
     } catch {
-      // The manual page remains usable; it will surface its existing storage warning.
+      existingDraft = null;
     }
-    navigateToPage("manual");
+    if (existingDraft && !manualScheduleDraftContentEqual(existingDraft, draft)) {
+      setPendingManualDraftReplacement(draft);
+      return;
+    }
+
+    openManualScheduleDraft(draft);
   }
 
   function clearIssueState() {
@@ -1905,6 +1938,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       fiammettaEnabled: effectiveManualFiammettaEnabled,
       initialDraft: accountCanUseCurrentBox ? manualDraftHandoff : null,
       onInitialDraftConsumed: () => setManualDraftHandoff(null),
+      onOpenCalculator: () => navigateToPage("calculator"),
       onShiftDurationsChange: setManualShiftDurations,
       onFiammettaEnabledChange: setManualFiammettaEnabled,
       onOpenSetup: handleManualSetup,
@@ -2154,6 +2188,11 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         busy={loading && Boolean(pendingProductChange)}
         onConfirm={() => void confirmScheduleProductChange()}
         onCancel={() => setPendingProductChange(null)}
+      /></Suspense> : null}
+      {pendingManualDraftReplacement ? <Suspense fallback={null}><ManualDraftReplaceDialog
+        draft={pendingManualDraftReplacement}
+        onCancel={() => setPendingManualDraftReplacement(null)}
+        onConfirm={confirmManualDraftReplacement}
       /></Suspense> : null}
       </SidebarInset>
     </SidebarProvider>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -733,12 +733,14 @@ export function RunButton({
 export function ShiftTabs({
   maaJson,
   rotation,
+  durations,
   active,
   closest,
   onChange,
 }: {
   maaJson?: MaaJson;
   rotation?: RotationJson;
+  durations?: readonly number[];
   active: number;
   closest?: number;
   onChange: (index: number) => void;
@@ -764,7 +766,12 @@ export function ShiftTabs({
       >
         {plans.map((plan, index) => {
           const shift = rotation?.shifts[index];
-          const label = en ? `Shift ${index + 1}${shift ? ` · ${compactNumber(shift.duration_hours)}h` : ""}` : shiftTabLabel(shift, index);
+          const durationHours = shift?.duration_hours ?? durations?.[index];
+          const label = en
+            ? `Shift ${index + 1}${durationHours !== undefined ? ` · ${compactNumber(durationHours)}h` : ""}`
+            : durationHours !== undefined
+              ? `第 ${index + 1} 班 · ${compactNumber(durationHours)}h`
+              : shiftTabLabel(shift, index);
           const originalTeamSummary = shiftTeamSummary(shift, rotation?.profile ?? DEFAULT_ROTATION_PROFILE);
           const teamSummary = en && originalTeamSummary ? originalTeamSummary.replaceAll("主力", "Main").replaceAll("替补", "Backup").replaceAll("上班", "working").replaceAll("休息", "resting") : originalTeamSummary;
           return (

--- a/src/components/FiammettaTargetChip.tsx
+++ b/src/components/FiammettaTargetChip.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { HeartPulse } from "lucide-react";
+
+import { demoOperatorName, useLanguageDemo } from "@/language-demo";
+
+export interface FiammettaTargetChipProps {
+  target?: string | null;
+  portrait?: string | null;
+  onClick?: () => void;
+}
+
+/** Shared morale-recovery target used beside schedule shift controls. */
+export function FiammettaTargetChip({ target, portrait, onClick }: FiammettaTargetChipProps) {
+  const { locale } = useLanguageDemo();
+  const en = locale === "en";
+  const displayTarget = target ? demoOperatorName(target, locale) : null;
+  const label = displayTarget
+    ? (en ? `Morale recovery ${displayTarget}` : `换心情 ${displayTarget}`)
+    : (en ? "Choose morale target" : "选择换心情目标");
+  const title = displayTarget
+    ? (en ? `Fiammetta restores ${displayTarget}` : `菲亚梅塔恢复 ${displayTarget}`)
+    : label;
+  const className = "flex h-7 items-center gap-1 rounded-[min(var(--radius-md),12px)] border border-[#016E65]/30 bg-[#016E65]/10 px-2.5 text-[0.8rem] text-[#016E65] shadow-xs max-sm:h-11";
+  const content = (
+    <>
+      <span className="size-5 shrink-0 overflow-hidden rounded-full border border-[#016E65]/25 bg-[#272A2B]">
+        {portrait && displayTarget
+          ? <img src={portrait} alt="" className="size-full object-cover" />
+          : <HeartPulse className="m-1 size-3 text-[#016E65]" />}
+      </span>
+      {displayTarget ? (
+        <span className="whitespace-nowrap"><span className="text-[#016E65]/70">{en ? "Morale recovery" : "换心情"}</span> {displayTarget}</span>
+      ) : (
+        <span className="whitespace-nowrap">{label}</span>
+      )}
+    </>
+  );
+
+  return onClick ? (
+    <button
+      type="button"
+      className={`${className} cursor-pointer outline-none transition-colors hover:bg-[#016E65]/15 focus-visible:ring-2 focus-visible:ring-[#FFD800] focus-visible:ring-offset-1`}
+      aria-label={label}
+      title={title}
+      data-fiammetta-target-chip
+      onClick={onClick}
+    >
+      {content}
+    </button>
+  ) : (
+    <span className={className} title={title} data-fiammetta-target-chip>
+      {content}
+    </span>
+  );
+}

--- a/src/components/ManualDraftReplaceDialog.tsx
+++ b/src/components/ManualDraftReplaceDialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ArrowRight, TriangleAlert } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useLanguageDemo } from "@/language-demo";
+import type { ManualScheduleDraft } from "@/manual-schedule";
+
+export function ManualDraftReplaceDialog({
+  draft,
+  onCancel,
+  onConfirm,
+}: {
+  draft: ManualScheduleDraft | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const { locale } = useLanguageDemo();
+  const en = locale === "en";
+  const sourceLabel = draft?.source?.variant === "progression-adjusted"
+    ? (en ? "progression-adjusted plan" : "练度调整后方案")
+    : (en ? "original plan" : "原方案");
+
+  return (
+    <Dialog open={Boolean(draft)} onOpenChange={(open) => { if (!open) onCancel(); }}>
+      <DialogContent className="gap-5 max-sm:px-4 sm:max-w-md sm:p-6" data-manual-draft-replace-dialog>
+        <DialogHeader className="gap-2 px-1 sm:px-2">
+          <div className="mb-1 flex size-10 items-center justify-center rounded-full bg-amber-100 text-amber-800" aria-hidden="true">
+            <TriangleAlert className="size-5" />
+          </div>
+          <DialogTitle className="text-lg font-semibold">
+            {en ? "Replace the existing manual draft?" : "替换现有手动草稿？"}
+          </DialogTitle>
+          <DialogDescription className="text-sm leading-6">
+            {en
+              ? `Creating a manual schedule from the ${sourceLabel} will replace your saved manual draft. This cannot be undone automatically.`
+              : `基于「${sourceLabel}」创建手动排班会替换你已保存的手动草稿，且无法自动撤销。`}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={onCancel}>
+            {en ? "Keep existing draft" : "保留现有草稿"}
+          </Button>
+          <Button type="button" onClick={onConfirm}>
+            {en ? "Replace and continue" : "替换并进入"}<ArrowRight />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/UpgradeSimulationDialog.tsx
+++ b/src/components/UpgradeSimulationDialog.tsx
@@ -37,6 +37,7 @@ export function UpgradeSimulationDialog({
   baseline,
   open,
   disabled = false,
+  showTrigger = true,
   onOpen,
   onOpenChange,
   onSimulate,
@@ -46,6 +47,7 @@ export function UpgradeSimulationDialog({
   baseline: PublicPlanData;
   open: boolean;
   disabled?: boolean;
+  showTrigger?: boolean;
   onOpen: () => void;
   onOpenChange: (open: boolean) => void;
   onSimulate: (trialOperbox: OperBoxEntry[]) => Promise<PublicPlanData>;
@@ -79,8 +81,8 @@ export function UpgradeSimulationDialog({
     if (pendingRef.current) return;
     if (!hasOperboxEliteStateChange(operbox, nextBox)) {
       setError(en
-        ? "Change at least one operator's ownership or elite stage before running the simulation."
-        : "请至少调整一名干员的精英化状态后再运行试算。");
+        ? "Change at least one operator's ownership or elite stage before recalculating."
+        : "请至少修改一名干员的持有或精英化状态后再重新计算。");
       return;
     }
 
@@ -96,7 +98,7 @@ export function UpgradeSimulationDialog({
     } catch (reason) {
       setError(reason instanceof Error
         ? reason.message
-        : en ? "Progression adjustment failed. Please try again later." : "调整练度试算失败，请稍后重试。");
+        : en ? "Recalculation with the updated progression failed. Please try again later." : "使用修改后的练度重新计算失败，请稍后重试。");
     } finally {
       pendingRef.current = false;
       setPending(false);
@@ -105,52 +107,55 @@ export function UpgradeSimulationDialog({
 
   return (
     <>
-      <Button type="button" variant="outline" size="sm" className="h-9 min-h-0 max-sm:h-11" disabled={disabled} onClick={onOpen}>
-        <FlaskConical />{en ? "Adjust progression" : "调整练度"}
-      </Button>
+      {showTrigger ? (
+        <Button type="button" variant="outline" size="sm" className="h-9 min-h-0 max-sm:h-11" disabled={disabled} onClick={onOpen}>
+          <FlaskConical />{en ? "Modify progression and recalculate" : "修改练度并重算"}
+        </Button>
+      ) : null}
       <Dialog open={open} onOpenChange={onOpenChange}>
         <DialogContent data-upgrade-simulation-dialog className="h-[min(720px,calc(100dvh-1rem))] max-w-[calc(100%-1rem)] grid-rows-[auto_minmax(0,1fr)] gap-0 overflow-hidden rounded-[24px] p-0 sm:max-w-[min(1060px,calc(100%-2rem))] sm:rounded-[32px]" aria-describedby="upgrade-simulation-description">
           <DialogHeader className="border-b border-border/70 px-4 py-3 pr-14 sm:flex-row sm:items-center sm:gap-5 sm:px-6 sm:py-4 sm:pr-16">
             <DialogTitle className="shrink-0 text-lg">
-              {en ? "Same-layout progression adjustment" : "同布局调整练度"}
+              {en ? "Modify progression and recalculate" : "修改练度并重新计算"}
             </DialogTitle>
             <DialogDescription id="upgrade-simulation-description" className="max-w-3xl leading-5">
               {en
-                ? "Adjust ownership or elite stage and solve with the same base layout. Successful changes sync to the manual BOX; the current schedule stays available for comparison."
-                : "调整干员持有或精英化状态，按当前布局重新求解；成功后同步到手动 BOX，当前班表保留用于对比。"}
+                ? "Update ownership or elite stage and recalculate with the same layout. After success, the current BOX is updated and the original plan remains available for comparison."
+                : "修改干员持有或精英化状态，并按当前布局重新计算；成功后会更新当前 BOX，同时保留原方案用于对比。"}
             </DialogDescription>
           </DialogHeader>
           <ScrollArea className="min-h-0" viewportClassName="overflow-x-hidden">
             <div className="px-4 py-3 sm:px-6 sm:py-4">
               <ManualOperboxPicker
                 compact
+                showProfessionFilter
                 operbox={operbox}
                 scheduledOperatorNames={scheduledOperatorNames}
                 scheduledOperatorShifts={scheduledOperatorShifts}
                 scheduledShiftCount={Math.min(3, baseline.maa.plans.length)}
-                title={en ? "Operators for this simulation" : "本次试算干员"}
+                title={en ? "Operators for this recalculation" : "本次重新计算使用的干员"}
                 description={en
-                  ? "Change at least one operator; this selection is shared with Schedule Settings."
-                  : "至少调整一名干员；这里的选择会与排班设置同步。"}
+                  ? "Change at least one operator. These updates are saved to the same BOX used by Schedule Settings."
+                  : "请至少修改一名干员；这里的修改会保存到排班设置使用的同一个 BOX。"}
                 applyLabel={pending
                   ? (en ? "Solving again…" : "正在重新求解…")
-                  : (en ? "Solve with adjustments" : "按调整重新试算")}
+                  : (en ? "Save progression and recalculate" : "保存练度并重新计算")}
                 applyDisabled={pending}
                 onApply={(entries) => void apply(entries)}
               />
               {pending ? (
                 <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
                   <Loader2 className="size-4 animate-spin" />
-                  {en ? "Solving again with the same layout…" : "正在按同一布局重新求解…"}
+                  {en ? "Recalculating with the updated progression and same layout…" : "正在使用修改后的练度按同一布局重新计算…"}
                 </p>
               ) : null}
               {error ? <p className="mt-3 border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive" role="alert">{error}</p> : null}
               {trial ? (
-                <section className="mt-3 flex flex-wrap items-center gap-3 border border-primary/25 bg-primary/5 px-3 py-2.5" aria-label={en ? "Progression adjustment result" : "调整练度结果"}>
+                <section className="mt-3 flex flex-wrap items-center gap-3 border border-primary/25 bg-primary/5 px-3 py-2.5" aria-label={en ? "Progression recalculation result" : "练度重新计算结果"}>
                   <div className="min-w-48 flex-1">
-                    <h3 className="font-semibold">{en ? "Simulation complete" : "试算完成"}</h3>
+                    <h3 className="font-semibold">{en ? "Recalculation complete" : "重新计算完成"}</h3>
                     <p className="mt-0.5 text-xs text-muted-foreground">
-                      {en ? "The manual BOX is synced. Switch between both schedules on the main screen." : "手动 BOX 已同步，可在主界面切换当前方案与调整练度方案。"}
+                      {en ? "The BOX is updated. Switch between the original and progression-adjusted plans on the main screen." : "当前 BOX 已更新，可在主界面切换原方案与练度调整后方案。"}
                     </p>
                   </div>
                   <dl className="grid w-full grid-cols-3 divide-x divide-primary/15 border border-primary/15 bg-background sm:w-auto">

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Download, Ellipsis, FlaskConical, HeartPulse, Keyboard, Loader2, PencilLine, Play, RefreshCw, Search, Settings2, X } from "lucide-react";
+import { ArrowRight, Download, Ellipsis, FlaskConical, Keyboard, Loader2, PencilLine, Play, RefreshCw, Search, Settings2, SlidersHorizontal, X } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { ScheduleBoard, ShiftTabs } from "@/components";
+import { FiammettaTargetChip } from "@/components/FiammettaTargetChip";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -20,7 +21,7 @@ import { PlanResultSummarySkeleton } from "@/components/PlanResultSummarySkeleto
 import type { FactoryRecipe, TradeOrder } from "@/blueprint";
 import { loadClientFeature } from "@/client-lazy-loader";
 import { cn } from "@/lib/utils";
-import { demoOperatorName, useLanguageDemo } from "@/language-demo";
+import { useLanguageDemo } from "@/language-demo";
 import type { ShiftDirection } from "@/motion";
 import { onboardingStepStatuses, shouldShowAnonymousSampleTrial } from "@/onboarding";
 import type { RoomRow } from "@/schedule";
@@ -403,6 +404,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
   }, [operbox]);
   const [shortcutGuideOpen, setShortcutGuideOpen] = useState(false);
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
+  const [planActionsOpen, setPlanActionsOpen] = useState(false);
   const [operatorQuery, setOperatorQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [shiftDirection, setShiftDirection] = useState<ShiftDirection>(0);
@@ -425,27 +427,46 @@ export function InfraCalculator(props: InfraCalculatorProps) {
     setShiftDirection(nextShift === activeShift ? 0 : nextShift > activeShift ? 1 : -1);
     onSetActiveShift(nextShift);
   };
-  const renderExportActions = (placement: "desktop" | "mobile") => (
+  const visibleVariantLabel = scheduleVariant === "trial" && upgradeComparison
+    ? (en ? "progression-adjusted plan" : "练度调整后方案")
+    : (en ? "original plan" : "原方案");
+  const openProgressionAction = () => {
+    setPlanActionsOpen(false);
+    onOpenUpgradeSimulation();
+  };
+  const openManualAction = () => {
+    setPlanActionsOpen(false);
+    onEditManualSchedule();
+  };
+  const renderPlanActions = (placement: "desktop" | "mobile") => placement === "desktop" ? (
     <div
-      className={placement === "desktop"
-        ? "hidden items-center gap-2 md:flex"
-        : "flex min-w-0 items-center justify-end gap-2"}
+      className="hidden flex-wrap items-center justify-end gap-2 md:flex"
       data-calculator-export-actions={placement}
+      data-calculator-plan-actions={placement}
     >
-      <Button
-        type="button"
-        size="sm"
-        variant="outline"
-        aria-label={en ? "Edit manually" : "手动修改排班"}
-        onClick={onEditManualSchedule}
-      >
-        <PencilLine />
-        <span className={placement === "mobile" ? "sr-only sm:not-sr-only" : undefined}>
-          {en ? "Edit manually" : "手动修改排班"}
-        </span>
+      {operbox ? (
+        <Button type="button" size="sm" variant="outline" onClick={onOpenUpgradeSimulation}>
+          <FlaskConical />{en ? "Modify progression & recalculate" : "修改练度并重算"}
+        </Button>
+      ) : null}
+      <Button type="button" size="sm" variant="outline" onClick={onEditManualSchedule}>
+        <PencilLine />{en ? "Edit the current plan" : "基于当前方案编辑"}<ArrowRight />
       </Button>
       <Button type="button" size="sm" variant="outline" disabled={!result?.maa} onClick={onDownloadMaa}>
         <Download />{en ? "Export to MAA" : "导出到 MAA"}
+      </Button>
+    </div>
+  ) : (
+    <div
+      className="flex min-w-0 flex-1 items-center justify-end gap-2"
+      data-calculator-export-actions={placement}
+      data-calculator-plan-actions={placement}
+    >
+      <Button type="button" size="sm" variant="outline" className="min-w-0 flex-1" onClick={() => setPlanActionsOpen(true)}>
+        <SlidersHorizontal />{en ? "Adjust plan" : "调整方案"}
+      </Button>
+      <Button type="button" size="sm" variant="outline" disabled={!result?.maa} onClick={onDownloadMaa}>
+        <Download />{en ? "Export MAA" : "导出到 MAA"}
       </Button>
     </div>
   );
@@ -584,19 +605,6 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                   </div>
                 ) : (
                   <div className="flex min-w-0 items-center justify-end gap-2 max-sm:justify-self-end">
-                    {operbox && scheduleResult ? (
-                      <Suspense fallback={<Button type="button" variant="outline" size="sm" className="h-9 min-h-0 max-sm:h-11" disabled><FlaskConical />{en ? "Adjust progression" : "调整练度"}</Button>}>
-                        <UpgradeSimulationDialog
-                          operbox={operbox}
-                          baseline={result ?? scheduleResult}
-                          open={upgradeSimulationOpen}
-                          onOpen={onOpenUpgradeSimulation}
-                          onOpenChange={onUpgradeSimulationOpenChange}
-                          onSimulate={onSimulateUpgrades}
-                          onTrialReady={onUpgradeTrialReady}
-                        />
-                      </Suspense>
-                    ) : null}
                     <RunButton canRun={canRun} hasBox={hasBox} plannerReady={plannerReady} requiresAccount={requiresAccount} runCooldownSeconds={runCooldownSeconds} onRun={onRun} />
                   </div>
                 )}
@@ -656,21 +664,16 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                   onValueChange={(value) => onScheduleVariantChange(value as "baseline" | "trial")}
                 >
                   <TabsList className="grid w-full grid-cols-2 sm:inline-flex sm:w-fit" aria-label={en ? "Schedule variant" : "排班方案切换"}>
-                    <TabsTrigger value="baseline">{en ? "Current plan" : "当前方案"}</TabsTrigger>
-                    <TabsTrigger value="trial">{en ? "Adjusted progression" : "调整练度方案"}</TabsTrigger>
+                    <TabsTrigger value="baseline">{en ? "Original plan" : "原方案"}</TabsTrigger>
+                    <TabsTrigger value="trial">{en ? "Progression adjusted" : "练度调整后"}</TabsTrigger>
                   </TabsList>
                 </Tabs>
               ) : undefined}
-              mobileActionsSlot={renderExportActions("mobile")}
+              mobileActionsSlot={scheduleResult ? renderPlanActions("mobile") : undefined}
               shiftInfoSlot={(
                 <div className="flex flex-wrap items-center justify-end gap-2 max-sm:w-full max-sm:justify-between" data-shift-actions>
                   {fiammettaTarget ? (
-                    <span className="flex h-7 items-center gap-1 rounded-[min(var(--radius-md),12px)] border border-[#016E65]/30 bg-[#016E65]/10 px-2.5 text-[0.8rem] text-[#016E65] shadow-xs max-sm:h-11" title={en ? `Fiammetta restores ${demoOperatorName(fiammettaTarget, locale)}` : `菲亚梅塔恢复 ${fiammettaTarget}`}>
-                      <span className="size-5 shrink-0 overflow-hidden rounded-full border border-[#016E65]/25 bg-[#272A2B]">
-                        {fiammettaPortrait ? <img src={fiammettaPortrait} alt="" className="size-full object-cover" /> : <HeartPulse className="m-1 size-3 text-[#016E65]" />}
-                      </span>
-                      <span className="whitespace-nowrap"><span className="text-[#016E65]/70">{en ? "Morale recovery" : "换心情"}</span> {demoOperatorName(fiammettaTarget, locale)}</span>
-                    </span>
+                    <FiammettaTargetChip target={fiammettaTarget} portrait={fiammettaPortrait} />
                   ) : null}
                   <ShiftTabs
                     maaJson={scheduleResult?.maa}
@@ -679,7 +682,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                     closest={closestComparison?.planIndex}
                     onChange={handleSetActiveShift}
                   />
-                  {renderExportActions("desktop")}
+                  {scheduleResult ? renderPlanActions("desktop") : null}
                 </div>
               )}
               onIssue={onMarkIssue}
@@ -714,6 +717,62 @@ export function InfraCalculator(props: InfraCalculatorProps) {
           </div>
         </aside>
       ) : null}
+      {operbox && scheduleResult ? (
+        <Suspense fallback={null}>
+          <UpgradeSimulationDialog
+            operbox={operbox}
+            baseline={result ?? scheduleResult}
+            open={upgradeSimulationOpen}
+            showTrigger={false}
+            onOpen={onOpenUpgradeSimulation}
+            onOpenChange={onUpgradeSimulationOpenChange}
+            onSimulate={onSimulateUpgrades}
+            onTrialReady={onUpgradeTrialReady}
+          />
+        </Suspense>
+      ) : null}
+      <Dialog open={planActionsOpen} onOpenChange={setPlanActionsOpen}>
+        <DialogContent className="gap-5 max-sm:bottom-0 max-sm:top-auto max-sm:max-w-none max-sm:translate-y-0 max-sm:rounded-t-[24px] max-sm:rounded-b-none sm:max-w-lg sm:p-6" data-plan-actions-dialog>
+          <DialogHeader className="gap-1.5 px-1 sm:px-2">
+            <DialogTitle className="text-lg font-semibold">{en ? "Adjust this plan" : "调整当前方案"}</DialogTitle>
+            <DialogDescription className="text-sm leading-6">
+              {en
+                ? `You are viewing the ${visibleVariantLabel}. Choose whether to change the inputs and recalculate, or edit this result directly.`
+                : `当前正在查看「${visibleVariantLabel}」。请选择修改输入并重新计算，或直接编辑这份结果。`}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2 px-1 sm:px-2">
+            {operbox ? (
+              <button
+                type="button"
+                className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
+                onClick={openProgressionAction}
+                data-plan-action="progression"
+              >
+                <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-[#313131] text-[#FFD800]" aria-hidden="true"><FlaskConical className="size-5" /></span>
+                <span className="min-w-0 flex-1">
+                  <strong className="block text-sm font-semibold">{en ? "Modify progression and recalculate" : "修改练度并重新计算"}</strong>
+                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">{en ? "Update the current BOX, keep the original plan, and create a comparison." : "更新当前 BOX，保留原方案，并生成一份可对比的新方案。"}</span>
+                </span>
+                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
+              onClick={openManualAction}
+              data-plan-action="manual"
+            >
+              <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-muted text-foreground" aria-hidden="true"><PencilLine className="size-5" /></span>
+              <span className="min-w-0 flex-1">
+                <strong className="block text-sm font-semibold">{en ? "Edit the current plan manually" : "基于当前方案手动编辑"}</strong>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{en ? "Copy the plan you are viewing and continue in Manual Scheduling." : "复制当前正在查看的方案，并进入手动排班工作台。"}</span>
+              </span>
+              <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
       <Suspense fallback={null}>
         <ShortcutGuideDialog open={shortcutGuideOpen} onOpenChange={setShortcutGuideOpen} />
         <Dialog open={cancelConfirmOpen} onOpenChange={setCancelConfirmOpen}>

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { Download, HeartPulse, Search, Settings2, Sparkles, X } from "lucide-react";
+import { ArrowLeft, Download, Search, Settings2, Sparkles, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { FactoryRecipe, TradeOrder } from "@/blueprint";
-import { ScheduleBoard } from "@/components";
+import { ScheduleBoard, ShiftTabs } from "@/components";
+import { FiammettaTargetChip } from "@/components/FiammettaTargetChip";
 import { OperatorSkillTooltip } from "@/components/OperatorSkillTooltip";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,7 +17,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { downloadJson } from "@/download";
 import { demoOperatorName, useLanguageDemo } from "@/language-demo";
@@ -45,6 +45,7 @@ export interface ManualSchedulePageProps {
   fiammettaEnabled: boolean;
   initialDraft: ManualScheduleDraft | null;
   onInitialDraftConsumed: () => void;
+  onOpenCalculator: () => void;
   onShiftDurationsChange: (durations: number[]) => void;
   onFiammettaEnabledChange: (enabled: boolean) => void;
   onOpenSetup: () => void;
@@ -61,10 +62,6 @@ type PendingMove = {
   target: Extract<PickerTarget, { kind: "slot" }>;
   conflict: ManualOperatorConflict;
 };
-
-function compactNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(2).replace(/\.?0+$/, "");
-}
 
 function ManualOperatorChoice({
   operator,
@@ -114,6 +111,7 @@ export function ManualSchedulePage({
   fiammettaEnabled,
   initialDraft,
   onInitialDraftConsumed,
+  onOpenCalculator,
   onShiftDurationsChange,
   onFiammettaEnabledChange,
   onOpenSetup,
@@ -306,6 +304,10 @@ export function ManualSchedulePage({
   }
 
   const fiammettaTarget = draft.shifts[activeShift]?.fiammettaTarget;
+  const fiammettaPortrait = fiammettaTarget ? operatorPortraitFor(fiammettaTarget) : null;
+  const sourceVariantLabel = draft.source?.variant === "progression-adjusted"
+    ? (en ? "Progression-adjusted plan" : "练度调整后方案")
+    : (en ? "Original plan" : "原方案");
   const previousRoomTitle = pendingMove ? rows.find((row) => row.roomId === pendingMove.conflict.roomId)?.title ?? pendingMove.conflict.roomId : "";
   const nextRoomTitle = pendingMove ? rows.find((row) => row.roomId === pendingMove.target.roomId)?.title ?? pendingMove.target.roomId : "";
 
@@ -316,6 +318,11 @@ export function ManualSchedulePage({
           <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
           <Input value={scheduleQuery} onChange={(event) => setScheduleQuery(event.target.value)} className="pl-9" aria-label={en ? "Search this manual schedule" : "搜索手动排班中的干员或房间"} placeholder={en ? "Search operators or rooms" : "搜索排班中的干员或房间"} />
         </div>
+        {draft.source ? (
+          <Button type="button" variant="ghost" size="sm" onClick={onOpenCalculator}>
+            <ArrowLeft />{en ? "Back to calculation" : "返回计算结果"}
+          </Button>
+        ) : null}
         <Button type="button" variant="outline" size="sm" onClick={onOpenSetup}><Settings2 />{en ? "Configure Box & layout" : "配置 Box 与布局"}</Button>
         <Button type="button" size="sm" onClick={exportMaa}><Download />{en ? "Export MAA" : "导出到 MAA"}</Button>
       </header>
@@ -323,27 +330,15 @@ export function ManualSchedulePage({
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3 border-y border-border/70 bg-muted/25 px-3 py-3">
         <div className="min-w-0">
           <p className="text-sm font-medium">{en ? "Manual draft" : "手动排班草稿"} · <span className="font-number">{layout.template}</span></p>
-          <p className="mt-1 truncate text-xs text-muted-foreground">{sourceName ?? (en ? "Current operator Box" : "当前干员 Box")} · {ownedOperators.length} {en ? "owned" : "名已拥有干员"}</p>
+          <p className="mt-1 truncate text-xs text-muted-foreground" data-manual-draft-source={draft.source?.variant ?? "standalone"}>
+            {draft.source ? (en ? `Based on ${sourceVariantLabel}` : `基于「${sourceVariantLabel}」创建`) : null}
+            {draft.source ? " · " : null}
+            {sourceName ?? (en ? "Current operator Box" : "当前干员 Box")} · {ownedOperators.length} {en ? "owned" : "名已拥有干员"}
+          </p>
         </div>
-        {fiammettaEnabled ? (
-          <Button type="button" variant="outline" size="sm" onClick={() => { setPickerQuery(""); setPicker({ kind: "fiammetta" }); }}>
-            <HeartPulse className="text-[#016E65]" />
-            {fiammettaTarget ? (en ? `Target: ${fiammettaTarget}` : `换心情：${fiammettaTarget}`) : (en ? "Choose morale target" : "选择换心情目标")}
-          </Button>
-        ) : null}
       </div>
 
       {storageWarning ? <p className="mb-3 text-sm text-amber-700" role="status">{storageWarning}</p> : null}
-
-      <div className="mb-4 max-w-full overflow-hidden">
-        <Tabs value={String(activeShift)} onValueChange={(value) => setActiveShift(Number(value))}>
-          <TabsList className="max-w-full justify-start overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden" data-manual-shift-tabs>
-            {draft.shifts.map((shift, index) => (
-              <TabsTrigger key={index} value={String(index)}>{en ? `Shift ${index + 1}` : `班次 ${index + 1}`} · <span className="font-number">{compactNumber(shift.durationHours)}h</span></TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-      </div>
 
       <ScheduleBoard
         rows={rows}
@@ -352,6 +347,23 @@ export function ManualSchedulePage({
         activeShift={activeShift}
         activePlan={activePlan}
         searchQuery={scheduleQuery}
+        shiftInfoSlot={(
+          <div className="flex flex-wrap items-center justify-end gap-2 max-sm:w-full max-sm:justify-between" data-shift-actions data-manual-shift-actions>
+            {fiammettaEnabled ? (
+              <FiammettaTargetChip
+                target={fiammettaTarget}
+                portrait={fiammettaPortrait}
+                onClick={() => { setPickerQuery(""); setPicker({ kind: "fiammetta" }); }}
+              />
+            ) : null}
+            <ShiftTabs
+              maaJson={maa}
+              durations={draft.shifts.map((shift) => shift.durationHours)}
+              active={activeShift}
+              onChange={setActiveShift}
+            />
+          </div>
+        )}
         onSlotClick={openSlotPicker}
         onFactoryRecipeChange={onFactoryRecipeChange}
         onTradeOrderChange={onTradeOrderChange}

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -5,9 +5,8 @@ import {
   useCallback,
   useDeferredValue,
   useMemo,
+  useRef,
   useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-  type ReactNode,
 } from "react";
 import { Check, RotateCcw, Search } from "lucide-react";
 
@@ -26,21 +25,24 @@ import {
   maxEliteForRarity,
   type ManualOperboxStage,
 } from "@/manual-operbox";
+import { PROFESSION_LABELS, PROFESSION_LABELS_ENGLISH } from "@/operator-presentation";
 import type { OperBoxEntry } from "@/types";
 
 const PAGE_SIZE = 48;
 const RARITIES = [6, 5, 4, 3, 2, 1] as const;
-const FILTER_BUTTON_CLASS = "min-h-11 min-w-11 shrink-0 border px-2 font-number";
+const PROFESSIONS = [8, 1, 3, 2, 6, 4, 5, 7] as const;
 
 type CatalogOperator = {
   id: string;
   order: number;
   portrait: string;
+  profession: number;
 };
 
 type ManualRosterOperator = OperBoxEntry & {
   order: number;
   portrait: string;
+  profession: number;
 };
 
 const CATALOG_BY_ID = new Map(
@@ -52,6 +54,7 @@ const MANUAL_ROSTER: ManualRosterOperator[] = (fullOperboxJson as OperBoxEntry[]
     ...operator,
     order: CATALOG_BY_ID.get(operator.id)?.order ?? 0,
     portrait: CATALOG_BY_ID.get(operator.id)?.portrait ?? "",
+    profession: CATALOG_BY_ID.get(operator.id)?.profession ?? 0,
   }))
   .sort((left, right) => right.rarity - left.rarity || right.order - left.order || left.name.localeCompare(right.name, "zh-CN"));
 
@@ -74,52 +77,6 @@ function shiftLabel(shift: number, en: boolean, short = false): string {
   if (en) return short ? `S${shift}` : `Shift ${shift}`;
   if (short) return `${shift}班`;
   return ["第一班", "第二班", "第三班"][shift - 1] ?? `第${shift}班`;
-}
-
-function moveFilterFocus(event: ReactKeyboardEvent<HTMLDivElement>) {
-  if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
-  const buttons = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("button:not(:disabled)"));
-  const currentIndex = buttons.indexOf(document.activeElement as HTMLButtonElement);
-  if (currentIndex < 0 || buttons.length === 0) return;
-  event.preventDefault();
-  const nextIndex = event.key === "Home"
-    ? 0
-    : event.key === "End"
-      ? buttons.length - 1
-      : (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + buttons.length) % buttons.length;
-  buttons[nextIndex]?.focus();
-}
-
-function FilterButton({
-  pressed,
-  disabled = false,
-  selectedClassName,
-  ariaLabel,
-  children,
-  onClick,
-}: {
-  pressed: boolean;
-  disabled?: boolean;
-  selectedClassName?: string;
-  ariaLabel?: string;
-  children: ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <Button
-      type="button"
-      size="sm"
-      variant={pressed ? "secondary" : "ghost"}
-      className={cn(FILTER_BUTTON_CLASS, pressed ? selectedClassName : "border-transparent")}
-      data-manual-operbox-filter-option=""
-      aria-pressed={pressed}
-      aria-label={ariaLabel}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      {children}
-    </Button>
-  );
 }
 
 function initialStages(operbox: OperBoxEntry[] | null): Record<string, ManualOperboxStage> {
@@ -258,27 +215,32 @@ export function ManualOperboxPicker({
   scheduledOperatorShifts,
   scheduledShiftCount = 0,
   compact = false,
+  showProfessionFilter = false,
 }: {
   operbox: OperBoxEntry[] | null;
   onApply: (entries: OperBoxEntry[]) => void;
   title?: string;
-  description?: string;
+  description?: string | null;
   applyLabel?: string;
   applyDisabled?: boolean;
   scheduledOperatorNames?: readonly string[];
   scheduledOperatorShifts?: Readonly<Record<string, readonly number[]>>;
   scheduledShiftCount?: number;
   compact?: boolean;
+  showProfessionFilter?: boolean;
 }) {
   const { locale } = useLanguageDemo();
   const en = locale === "en";
   const [query, setQuery] = useState("");
   const [onlyOwned, setOnlyOwned] = useState(false);
   const [rarity, setRarity] = useState("all");
+  const [profession, setProfession] = useState("all");
   const [rosterScope, setRosterScope] = useState<"scheduled" | "other">("scheduled");
   const [scheduledShift, setScheduledShift] = useState<"all" | number>("all");
   const [visibleLimit, setVisibleLimit] = useState(PAGE_SIZE);
   const [stages, setStages] = useState<Record<string, ManualOperboxStage>>(() => initialStages(operbox));
+  const [allMaximumStages, setAllMaximumStages] = useState(false);
+  const stagesBeforeAllMaximum = useRef<Record<string, ManualOperboxStage> | null>(null);
   const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase(locale === "en" ? "en-US" : "zh-CN"));
   const scheduledNames = useMemo(() => new Set([
     ...(scheduledOperatorNames ?? []),
@@ -293,6 +255,8 @@ export function ManualOperboxPicker({
   }), [scheduledOperatorShifts, scheduledShiftCount]);
 
   const handleStageChange = useCallback((id: string, stage: ManualOperboxStage) => {
+    stagesBeforeAllMaximum.current = null;
+    setAllMaximumStages(false);
     setStages((current) => ({ ...current, [id]: stage }));
   }, []);
 
@@ -309,12 +273,13 @@ export function ManualOperboxPicker({
     if (rosterScope === "scheduled" && scheduledShift !== "all" && !scheduledOperatorShifts?.[operator.name]?.includes(scheduledShift)) return false;
     if (onlyOwned && stage === "none") return false;
     if (rarity !== "all" && operator.rarity !== Number(rarity)) return false;
+    if (showProfessionFilter && profession !== "all" && operator.profession !== Number(profession)) return false;
     if (!deferredQuery) return true;
     const displayName = demoOperatorName(operator.name, locale).toLocaleLowerCase(locale === "en" ? "en-US" : "zh-CN");
     return operator.name.toLocaleLowerCase("zh-CN").includes(deferredQuery)
       || displayName.includes(deferredQuery)
       || operator.id.toLocaleLowerCase("en-US").includes(deferredQuery);
-  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, rarity, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, stages]);
+  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, profession, rarity, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, showProfessionFilter, stages]);
 
   function resetListView() {
     setVisibleLimit(PAGE_SIZE);
@@ -325,16 +290,141 @@ export function ManualOperboxPicker({
     onApply(buildManualOperbox(MANUAL_ROSTER, stages));
   }
 
+  function toggleAllMaximumStages() {
+    if (allMaximumStages) {
+      const previousStages = stagesBeforeAllMaximum.current;
+      stagesBeforeAllMaximum.current = null;
+      setAllMaximumStages(false);
+      if (previousStages) setStages(previousStages);
+      resetListView();
+      return;
+    }
+
+    stagesBeforeAllMaximum.current = stages;
+    setStages(Object.fromEntries(
+      MANUAL_ROSTER.map((operator) => [operator.id, maximumStageForRarity(operator.rarity)]),
+    ));
+    setAllMaximumStages(true);
+    setOnlyOwned(false);
+    resetListView();
+  }
+
+  const rarityTabs = (
+    <Tabs
+      className="min-w-0 shrink-0"
+      value={rarity}
+      onValueChange={(value) => {
+        setRarity(value);
+        resetListView();
+      }}
+    >
+      <TabsList
+        aria-label={en ? "Filter by rarity" : "星级筛选"}
+        className="max-w-full justify-start overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        <TabsTrigger value="all" disabled={applyDisabled}>
+          {en ? "All" : "全部"}
+        </TabsTrigger>
+        {RARITIES.map((value) => (
+          <TabsTrigger
+            key={value}
+            value={String(value)}
+            className="font-number"
+            aria-label={en ? `${value}-star operators` : `${value} 星干员`}
+            disabled={applyDisabled}
+          >
+            {value}★
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+
+  const rosterScopeTabs = hasScheduledOperators ? (
+    <Tabs
+      className="shrink-0"
+      value={rosterScope}
+      onValueChange={(value) => {
+        const nextScope = value as "scheduled" | "other";
+        setRosterScope(nextScope);
+        if (nextScope === "other") setScheduledShift("all");
+        resetListView();
+      }}
+    >
+      <TabsList aria-label={en ? "Operator list scope" : "干员列表范围"}>
+        <TabsTrigger value="scheduled">
+          {en ? "In schedule" : "进入排班"}<span className="font-number opacity-65">{scheduledNames.size}</span>
+        </TabsTrigger>
+        <TabsTrigger value="other">
+          {en ? "Not scheduled" : "未进排班"}<span className="font-number opacity-65">{MANUAL_ROSTER.length - scheduledNames.size}</span>
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  ) : null;
+
+  const scheduledShiftTabs = compact && rosterScope === "scheduled" && scheduledShiftCount > 0 ? (
+    <Tabs
+      className="shrink-0 border-l border-border/70 pl-2"
+      value={String(scheduledShift)}
+      onValueChange={(value) => {
+        setScheduledShift(value === "all" ? "all" : Number(value));
+        resetListView();
+      }}
+    >
+      <TabsList aria-label={en ? "Schedule shift" : "排班班次"}>
+        <TabsTrigger value="all">
+          {en ? "All shifts" : "全部班次"}
+        </TabsTrigger>
+        {shiftCounts.map((count, index) => {
+          const shift = index + 1;
+          return (
+            <TabsTrigger key={shift} value={String(shift)}>
+              {shiftLabel(shift, en)}<span className="font-number opacity-65">{count}</span>
+            </TabsTrigger>
+          );
+        })}
+      </TabsList>
+    </Tabs>
+  ) : null;
+
+  const professionTabs = showProfessionFilter ? (
+    <Tabs
+      className="min-w-0 shrink-0"
+      value={profession}
+      onValueChange={(value) => {
+        setProfession(value);
+        resetListView();
+      }}
+    >
+      <TabsList aria-label={en ? "Filter by profession" : "职业筛选"}>
+        <TabsTrigger value="all" disabled={applyDisabled}>
+          {en ? "All" : "全部"}
+        </TabsTrigger>
+        {PROFESSIONS.map((value) => (
+          <TabsTrigger key={value} value={String(value)} disabled={applyDisabled}>
+            {en ? PROFESSION_LABELS_ENGLISH[value] : PROFESSION_LABELS[value]}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  ) : null;
+
+  const resolvedDescription = description === undefined
+    ? (en
+        ? "Choose ownership and elite stage. Levels use each stage cap so level-gated infrastructure skills remain available."
+        : "选择持有状态与精英阶段；等级按该阶段上限估算，避免漏掉有等级要求的基建技能。")
+    : description;
+
   return (
     <div className={cn("grid", compact ? "gap-2.5" : "gap-4")} data-manual-operbox-picker data-density={compact ? "compact" : "comfortable"}>
       <div className={cn("flex flex-wrap justify-between gap-3 border-b border-border/70", compact ? "items-center pb-2.5" : "items-start pb-4")}>
         <div className={cn("min-w-0", compact && "flex flex-1 flex-wrap items-baseline gap-x-3 gap-y-1 max-sm:w-full max-sm:flex-none")}>
           <h4 className="shrink-0 text-sm font-semibold">{title ?? (en ? "Build your operator Box" : "手动选择干员 Box")}</h4>
-          <p className={cn("max-w-2xl text-xs text-muted-foreground", compact ? "leading-4" : "mt-1 leading-5")}>
-            {description ?? (en
-              ? "Choose ownership and elite stage. Levels use each stage cap so level-gated infrastructure skills remain available."
-              : "选择持有状态与精英阶段；等级按该阶段上限估算，避免漏掉有等级要求的基建技能。")}
-          </p>
+          {resolvedDescription ? (
+            <p className={cn("max-w-2xl text-xs text-muted-foreground", compact ? "leading-4" : "mt-1 leading-5")}>
+              {resolvedDescription}
+            </p>
+          ) : null}
           {compact ? (
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs" aria-live="polite">
               <strong className="font-number text-foreground">{en ? `${ownedCount} owned` : `已拥有 ${ownedCount} 名`}</strong>
@@ -376,11 +466,11 @@ export function ManualOperboxPicker({
             aria-label={en ? "Search operator" : "搜索干员"}
           />
         </label>
-        <div className={cn("grid grid-cols-3", compact ? "gap-1.5" : "gap-2")} data-manual-operbox-actions>
-          <Button
+        <div className={cn("flex flex-nowrap items-center", compact ? "gap-1.5" : "gap-2")} data-manual-operbox-actions>
+          <SetupActionButton
             type="button"
             variant={onlyOwned ? "default" : "outline"}
-            className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
+            className="h-8 min-w-[92px] px-2 text-[11px] font-normal max-sm:min-w-[92px] sm:h-8 sm:min-w-[104px] sm:px-2 sm:text-xs"
             aria-pressed={onlyOwned}
             onClick={() => {
               setOnlyOwned((current) => !current);
@@ -388,27 +478,24 @@ export function ManualOperboxPicker({
             }}
           >
             {en ? "Owned only" : "只看已拥有"}
-          </Button>
-          <Button
+          </SetupActionButton>
+          <SetupActionButton
             type="button"
-            variant="outline"
-            className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
-            onClick={() => {
-              setStages(Object.fromEntries(
-                MANUAL_ROSTER.map((operator) => [operator.id, maximumStageForRarity(operator.rarity)]),
-              ));
-              setOnlyOwned(false);
-              resetListView();
-            }}
+            variant={allMaximumStages ? "default" : "outline"}
+            className="h-8 min-w-[104px] px-2 text-[11px] font-normal max-sm:min-w-[104px] sm:h-8 sm:min-w-[116px] sm:px-2 sm:text-xs"
+            aria-pressed={allMaximumStages}
+            onClick={toggleAllMaximumStages}
           >
             {en ? "Select all at max elite" : "全选最高精英"}
-          </Button>
+          </SetupActionButton>
           <Button
             type="button"
             variant="ghost"
             className={cn("min-w-0 overflow-hidden px-2 text-ellipsis text-xs sm:px-3", compact ? "h-9" : "min-h-11 sm:text-sm")}
             disabled={!ownedCount}
             onClick={() => {
+              stagesBeforeAllMaximum.current = null;
+              setAllMaximumStages(false);
               setStages(Object.fromEntries(MANUAL_ROSTER.map((operator) => [operator.id, "none"])));
               setOnlyOwned(false);
               resetListView();
@@ -419,90 +506,55 @@ export function ManualOperboxPicker({
         </div>
       </div>
 
-      <div className="flex min-w-0 items-center gap-1" data-manual-operbox-rarity-filter>
-        <div className="shrink-0 text-xs font-medium text-muted-foreground">{en ? "Rarity" : "星级"}</div>
+      {compact && hasScheduledOperators ? (
         <div
-          role="group"
-          aria-label={en ? "Filter by rarity" : "星级筛选"}
-          className="flex min-w-0 flex-1 flex-nowrap gap-0.5 overflow-x-auto"
-          onKeyDown={moveFilterFocus}
+          className="grid min-w-0 gap-1.5"
+          data-upgrade-operbox-filters
         >
-          <FilterButton
-            pressed={rarity === "all"}
-            disabled={applyDisabled}
-            selectedClassName={SHIFT_BADGE_CLASS[0]}
-            onClick={() => {
-              setRarity("all");
-              resetListView();
-            }}
+          <div
+            className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto pb-1 [scrollbar-width:thin]"
+            data-upgrade-operbox-schedule-filters
           >
-            {en ? "All" : "全部"}
-          </FilterButton>
-          {RARITIES.map((value) => (
-            <FilterButton
-              key={value}
-              pressed={rarity === String(value)}
-              disabled={applyDisabled}
-              selectedClassName={SHIFT_BADGE_CLASS[0]}
-              ariaLabel={en ? `${value}-star operators` : `${value} 星干员`}
-              onClick={() => {
-                setRarity((current) => current === String(value) ? "all" : String(value));
-                resetListView();
-              }}
-            >
-              {value}★
-            </FilterButton>
-          ))}
+            {rosterScopeTabs}
+            {scheduledShiftTabs}
+          </div>
+          <div
+            className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto pb-1 [scrollbar-width:thin]"
+            data-upgrade-operbox-operator-filters
+          >
+            <div className="flex shrink-0 items-center gap-1" data-manual-operbox-rarity-filter>
+              <div className="shrink-0 text-xs font-medium text-muted-foreground">{en ? "Rarity" : "星级"}</div>
+              {rarityTabs}
+            </div>
+            {professionTabs ? (
+              <div className="flex shrink-0 items-center gap-1 border-l border-border/70 pl-2" data-manual-operbox-profession-filter>
+                <div className="shrink-0 text-xs font-medium text-muted-foreground">{en ? "Profession" : "职业"}</div>
+                {professionTabs}
+              </div>
+            ) : null}
+          </div>
         </div>
-      </div>
-
-      {hasScheduledOperators ? (
-        <div className={cn(compact ? "flex flex-wrap items-center gap-1.5" : "flex flex-wrap items-center gap-2")}>
-          <Tabs
-            value={rosterScope}
-            onValueChange={(value) => {
-              const nextScope = value as "scheduled" | "other";
-              setRosterScope(nextScope);
-              if (nextScope === "other") setScheduledShift("all");
-              resetListView();
-            }}
-          >
-            <TabsList aria-label={en ? "Operator list scope" : "干员列表范围"}>
-              <TabsTrigger value="scheduled">
-                {en ? "In schedule" : "进入排班"}<span className="font-number opacity-65">{scheduledNames.size}</span>
-              </TabsTrigger>
-              <TabsTrigger value="other">
-                {en ? "Not scheduled" : "未进排班"}<span className="font-number opacity-65">{MANUAL_ROSTER.length - scheduledNames.size}</span>
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-          {compact && rosterScope === "scheduled" && scheduledShiftCount > 0 ? (
-            <div
-              role="group"
-              className="ml-1 flex flex-wrap items-center gap-1 border-l border-border/70 pl-2"
-              aria-label={en ? "Schedule shift" : "排班班次"}
-              onKeyDown={moveFilterFocus}
-            >
-              <FilterButton pressed={scheduledShift === "all"} onClick={() => { setScheduledShift("all"); resetListView(); }}>
-                {en ? "All shifts" : "全部班次"}
-              </FilterButton>
-              {shiftCounts.map((count, index) => {
-                const shift = index + 1;
-                return (
-                  <FilterButton
-                    key={shift}
-                    pressed={scheduledShift === shift}
-                    selectedClassName={SHIFT_BADGE_CLASS[index % SHIFT_BADGE_CLASS.length]}
-                    onClick={() => { setScheduledShift(shift); resetListView(); }}
-                  >
-                    {shiftLabel(shift, en)}<span className="font-number opacity-65">{count}</span>
-                  </FilterButton>
-                );
-              })}
+      ) : (
+        <>
+          <div className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto pb-1 [scrollbar-width:thin]">
+            <div className="flex shrink-0 items-center gap-1" data-manual-operbox-rarity-filter>
+              <div className="shrink-0 text-xs font-medium text-muted-foreground">{en ? "Rarity" : "星级"}</div>
+              {rarityTabs}
+            </div>
+            {professionTabs ? (
+              <div className="flex shrink-0 items-center gap-1 border-l border-border/70 pl-2" data-manual-operbox-profession-filter>
+                <div className="shrink-0 text-xs font-medium text-muted-foreground">{en ? "Profession" : "职业"}</div>
+                {professionTabs}
+              </div>
+            ) : null}
+          </div>
+          {hasScheduledOperators ? (
+            <div className="flex flex-wrap items-center gap-2">
+              {rosterScopeTabs}
             </div>
           ) : null}
-        </div>
-      ) : null}
+        </>
+      )}
 
       {filteredOperators.length ? (
         <>

--- a/src/manual-schedule.test.ts
+++ b/src/manual-schedule.test.ts
@@ -5,6 +5,8 @@ import {
   assignManualOperator,
   createManualScheduleDraft,
   createManualScheduleDraftFromCalculator,
+  loadManualScheduleDraft,
+  manualScheduleDraftContentEqual,
   manualScheduleToMaa,
   reconcileManualScheduleDraft,
   resizeManualScheduleDraft,
@@ -156,4 +158,47 @@ test("calculator results become an editable manual draft with room order, shifts
   assert.equal(draft.shifts[0]?.fiammettaTarget, "但书");
   assert.deepEqual(draft.shifts[0]?.rooms.training_room?.operators, ["巫恋", "菲亚梅塔"]);
   assert.deepEqual(draft.shifts[1]?.rooms.manu_1?.operators, ["巫恋", null, null]);
+});
+
+test("manual draft source survives reconciliation without affecting content equality", () => {
+  const original = createManualScheduleDraft([12, 6]);
+  original.source = {
+    kind: "calculator",
+    variant: "progression-adjusted",
+    createdAt: "2026-09-05T00:00:00.000Z",
+  };
+  const reconciled = reconcileManualScheduleDraft(original, layout, box);
+  const sameContent = structuredClone(reconciled);
+  sameContent.source = {
+    kind: "calculator",
+    variant: "baseline",
+    createdAt: "2026-09-05T01:00:00.000Z",
+  };
+
+  assert.equal(reconciled.source?.variant, "progression-adjusted");
+  assert.equal(manualScheduleDraftContentEqual(reconciled, sameContent), true);
+  sameContent.shifts[0]!.durationHours = 10;
+  assert.equal(manualScheduleDraftContentEqual(reconciled, sameContent), false);
+});
+
+test("manual draft loading preserves only valid calculator source metadata", () => {
+  const draft = createManualScheduleDraft([12, 6]);
+  draft.source = {
+    kind: "calculator",
+    variant: "progression-adjusted",
+    createdAt: "2026-09-05T00:00:00.000Z",
+  };
+  const storage = {
+    getItem: () => JSON.stringify(draft),
+    setItem: () => undefined,
+  };
+
+  assert.deepEqual(loadManualScheduleDraft(storage)?.source, draft.source);
+
+  const invalidDraft = structuredClone(draft);
+  invalidDraft.source.createdAt = "not-a-date";
+  assert.equal(loadManualScheduleDraft({
+    ...storage,
+    getItem: () => JSON.stringify(invalidDraft),
+  })?.source, undefined);
 });

--- a/src/manual-schedule.ts
+++ b/src/manual-schedule.ts
@@ -34,11 +34,18 @@ export interface ManualShift {
   fiammettaTarget: string | null;
 }
 
+export interface ManualScheduleSource {
+  kind: "calculator";
+  variant: "baseline" | "progression-adjusted";
+  createdAt: string;
+}
+
 export interface ManualScheduleDraft {
   version: 2;
   activeShift: number;
   fiammettaEnabled: boolean;
   shifts: ManualShift[];
+  source?: ManualScheduleSource;
 }
 
 export interface ManualOperatorConflict {
@@ -100,6 +107,7 @@ export function createManualScheduleDraftFromCalculator(input: {
   fallbackDurations: readonly number[];
   fiammettaEnabled: boolean;
   trainingRoomShifts?: readonly TrainingRoomShift[];
+  source?: ManualScheduleSource;
 }): ManualScheduleDraft {
   const planCount = input.maa?.plans.length ?? 0;
   const durations = Array.from(
@@ -114,6 +122,7 @@ export function createManualScheduleDraftFromCalculator(input: {
   );
   const draft = createManualScheduleDraft(durations);
   draft.fiammettaEnabled = input.fiammettaEnabled;
+  if (input.source) draft.source = { ...input.source };
 
   input.maa?.plans.forEach((plan, shiftIndex) => {
     const shift = draft.shifts[shiftIndex];
@@ -179,11 +188,25 @@ export function loadManualScheduleDraft(storage: StorageLike): ManualScheduleDra
     const activeShift = "activeShift" in value && Number.isInteger(value.activeShift)
       ? Math.max(0, Math.min(shifts.length - 1, Number(value.activeShift)))
       : 0;
+    const rawSource = "source" in value && value.source && typeof value.source === "object"
+      ? value.source as Partial<ManualScheduleSource>
+      : null;
+    const source = rawSource?.kind === "calculator"
+      && (rawSource.variant === "baseline" || rawSource.variant === "progression-adjusted")
+      && typeof rawSource.createdAt === "string"
+      && Number.isFinite(Date.parse(rawSource.createdAt))
+      ? {
+          kind: "calculator" as const,
+          variant: rawSource.variant,
+          createdAt: new Date(rawSource.createdAt).toISOString(),
+        }
+      : undefined;
     return {
       version: 2,
       activeShift,
       fiammettaEnabled: "fiammettaEnabled" in value && value.fiammettaEnabled === true,
       shifts,
+      ...(source ? { source } : {}),
     };
   } catch {
     return null;
@@ -208,6 +231,7 @@ export function resizeManualScheduleDraft(
     activeShift: Math.min(draft.activeShift, shifts.length - 1),
     fiammettaEnabled: draft.fiammettaEnabled,
     shifts,
+    ...(draft.source ? { source: { ...draft.source } } : {}),
   };
 }
 
@@ -221,6 +245,7 @@ export function reconcileManualScheduleDraft(
     version: 2,
     activeShift: Math.min(Math.max(0, draft.activeShift), Math.max(0, draft.shifts.length - 1)),
     fiammettaEnabled: draft.fiammettaEnabled === true,
+    ...(draft.source ? { source: { ...draft.source } } : {}),
     shifts: draft.shifts.map((shift) => ({
       durationHours: finitePositive(shift.durationHours, 12),
       fiammettaTarget: shift.fiammettaTarget && (!owned || owned.has(shift.fiammettaTarget))
@@ -242,6 +267,19 @@ export function reconcileManualScheduleDraft(
       })),
     })),
   };
+}
+
+export function manualScheduleDraftContentEqual(
+  left: ManualScheduleDraft,
+  right: ManualScheduleDraft,
+): boolean {
+  return JSON.stringify({
+    fiammettaEnabled: left.fiammettaEnabled,
+    shifts: left.shifts,
+  }) === JSON.stringify({
+    fiammettaEnabled: right.fiammettaEnabled,
+    shifts: right.shifts,
+  });
 }
 
 export function findManualOperatorConflict(

--- a/src/server/telemetry.test.ts
+++ b/src/server/telemetry.test.ts
@@ -18,6 +18,16 @@ const validEvent = {
 
 test("telemetry validation accepts only the public field whitelist", () => {
   assert.deepEqual(validateTelemetryEvent(validEvent), validEvent);
+  assert.ok(validateTelemetryEvent({
+    ...validEvent,
+    type: "interaction",
+    name: "upgrade_simulation_submit",
+  }));
+  assert.ok(validateTelemetryEvent({
+    ...validEvent,
+    type: "interaction",
+    name: "upgrade_simulation_response",
+  }));
   assert.equal(validateTelemetryEvent({ ...validEvent, createdAt: Date.now() }), null);
   assert.equal(validateTelemetryEvent({ ...validEvent, token: "secret" }), null);
   assert.equal(validateTelemetryEvent({ ...validEvent, meta: { unknown: "value" } }), null);

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -20,6 +20,8 @@ const ALLOWED_NAMES = new Set([
   "plan_response",
   "plan_render",
   "plan_result",
+  "upgrade_simulation_submit",
+  "upgrade_simulation_response",
   "page_view",
   "js_error",
   "api_error",

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -478,11 +478,10 @@ export function SetupDialog({
                           <Suspense fallback={<div className="grid min-h-40 place-items-center border border-dashed border-border text-sm text-muted-foreground">{en ? "Loading operator roster" : "正在加载干员列表"}</div>}>
                             <ManualOperboxPicker
                               compact
+                              showProfessionFilter
                               operbox={operbox}
                               title={en ? "Build your operator BOX" : "手动选择干员 Box"}
-                              description={en
-                                ? "Ownership and elite stages are shared with Adjust progression."
-                                : "持有与精英阶段会同步用于排班和调整练度。"}
+                              description={null}
                               onApply={applyManualBox}
                             />
                           </Suspense>


### PR DESCRIPTION
## Summary
- clarify progression recalculation versus direct schedule editing
- reuse shared rarity, profession, shift, and Fiammetta controls across calculator and manual scheduling
- preserve and validate manual draft sources and improve mobile result actions

## Verification
- npm test (371 passed)
- npm run test:api-contract (68 passed)
- npm run test:shift-comparison (15 passed)
- targeted Chromium E2E (14 passed)
- npx tsc --noEmit
- ESLint on all changed files
- git diff --check