### PR TITLE
test: fix manual controls release checks

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test, type Locator } from "@playwright/test";
+import arkntoolsSource from "../src/generated/arkntools/source.json" with { type: "json" };
 import { requestId, diagnosticId, waitForOwnAnimations, gotoStable, expectVisibleNumbersUseNumberFont, profile, planData, scheduleVisualPlanData, sampleData, authenticatedSklandSnapshot, mockApis, openSklandOverview, seedPreferences, seedV4Session } from "./production-readiness.fixture";
+
+const fullOperatorCount = arkntoolsSource.counts.operators;
 
 test.beforeEach(async ({ page }) => {
   await page.route("**/api/auth/get-session", (route) => route.fulfill({

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -470,7 +470,7 @@ export function ManualOperboxPicker({
           <SetupActionButton
             type="button"
             variant={onlyOwned ? "default" : "outline"}
-            className="h-8 min-w-[92px] px-2 text-[11px] font-normal max-sm:min-w-[92px] sm:h-8 sm:min-w-[104px] sm:px-2 sm:text-xs"
+            className="min-w-[92px] px-2 text-[11px] font-normal max-sm:min-w-[92px] sm:min-w-[104px] sm:px-2 sm:text-xs"
             aria-pressed={onlyOwned}
             onClick={() => {
               setOnlyOwned((current) => !current);
@@ -482,7 +482,7 @@ export function ManualOperboxPicker({
           <SetupActionButton
             type="button"
             variant={allMaximumStages ? "default" : "outline"}
-            className="h-8 min-w-[104px] px-2 text-[11px] font-normal max-sm:min-w-[104px] sm:h-8 sm:min-w-[116px] sm:px-2 sm:text-xs"
+            className="min-w-[104px] px-2 text-[11px] font-normal max-sm:min-w-[104px] sm:min-w-[116px] sm:px-2 sm:text-xs"
             aria-pressed={allMaximumStages}
             onClick={toggleAllMaximumStages}
           >

--- a/src/manual-schedule.test.ts
+++ b/src/manual-schedule.test.ts
@@ -196,6 +196,7 @@ test("manual draft loading preserves only valid calculator source metadata", () 
   assert.deepEqual(loadManualScheduleDraft(storage)?.source, draft.source);
 
   const invalidDraft = structuredClone(draft);
+  assert.ok(invalidDraft.source);
   invalidDraft.source.createdAt = "not-a-date";
   assert.equal(loadManualScheduleDraft({
     ...storage,


### PR DESCRIPTION
## Summary
- restore generated operator count used by the production-readiness test
- narrow optional source metadata after an explicit assertion
- keep compact toggle widths and typography while preserving shared 36/44px click targets

## Verification
- clean production build and worker build passed
- targeted Chromium regression passed
- targeted unit test passed
- targeted ESLint passed