### PR TITLE
修复手选干员技能悬浮提示

### DIFF
--- a/e2e/manual-schedule.spec.ts
+++ b/e2e/manual-schedule.spec.ts
@@ -250,18 +250,14 @@ test("manual scheduling configures independent shifts, moves conflicts and enabl
   await expect(fiammettaPicker.locator("[data-manual-operator-choice]").first().locator("img")).toBeVisible();
   await expect(fiammettaPicker.getByText(/精2 Lv\.60/).first()).toBeVisible();
   await fiammettaPicker.getByRole("button", { name: /锡兰/ }).hover();
-  await page.waitForTimeout(1_000);
-  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toHaveCount(0);
-  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toBeVisible({ timeout: 1_000 });
   await fiammettaPicker.locator("[data-manual-operator-picker]").evaluate((element) => {
     element.dispatchEvent(new Event("scroll"));
   });
   await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toHaveCount(0);
   await page.waitForTimeout(200);
   await fiammettaPicker.getByRole("button", { name: /阿米娅/ }).hover();
-  await page.waitForTimeout(1_000);
-  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toHaveCount(0);
-  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toBeVisible({ timeout: 2_000 });
+  await expect(page.locator('[data-slot="tooltip-content"][data-open]')).toBeVisible({ timeout: 1_000 });
   await fiammettaPicker.getByRole("button", { name: /锡兰/ }).click();
   await expect(manualShiftActions.getByRole("button", { name: "换心情 锡兰" })).toBeVisible();
   await expect(manualShiftActions.locator("[data-fiammetta-target-chip] img")).toBeVisible();

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -298,7 +298,7 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   await expect(manualSkillTooltip.getByText("当前选择：精1 Lv.70", { exact: true })).toBeVisible();
   await expect(manualSkillTooltip.getByText("已解锁", { exact: true })).toBeVisible();
   await expect(manualSkillTooltip.getByText("未解锁", { exact: true })).toBeVisible();
-  await expect(manualSkillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.4");
+  await expect(manualSkillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.7");
   await expect(manualSkillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("filter", "grayscale(1)");
   await expect(manualPicker.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" }).getByRole("radio", { name: "精1", exact: true })).toBeChecked();
   await setupDialog.getByRole("button", { name: "Close" }).click();

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -293,7 +293,13 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   const manualPicker = setupDialog.locator("[data-manual-operbox-picker]");
   await manualPicker.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
   await manualPicker.getByRole("button", { name: "查看阿米娅的基建技能", exact: true }).hover();
-  await expect(page.locator('[data-slot="tooltip-content"]')).toBeVisible();
+  const manualSkillTooltip = page.locator('[data-slot="tooltip-content"]');
+  await expect(manualSkillTooltip).toBeVisible();
+  await expect(manualSkillTooltip.getByText("当前选择：精1 Lv.70", { exact: true })).toBeVisible();
+  await expect(manualSkillTooltip.getByText("已解锁", { exact: true })).toBeVisible();
+  await expect(manualSkillTooltip.getByText("未解锁", { exact: true })).toBeVisible();
+  await expect(manualSkillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.4");
+  await expect(manualSkillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("filter", "grayscale(1)");
   await expect(manualPicker.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" }).getByRole("radio", { name: "精1", exact: true })).toBeChecked();
   await setupDialog.getByRole("button", { name: "Close" }).click();
 

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -292,6 +292,8 @@ test("progression adjustments sync back to the schedule settings manual BOX", as
   await expect(setupDialog.getByRole("tab", { name: "手动选择", exact: true })).toHaveAttribute("aria-selected", "true");
   const manualPicker = setupDialog.locator("[data-manual-operbox-picker]");
   await manualPicker.getByRole("textbox", { name: "搜索干员" }).fill("阿米娅");
+  await manualPicker.getByRole("button", { name: "查看阿米娅的基建技能", exact: true }).hover();
+  await expect(page.locator('[data-slot="tooltip-content"]')).toBeVisible();
   await expect(manualPicker.getByRole("radiogroup", { name: "阿米娅持有与精英阶段" }).getByRole("radio", { name: "精1", exact: true })).toBeChecked();
   await setupDialog.getByRole("button", { name: "Close" }).click();
 

--- a/e2e/production-readiness-planning.spec.ts
+++ b/e2e/production-readiness-planning.spec.ts
@@ -199,7 +199,10 @@ test("operator skill terms reveal square hover cards on pointer and keyboard foc
   await mockApis(page);
   const termPlanData = structuredClone(scheduleVisualPlanData);
   termPlanData.maa.plans[0].rooms.trading[0].operators = [{ name: "陈", skill: 1 }];
-  await seedV4Session(page, termPlanData, { boxSource: "maa" });
+  await seedV4Session(page, termPlanData, {
+    boxSource: "maa",
+    operbox: [{ id: "char_010_chen", name: "陈", elite: 0, level: 1, own: true, potential: 1, rarity: 6 }],
+  });
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto("/");
 
@@ -208,6 +211,8 @@ test("operator skill terms reveal square hover cards on pointer and keyboard foc
   await operatorPortrait.hover({ position: { x: 8, y: Math.max(8, (portraitBox?.height ?? 80) / 2) } });
   const skillTooltip = page.locator('[data-slot="tooltip-content"][data-open]');
   await expect(skillTooltip).toBeVisible({ timeout: 10_000 });
+  await expect(skillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.4");
+  await expect(skillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("filter", "grayscale(1)");
   const termTrigger = skillTooltip.locator(".riic-term-hover > .riic-term").first();
   const termCard = skillTooltip.locator(".riic-term-hover-card").first();
 

--- a/e2e/production-readiness-planning.spec.ts
+++ b/e2e/production-readiness-planning.spec.ts
@@ -211,7 +211,7 @@ test("operator skill terms reveal square hover cards on pointer and keyboard foc
   await operatorPortrait.hover({ position: { x: 8, y: Math.max(8, (portraitBox?.height ?? 80) / 2) } });
   const skillTooltip = page.locator('[data-slot="tooltip-content"][data-open]');
   await expect(skillTooltip).toBeVisible({ timeout: 10_000 });
-  await expect(skillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.4");
+  await expect(skillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("opacity", "0.7");
   await expect(skillTooltip.locator('[data-skill-unlocked="false"]')).toHaveCSS("filter", "grayscale(1)");
   const termTrigger = skillTooltip.locator(".riic-term-hover > .riic-term").first();
   const termCard = skillTooltip.locator(".riic-term-hover-card").first();

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1371,6 +1371,7 @@ export function OperatorSlot({
   slot,
   currentMorale,
   elite,
+  operatorLevel,
   autofill = false,
   compactFactory = false,
   compactView = false,
@@ -1390,6 +1391,8 @@ export function OperatorSlot({
   currentMorale?: number;
   /** 干员精英化等级（0/1/2），传入后会在头像左下角显示对应角标。 */
   elite?: number;
+  /** 干员当前等级，用于判断带等级要求的基建技能是否已解锁。 */
+  operatorLevel?: number;
   autofill?: boolean;
   compactFactory?: boolean;
   compactView?: boolean;
@@ -1539,6 +1542,8 @@ export function OperatorSlot({
             trigger={frame}
             highlightedSkillIds={skillTooltipHighlightIds}
             contextLabel={skillTooltipContextLabel}
+            currentElite={elite}
+            currentLevel={operatorLevel}
           />
         </Suspense>
       ) : undefined}
@@ -1562,6 +1567,7 @@ export function ScheduleBoard({
   layout,
   planRevision,
   eliteByOperator,
+  levelByOperator,
   viewControlsSlot,
   mobileActionsSlot,
   shiftInfoSlot,
@@ -1582,6 +1588,8 @@ export function ScheduleBoard({
   planRevision?: string;
   /** 按干员名查精英化等级（0/1/2），用于在排班头像左下角显示角标。 */
   eliteByOperator?: ReadonlyMap<string, number>;
+  /** 按干员名查当前等级，用于技能解锁状态。 */
+  levelByOperator?: ReadonlyMap<string, number>;
   viewControlsSlot?: ReactNode;
   mobileActionsSlot?: ReactNode;
   shiftInfoSlot?: ReactNode;
@@ -1939,6 +1947,7 @@ export function ScheduleBoard({
                             key={`${row.key}-${index}`}
                             slot={slot}
                             elite={slot ? eliteByOperator?.get(slot.name) : undefined}
+                            operatorLevel={slot ? levelByOperator?.get(slot.name) : undefined}
                             autofill={row.group === "dormitory" && row.autofill}
                             compactFactory={compactFactoryRoom}
                             centerFrameInList
@@ -1995,6 +2004,7 @@ export function ScheduleBoard({
               rows={visibleRows}
               layout={layout}
               eliteByOperator={eliteByOperator}
+              levelByOperator={levelByOperator}
               activeShift={activeShift}
               activePlan={activePlan}
               shiftDirection={shiftDirection}

--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -40,6 +40,7 @@ export interface CompactScheduleViewProps {
   rows: RoomRow[];
   layout: BaseBlueprint;
   eliteByOperator?: ReadonlyMap<string, number>;
+  levelByOperator?: ReadonlyMap<string, number>;
   activeShift: number;
   activePlan?: MaaPlan;
   shiftDirection: ShiftDirection;
@@ -67,6 +68,7 @@ function CompactRoomCard({
   efficiency,
   slots,
   eliteByOperator,
+  levelByOperator,
   shiftDirection,
   onIssue,
   feedbackDisabled = false,
@@ -81,6 +83,7 @@ function CompactRoomCard({
   efficiency: ReturnType<typeof presentRoomEfficiency>;
   slots: { slot: RoomRow["operatorSlots"][number] | undefined; positionLabel?: string }[];
   eliteByOperator?: ReadonlyMap<string, number>;
+  levelByOperator?: ReadonlyMap<string, number>;
   shiftDirection: ShiftDirection;
   onIssue?: (row: RoomRow) => void;
   feedbackDisabled?: boolean;
@@ -171,6 +174,7 @@ function CompactRoomCard({
       key={`${row.key}-${index}`}
       slot={slot}
       elite={slot ? eliteByOperator?.get(slot.name) : undefined}
+      operatorLevel={slot ? levelByOperator?.get(slot.name) : undefined}
       autofill={row.group === "dormitory" && row.autofill}
       compactView
       showSkillTooltip
@@ -271,7 +275,7 @@ function CompactFeedbackButton({ row, disabled, onIssue }: { row: RoomRow; disab
 }
 
 export function CompactScheduleView(props: CompactScheduleViewProps) {
-  const { rows, layout, eliteByOperator, shiftDirection, onIssue, feedbackDisabled = false, onSlotClick } = props;
+  const { rows, layout, eliteByOperator, levelByOperator, shiftDirection, onIssue, feedbackDisabled = false, onSlotClick } = props;
   const { locale } = useLanguageDemo();
 
   if (rows.length === 0) {
@@ -314,6 +318,7 @@ export function CompactScheduleView(props: CompactScheduleViewProps) {
         efficiency={efficiency}
         slots={slots}
         eliteByOperator={eliteByOperator}
+        levelByOperator={levelByOperator}
         shiftDirection={shiftDirection}
         onIssue={onIssue}
         feedbackDisabled={feedbackDisabled}

--- a/src/components/OperatorSkillTooltip.tsx
+++ b/src/components/OperatorSkillTooltip.tsx
@@ -24,6 +24,8 @@ export function OperatorSkillTooltip({
   trigger,
   highlightedSkillIds = [],
   contextLabel,
+  currentElite,
+  currentLevel,
   delay,
   disabled,
 }: {
@@ -31,6 +33,8 @@ export function OperatorSkillTooltip({
   trigger: ReactElement;
   highlightedSkillIds?: readonly string[];
   contextLabel?: string;
+  currentElite?: number | null;
+  currentLevel?: number;
   delay?: number;
   disabled?: boolean;
 }) {
@@ -77,6 +81,11 @@ export function OperatorSkillTooltip({
           locale={locale}
           skill={demoBuildingSkill(sourceSkill.id, locale, sourceSkill) as BuildingSkillPresentation}
           highlighted={highlighted.has(sourceSkill.id)}
+          unlocked={currentElite === undefined
+            ? undefined
+            : currentElite !== null
+              && (sourceSkill.elite < currentElite
+                || (sourceSkill.elite === currentElite && sourceSkill.level <= (currentLevel ?? 1)))}
         />
       ))}
     </TooltipContent>
@@ -99,15 +108,41 @@ export function OperatorSkillTooltip({
   );
 }
 
-function SkillBlock({ skill, locale, highlighted }: { skill: BuildingSkillPresentation; locale: "zh" | "en"; highlighted: boolean }) {
+function SkillBlock({
+  skill,
+  locale,
+  highlighted,
+  unlocked,
+}: {
+  skill: BuildingSkillPresentation;
+  locale: "zh" | "en";
+  highlighted: boolean;
+  unlocked?: boolean;
+}) {
   return (
-    <div className={cn("min-w-0", highlighted && "border-l-2 border-[#FFD501] pl-2")}>
+    <div className={cn(
+      "min-w-0 transition-[filter,opacity] duration-200 motion-reduce:transition-none",
+      highlighted && "border-l-2 border-[#FFD501] pl-2",
+      unlocked === false && "grayscale opacity-40",
+    )} data-skill-unlocked={unlocked === undefined ? undefined : String(unlocked)}>
       <span className="flex flex-wrap items-center gap-1.5 font-semibold">
         <img src={skill.icon} alt="" aria-hidden="true" className="size-7 shrink-0 object-contain" />
         <span>{skill.name}</span>
         {highlighted ? (
           <span className="rounded-sm bg-[#FFD501] px-1.5 py-0.5 text-[10px] font-bold text-[#202223]">
             {locale === "en" ? "THIS TARGET" : "本次目标"}
+          </span>
+        ) : null}
+        {unlocked !== undefined ? (
+          <span className={cn(
+            "rounded-sm border px-1.5 py-0.5 text-[10px] font-bold",
+            unlocked
+              ? "border-emerald-400/35 bg-emerald-400/15 text-emerald-200"
+              : "border-background/20 bg-background/10 text-background/65",
+          )}>
+            {unlocked
+              ? (locale === "en" ? "UNLOCKED" : "已解锁")
+              : (locale === "en" ? "LOCKED" : "未解锁")}
           </span>
         ) : null}
       </span>

--- a/src/components/OperatorSkillTooltip.tsx
+++ b/src/components/OperatorSkillTooltip.tsx
@@ -123,7 +123,7 @@ function SkillBlock({
     <div className={cn(
       "min-w-0 transition-[filter,opacity] duration-200 motion-reduce:transition-none",
       highlighted && "border-l-2 border-[#FFD501] pl-2",
-      unlocked === false && "grayscale opacity-40",
+      unlocked === false && "grayscale opacity-70",
     )} data-skill-unlocked={unlocked === undefined ? undefined : String(unlocked)}>
       <span className="flex flex-wrap items-center gap-1.5 font-semibold">
         <img src={skill.icon} alt="" aria-hidden="true" className="size-7 shrink-0 object-contain" />

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -402,6 +402,13 @@ export function InfraCalculator(props: InfraCalculatorProps) {
     }
     return map;
   }, [operbox]);
+  const levelByOperator = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const entry of operbox ?? []) {
+      if (entry.own) map.set(entry.name, entry.level);
+    }
+    return map;
+  }, [operbox]);
   const [shortcutGuideOpen, setShortcutGuideOpen] = useState(false);
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
   const [planActionsOpen, setPlanActionsOpen] = useState(false);
@@ -652,6 +659,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
               layout={layout}
               planRevision={scheduleResult?.diagnosticId}
               eliteByOperator={eliteByOperator}
+              levelByOperator={levelByOperator}
               activeShift={activeShift}
               shiftDirection={shiftDirection}
               activePlan={activePlan}

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -139,6 +139,12 @@ export function ManualSchedulePage({
   ), [operbox]);
   const canPersistDraft = ownedOperators.length > 0;
   const ownedFingerprint = ownedOperators.map((operator) => operator.name).join("\0");
+  const eliteByOperator = useMemo(() => new Map(
+    ownedOperators.map((operator) => [operator.name, operator.elite]),
+  ), [ownedOperators]);
+  const levelByOperator = useMemo(() => new Map(
+    ownedOperators.map((operator) => [operator.name, operator.level]),
+  ), [ownedOperators]);
 
   useEffect(() => {
     if (restored) return;
@@ -344,6 +350,8 @@ export function ManualSchedulePage({
         rows={rows}
         layout={layout}
         planRevision={`manual-${activeShift}`}
+        eliteByOperator={eliteByOperator}
+        levelByOperator={levelByOperator}
         activeShift={activeShift}
         activePlan={activePlan}
         searchQuery={scheduleQuery}

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -100,7 +100,7 @@ function ManualOperatorChoice({
       </span>
     </button>
   );
-  return <OperatorSkillTooltip name={operator.name} trigger={card} delay={1_500} disabled={tooltipDisabled} />;
+  return <OperatorSkillTooltip name={operator.name} trigger={card} delay={300} disabled={tooltipDisabled} />;
 }
 
 export function ManualSchedulePage({
@@ -380,7 +380,7 @@ export function ManualSchedulePage({
             <Input autoFocus value={pickerQuery} onChange={(event) => setPickerQuery(event.target.value)} className="pl-9" placeholder={en ? "Search operators" : "搜索干员"} aria-label={en ? "Search selectable operators" : "搜索可选干员"} />
           </div>
           <div className="grid max-h-[52svh] grid-cols-1 gap-2 overflow-y-auto pr-1 sm:grid-cols-2" data-manual-operator-picker onScroll={handlePickerScroll}>
-            <TooltipProvider delay={1_500} timeout={0}>
+            <TooltipProvider delay={300} timeout={100}>
               {picker?.kind === "slot" ? (
                 <div className="col-span-full grid grid-cols-2 gap-2">
                   <Button type="button" variant="outline" className="min-w-0 justify-center" onClick={() => chooseOperator(null)}><X />{en ? "Leave empty" : "保持空置"}</Button>

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -22,6 +22,7 @@ import { demoOperatorName, useLanguageDemo, type DemoLocale } from "@/language-d
 import { cn } from "@/lib/utils";
 import {
   buildManualOperbox,
+  manualLevelFor,
   manualStageForEntry,
   maxEliteForRarity,
   type ManualOperboxStage,
@@ -121,6 +122,8 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
   const en = locale === "en";
   const displayName = demoOperatorName(operator.name, locale);
   const maxElite = maxEliteForRarity(operator.rarity);
+  const selectedElite = stage === "none" ? null : stage === "e2" ? 2 : stage === "e1" ? 1 : 0;
+  const selectedLevel = selectedElite === null ? undefined : manualLevelFor(operator.rarity, selectedElite);
   const identity = (
     <button
       type="button"
@@ -173,7 +176,16 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
         ? "grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-2 p-2 [contain-intrinsic-size:4.5rem] sm:grid-cols-[2.5rem_minmax(6.5rem,0.72fr)_minmax(13rem,1.28fr)]"
         : "grid gap-3 p-3 [contain-intrinsic-size:8.5rem]",
     )}>
-      <OperatorSkillTooltip name={operator.name} trigger={identity} delay={400} />
+      <OperatorSkillTooltip
+        name={operator.name}
+        trigger={identity}
+        contextLabel={selectedElite === null
+          ? (en ? "Current selection: Unowned" : "当前选择：未拥有")
+          : (en ? `Current selection: E${selectedElite} Lv.${selectedLevel}` : `当前选择：精${selectedElite} Lv.${selectedLevel}`)}
+        currentElite={selectedElite}
+        currentLevel={selectedLevel}
+        delay={400}
+      />
 
       <div
         role="radiogroup"

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LoadMore } from "@/components/ui/load-more";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { OperatorSkillTooltip } from "@/components/OperatorSkillTooltip";
 import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import { demoOperatorName, useLanguageDemo, type DemoLocale } from "@/language-demo";
 import { cn } from "@/lib/utils";
@@ -120,6 +121,50 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
   const en = locale === "en";
   const displayName = demoOperatorName(operator.name, locale);
   const maxElite = maxEliteForRarity(operator.rarity);
+  const identity = (
+    <button
+      type="button"
+      className={cn(
+        "min-w-0 rounded-[4px] text-left outline-none hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800] focus-visible:ring-offset-2",
+        compact
+          ? "col-span-2 grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-2 sm:col-span-2"
+          : "flex items-center gap-3",
+      )}
+      aria-label={en ? `Show ${displayName} infrastructure skills` : `查看${displayName}的基建技能`}
+    >
+      <span className={cn("shrink-0 overflow-hidden border border-border bg-muted", compact ? "size-10" : "size-12 sm:size-14")}>
+        {operator.portrait ? (
+          <img
+            src={operator.portrait}
+            alt={en ? `${displayName} portrait` : `${displayName}头像`}
+            className="size-full object-cover"
+            loading="lazy"
+            decoding="async"
+          />
+        ) : null}
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-semibold">{displayName}</span>
+        <span className={cn("flex min-w-0 flex-wrap items-center gap-1", compact ? "mt-0.5" : "mt-1")}>
+          <span className="font-number text-xs text-muted-foreground">
+            {operator.rarity}★ · {en ? `Up to E${maxElite}` : `最高精${maxElite}`}
+          </span>
+          {scheduledShifts?.map((shift) => (
+            <span
+              key={shift}
+              className={cn(
+                "inline-flex h-4 items-center border px-1 text-[10px] font-semibold leading-none",
+                SHIFT_BADGE_CLASS[(shift - 1) % SHIFT_BADGE_CLASS.length],
+              )}
+              title={shiftLabel(shift, en)}
+            >
+              {shiftLabel(shift, en, true)}
+            </span>
+          ))}
+        </span>
+      </span>
+    </button>
+  );
 
   return (
     <article className={cn(
@@ -128,39 +173,7 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
         ? "grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-2 p-2 [contain-intrinsic-size:4.5rem] sm:grid-cols-[2.5rem_minmax(6.5rem,0.72fr)_minmax(13rem,1.28fr)]"
         : "grid gap-3 p-3 [contain-intrinsic-size:8.5rem]",
     )}>
-      <div className={cn("flex min-w-0 items-center", compact ? "contents" : "gap-3")}>
-        <div className={cn("shrink-0 overflow-hidden border border-border bg-muted", compact ? "size-10" : "size-12 sm:size-14")}>
-          {operator.portrait ? (
-            <img
-              src={operator.portrait}
-              alt={en ? `${displayName} portrait` : `${displayName}头像`}
-              className="size-full object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : null}
-        </div>
-        <div className="min-w-0">
-          <h5 className="truncate text-sm font-semibold">{displayName}</h5>
-          <div className={cn("flex min-w-0 flex-wrap items-center gap-1", compact ? "mt-0.5" : "mt-1")}>
-            <span className="font-number text-xs text-muted-foreground">
-              {operator.rarity}★ · {en ? `Up to E${maxElite}` : `最高精${maxElite}`}
-            </span>
-            {scheduledShifts?.map((shift) => (
-              <span
-                key={shift}
-                className={cn(
-                  "inline-flex h-4 items-center border px-1 text-[10px] font-semibold leading-none",
-                  SHIFT_BADGE_CLASS[(shift - 1) % SHIFT_BADGE_CLASS.length],
-                )}
-                title={shiftLabel(shift, en)}
-              >
-                {shiftLabel(shift, en, true)}
-              </span>
-            ))}
-          </div>
-        </div>
-      </div>
+      <OperatorSkillTooltip name={operator.name} trigger={identity} delay={400} />
 
       <div
         role="radiogroup"


### PR DESCRIPTION
## 修改内容
- 手动选择 Box 时，悬浮干员头像与名称可查看完整基建技能
- 手动排班换人弹窗的悬浮等待由 1.5 秒缩短至 0.3 秒
- 支持点击、Enter 和空格展开，兼顾触屏与键盘操作
- 滚动干员列表时仍会自动收起提示，避免遮挡

## 验证
- ESLint 通过
- 手动 Box 技能悬浮 E2E 通过
- 手动排班换人及技能悬浮 E2E 通过