### PR TITLE
v0.5.1 perf: keep manual route within bundle budget

### DIFF
--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowLeft, Download, Search, Settings2, Sparkles, X } from "lucide-react";
+import { Download, Search, Settings2, Sparkles, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { FactoryRecipe, TradeOrder } from "@/blueprint";
@@ -320,7 +320,7 @@ export function ManualSchedulePage({
         </div>
         {draft.source ? (
           <Button type="button" variant="ghost" size="sm" onClick={onOpenCalculator}>
-            <ArrowLeft />{en ? "Back to calculation" : "返回计算结果"}
+            {en ? "Back to calculation" : "返回计算结果"}
           </Button>
         ) : null}
         <Button type="button" variant="outline" size="sm" onClick={onOpenSetup}><Settings2 />{en ? "Configure Box & layout" : "配置 Box 与布局"}</Button>


### PR DESCRIPTION
## Summary

- Remove the separately bundled decorative back-arrow icon from the Manual Scheduling return action while keeping the same button label and behavior.
- Bring the production `/manual` initial JavaScript back below the existing release budget without relaxing the budget.

## Scope

- One-file follow-up on top of the merged `v0.5.1` release.
- No `develop` commits or unrelated changes are included.

## Verification

- `npx eslint src/components/pages/ManualSchedulePage.tsx`
- `git diff --check`
- CI-equivalent production `npm run build`
- `npm run check:bundle-budget` — `/manual` is 1,601,910 / 1,602,000 bytes
- `npm run check:build-traces`
- `npm run check:production-client`
- `npm run worker:build`

## Context

The first `v0.5.1` post-merge run passed static/unit checks, database integration, browser release boundaries, and all four Chromium shards. Its release build compiled successfully but exceeded the `/manual` raw bundle ceiling by 139 bytes, so deployment was correctly skipped.
