### PR TITLE
v0.6.1 fix: align main release browser test count

### DIFF
--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -208,7 +208,8 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
   assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 100);
+  // main intentionally excludes the develop-only browser scenario from this selective release.
+  assert.equal(readinessTestCount, 99);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: true/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);


### PR DESCRIPTION
## v0.6.1 release CI correction

The selective v0.6.1 release intentionally excludes one develop-only browser scenario. Restore main's expected readiness count from 100 to 99 so the post-merge quality gate reflects the files actually present on main.

Product code, database migration, build output, and runtime behavior are unchanged.

Validation: node --test --experimental-strip-types scripts/build-tooling.test.mjs (22/22).