### PR TITLE
fix: reannounce v0.6.1 once in production

### DIFF
--- a/src/components/changelog/ReleaseAnnouncement.tsx
+++ b/src/components/changelog/ReleaseAnnouncement.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { isBrowserReleaseUnread, markBrowserReleaseSeen, RELEASE_SEEN_EVENT, RELEASE_SEEN_KEY, releaseSeenKey } from "@/releases/announcement-state";
+import { isBrowserReleaseUnread, markBrowserReleaseSeen, RELEASE_SEEN_EVENT, releaseSeenKey } from "@/releases/announcement-state";
 import type { ReleaseDraft, ReleaseEnvironment } from "@/releases/types";
 import { useReleaseFeed } from "@/releases/use-release-feed";
 import { ReleaseDialog } from "./ReleaseDialog";
@@ -27,7 +27,7 @@ function Announcement({ enabled, latestRelease, environment }: {
       setDismissed(true);
     };
     const onStorage = (event: StorageEvent) => {
-      if (event.key === releaseSeenKey(environment) || event.key === RELEASE_SEEN_KEY || event.key === null) syncSeen();
+      if (event.key === releaseSeenKey(environment) || event.key === null) syncSeen();
     };
     window.addEventListener("storage", onStorage);
     window.addEventListener(RELEASE_SEEN_EVENT, syncSeen);

--- a/src/releases/announcement-state.test.ts
+++ b/src/releases/announcement-state.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { isReleaseUnread, readSeenRelease, rememberRelease, RELEASE_SEEN_KEY } from "./announcement-state.ts";
+import { isReleaseUnread, readSeenRelease, releaseSeenKey, rememberRelease, RELEASE_SEEN_KEY } from "./announcement-state.ts";
 import { releaseHistory } from "./history.ts";
 import { latestRelease } from "./latest.ts";
 
@@ -35,6 +35,22 @@ test("acknowledgement touches only the release key and preserves newer acknowled
   assert.equal(readSeenRelease(storage), "0.7.0");
   assert.equal(values.get("box"), "original");
   assert.equal(values.size, 2);
+});
+
+test("the one-time announcement revision ignores old production markers then stays seen", () => {
+  const values = new Map([["riic-release-seen-v2:production", "0.6.1"]]);
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => { values.set(key, value); },
+  };
+  const activeKey = releaseSeenKey("production");
+  assert.equal(activeKey, "riic-release-seen-v3:production");
+  assert.equal(releaseSeenKey("development"), "riic-release-seen-v2:development");
+  assert.equal(releaseSeenKey("local"), "riic-release-seen-v2:local");
+  assert.equal(isReleaseUnread("0.6.1", readSeenRelease(storage, activeKey)), true);
+  rememberRelease(storage, "0.6.1", activeKey);
+  assert.equal(isReleaseUnread("0.6.1", readSeenRelease(storage, activeKey)), false);
+  assert.equal(values.get("riic-release-seen-v2:production"), "0.6.1");
 });
 
 test("unavailable or full browser storage does not throw", () => {

--- a/src/releases/announcement-state.ts
+++ b/src/releases/announcement-state.ts
@@ -3,8 +3,14 @@ import type { ReleaseEnvironment } from "./types.ts";
 export const RELEASE_SEEN_KEY = "riic-release-seen-v1";
 export const RELEASE_SEEN_EVENT = "riic-release-seen";
 
+// Revision 3 intentionally gives every production browser one fresh v0.6.1
+// announcement. Once acknowledged, the new marker keeps later reloads and
+// redeployments quiet exactly as before.
+const PRODUCTION_RELEASE_SEEN_STORAGE_REVISION = 3;
+
 export function releaseSeenKey(environment: ReleaseEnvironment): string {
-  return `riic-release-seen-v2:${environment}`;
+  const revision = environment === "production" ? PRODUCTION_RELEASE_SEEN_STORAGE_REVISION : 2;
+  return `riic-release-seen-v${revision}:${environment}`;
 }
 
 type ReleaseStorage = Pick<Storage, "getItem" | "setItem">;
@@ -46,8 +52,7 @@ const sessionSeen = new Map<ReleaseEnvironment, string>();
 export function isBrowserReleaseUnread(version: string, environment: ReleaseEnvironment): boolean {
   if (!isReleaseUnread(version, sessionSeen.get(environment) ?? null)) return false;
   try {
-    const seen = readSeenRelease(window.localStorage, releaseSeenKey(environment))
-      ?? (environment === "production" ? readSeenRelease(window.localStorage) : null);
+    const seen = readSeenRelease(window.localStorage, releaseSeenKey(environment));
     return isReleaseUnread(version, seen);
   }
   catch { return true; }


### PR DESCRIPTION
## Summary
- give every production browser one fresh v0.6.1 announcement
- preserve development and local read markers
- keep the new acknowledgement stable across refreshes and redeployments

## Verification
- npm run check
- npm run build
- previous local preview remains healthy on port 5194