### PR TITLE
fix(i18n): release catalog hydration hotfix

### DIFF
--- a/e2e/i18n-skill-filters.spec.ts
+++ b/e2e/i18n-skill-filters.spec.ts
@@ -58,6 +58,27 @@ test("legacy preference migrates once; an existing cookie takes precedence", asy
   await expect(page.locator("html")).toHaveAttribute("lang", "zh-CN");
 });
 
+test("a warm English game catalog does not race workbench hydration", async ({ page, context, baseURL }) => {
+  await context.addCookies([{ name: "riic-locale", value: "en", url: baseURL! }]);
+  const hydrationErrors: string[] = [];
+  page.on("pageerror", (error) => {
+    if (/hydration|React error #418/i.test(error.message)) hydrationErrors.push(error.message);
+  });
+
+  await page.goto("/");
+  // Let the independently loaded game catalog enter the browser cache before
+  // repeatedly hydrating a route that renders localized operator and skill text.
+  await page.waitForTimeout(2_000);
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    await page.goto("/skills");
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator("[data-skill-filter-row]")).toHaveCount(4);
+    await page.goto("/");
+  }
+
+  expect(hydrationErrors).toEqual([]);
+});
+
 for (const locale of ["zh", "en"] as const) {
   test(`${locale} public pages render translated headings and metadata`, async ({ page, context, baseURL }) => {
     await context.addCookies([{ name: "riic-locale", value: locale, url: baseURL! }]);

--- a/src/app/admin/issues/issues-client.tsx
+++ b/src/app/admin/issues/issues-client.tsx
@@ -45,6 +45,7 @@ import type {
   ApiResponse,
 } from "@/types";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 const PAGE_SIZE = 50;
 
@@ -121,6 +122,7 @@ function downloadReproduction(reproduction: AdminReproductionData): void {
 function ReproductionPanel({ state }: { state: DetailState }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const [copied, setCopied] = useState(false);
   if (state.loading) {
@@ -129,7 +131,7 @@ function ReproductionPanel({ state }: { state: DetailState }) {
   if (state.error) return <p role="alert" className="py-4 text-sm text-destructive">{state.error}</p>;
   const reproduction = state.reproduction;
   if (!reproduction) return null;
-  const operatorNames = reproduction.operbox?.map((operator) => localizedOperatorName(operator.name, locale)).filter(Boolean) ?? [];
+  const operatorNames = reproduction.operbox?.map((operator) => localizedOperatorName(operator.name, locale, gameCatalog)).filter(Boolean) ?? [];
   return (
     <div className="grid gap-4 border-t border-border/70 pt-4">
       {!reproduction.available ? (
@@ -214,6 +216,7 @@ function FeedbackRow({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const statusLabels = messageRecord(en, "app_admin_issues_issues_client_labels2");
   const facilityLabels = messageRecord(en, "app_admin_issues_issues_client_labels3");
@@ -230,7 +233,7 @@ function FeedbackRow({
             <span className="font-number text-xs text-muted-foreground">{formatDate(item.createdAt, en)}</span>
           </div>
           <p className="mt-2 break-words whitespace-pre-wrap text-sm leading-6">{item.note}</p>
-          {item.room?.operators.length ? <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">{intl("app_admin_issues_issues_client.currentOperators")}{item.room.operators.map((name) => localizedOperatorName(name, locale)).join(intl("app_admin_issues_issues_client.label"))}</p> : null}
+          {item.room?.operators.length ? <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">{intl("app_admin_issues_issues_client.currentOperators")}{item.room.operators.map((name) => localizedOperatorName(name, locale, gameCatalog)).join(intl("app_admin_issues_issues_client.label"))}</p> : null}
           <p className="font-number mt-2 break-all text-[11px] text-muted-foreground">{item.diagnosticId}</p>
         </div>
       </div>

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -49,6 +49,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
 import { loadClientFeature } from "@/client-lazy-loader";
 import { localizedBuildingSkill, localizedOperatorName, localizedRoomTitle } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import {
   BUILDING_SKILL_ENHANCED_WORD,
   buildingSkillUnlockLabel,
@@ -606,6 +607,7 @@ export function LayoutEditor({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
 
   const factoryRecipesUnlocked = hasUnlockedFactoryRecipes(layout);
   const roomGroups = [
@@ -648,7 +650,7 @@ export function LayoutEditor({
               const levelMax = maxRoomLevel(room.kind);
               const visualGroup = roomVisualGroupForKind(room.kind);
               const originalName = group.rooms.length > 1 ? `${roomKindLabel(room.kind)} ${roomIndex + 1}` : roomKindLabel(room.kind);
-              const displayName = localizedRoomTitle(originalName, visualGroup, locale);
+              const displayName = localizedRoomTitle(originalName, visualGroup, locale, gameCatalog);
 
               return (
                 <div
@@ -1173,6 +1175,7 @@ export function RoomProductControls({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
 
   if (row.group === "training") {
     return null;
@@ -1188,7 +1191,7 @@ export function RoomProductControls({
     return (
       <div className={cn("w-full", isTrade ? "max-sm:w-fit" : "max-w-[220px]")}>
         <ProductToggleGroup<TradeOrder | FactoryRecipe>
-          ariaLabel={`${localizedRoomTitle(row.title, row.group, locale)} ${isTrade ? (intl("components.orders")) : (intl("components.recipe"))}`}
+          ariaLabel={`${localizedRoomTitle(row.title, row.group, locale, gameCatalog)} ${isTrade ? (intl("components.orders")) : (intl("components.recipe"))}`}
           value={activeProduct}
           options={isTrade ? TRADE_ORDER_OPTIONS : FACTORY_RECIPE_OPTIONS}
           columns={isTrade ? 2 : 4}
@@ -1310,7 +1313,8 @@ function BuildingSkillBadge({
   const intl = useTranslations();
   const [open, setOpen] = useState(false);
   const locale = useLocale();
-  const displaySkill = localizedBuildingSkill(skill.id, locale, skill);
+  const gameCatalog = useGameCatalog();
+  const displaySkill = localizedBuildingSkill(skill.id, locale, skill, gameCatalog);
   const unlockLabel = locale === "en"
     ? buildingSkillUnlockLabelEnglish(skill.elite, skill.level, skill.enhanced)
     : buildingSkillUnlockLabel(skill.elite, skill.level, skill.enhanced);
@@ -1412,7 +1416,8 @@ export function OperatorSlot({
   const intl = useTranslations();
   const shouldReduceMotion = useReducedMotion();
   const locale = useLocale();
-  const displayName = slot ? localizedOperatorName(slot.name, locale) : undefined;
+  const gameCatalog = useGameCatalog();
+  const displayName = slot ? localizedOperatorName(slot.name, locale, gameCatalog) : undefined;
   const displayPositionLabel = locale === "en" ? (positionLabel === "训练位" ? "Trainee" : positionLabel === "协助位" ? "Trainer" : positionLabel) : positionLabel;
   const identity = slot?.name ?? (autofill ? "autofill" : "empty");
   const suppressNativeTitles = showSkillTooltip && slot !== undefined;
@@ -1613,6 +1618,7 @@ export function ScheduleBoard({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const [collapsedGroups, setCollapsedGroups] = useState<Record<string, boolean>>({});
   const [hiddenGroups, setHiddenGroups] = useState<Record<string, boolean>>({});
@@ -1905,7 +1911,7 @@ export function ScheduleBoard({
                           <div>
                             <div className="flex items-center gap-2.5 max-sm:gap-1.5">
                               <div className={cn("font-number min-w-0 truncate font-medium tracking-[-0.02em] text-white [text-shadow:0_2px_3px_rgba(0,0,0,0.75)]", listRoomTitleSizeClass())}>
-                                {localizedRoomTitle(row.title, row.group, locale)}
+                                {localizedRoomTitle(row.title, row.group, locale, gameCatalog)}
                               </div>
                               <LevelDiamonds level={row.level} maxLevel={layoutRoom ? maxRoomLevel(layoutRoom.kind) : row.level} />
                             </div>
@@ -1982,7 +1988,7 @@ export function ScheduleBoard({
                             variant="ghost"
                             size="icon-sm"
                             className="border border-white/10 bg-[#3C3C3C]/55 text-white/70 hover:bg-[#4B4B4B] hover:text-white disabled:cursor-not-allowed disabled:opacity-45 max-sm:size-11"
-                            aria-label={intl("components.reportScheduleIssue", { value1: (en) ? (localizedRoomTitle(row.title, row.group, locale)) : "", title: (en) ? "" : (row.title) })}
+                            aria-label={intl("components.reportScheduleIssue", { value1: (en) ? (localizedRoomTitle(row.title, row.group, locale, gameCatalog)) : "", title: (en) ? "" : (row.title) })}
                             disabled={feedbackDisabled}
                             onClick={() => onIssue(row)}
                           >

--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -36,6 +36,7 @@ import type { RoomRow } from "@/schedule";
 import type { BaseBlueprint, MaaPlan } from "@/types";
 import type { ShiftDirection } from "@/motion";
 import { localizedRoomTitle } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 export interface CompactScheduleViewProps {
   rows: RoomRow[];
@@ -95,6 +96,7 @@ function CompactRoomCard({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const efficiencyLabel = (label?: string) => en && label ? ({ "纯技能": "Skill", "技能效率": "Skill efficiency", "跨设施": "Cross-facility", "综合加成": "Combined bonus", "仓储上限": "Capacity", "订单机制": "Order mechanic", "总充能": "Total charge" }[label] ?? label) : label;
   const isTrade = layoutRoom?.kind === "trade_post";
@@ -112,7 +114,7 @@ function CompactRoomCard({
   const header = (
     <div className={COMPACT_HEADER_CLASS}>
       <span className="infra-room-accent h-5 w-1 shrink-0 bg-[var(--room-accent)]" aria-hidden="true" />
-      <span className={`${COMPACT_ROOM_TITLE_CLASS} font-number`}>{localizedRoomTitle(row.title, row.group, locale)}</span>
+      <span className={`${COMPACT_ROOM_TITLE_CLASS} font-number`}>{localizedRoomTitle(row.title, row.group, locale, gameCatalog)}</span>
       <LevelDiamonds
         level={row.level}
         maxLevel={layoutRoom ? maxRoomLevel(layoutRoom.kind) : row.level}
@@ -251,8 +253,9 @@ function CompactRoomCard({
 function CompactFeedbackButton({ row, disabled, onIssue }: { row: RoomRow; disabled: boolean; onIssue: (row: RoomRow) => void }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
 
-  const roomTitle = localizedRoomTitle(row.title, row.group, locale);
+  const roomTitle = localizedRoomTitle(row.title, row.group, locale, gameCatalog);
   return (
     <Tooltip>
       <TooltipTrigger

--- a/src/components/FiammettaTargetChip.tsx
+++ b/src/components/FiammettaTargetChip.tsx
@@ -4,6 +4,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { HeartPulse } from "lucide-react";
 
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 export interface FiammettaTargetChipProps {
   target?: string | null;
@@ -15,8 +16,9 @@ export interface FiammettaTargetChipProps {
 export function FiammettaTargetChip({ target, portrait, onClick }: FiammettaTargetChipProps) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
 
-  const displayTarget = target ? localizedOperatorName(target, locale) : null;
+  const displayTarget = target ? localizedOperatorName(target, locale, gameCatalog) : null;
   const label = displayTarget
     ? (intl("components_FiammettaTargetChip.moraleRecovery", { displayTarget: displayTarget }))
     : (intl("components_FiammettaTargetChip.chooseMoraleTarget"));

--- a/src/components/OperatorSkillTooltip.tsx
+++ b/src/components/OperatorSkillTooltip.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/operatorPortraits";
 import { useLocale } from "next-intl";
 import { localizedBuildingSkill } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import { cn } from "@/lib/utils";
 
 /**
@@ -52,6 +53,7 @@ export function OperatorSkillTooltip({
   disabled?: boolean;
 }) {
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const [open, setOpen] = useState(false);
   const skills = operatorBuildingSkillList(name);
   useEffect(() => {
@@ -93,7 +95,7 @@ export function OperatorSkillTooltip({
         <SkillBlock
           key={sourceSkill.id}
           locale={locale}
-          skill={localizedBuildingSkill(sourceSkill.id, locale, sourceSkill) as BuildingSkillPresentation}
+          skill={localizedBuildingSkill(sourceSkill.id, locale, sourceSkill, gameCatalog) as BuildingSkillPresentation}
           highlighted={highlighted.has(sourceSkill.id)}
           unlocked={currentElite === undefined
             ? undefined

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -13,6 +13,7 @@ import { operatorPortraitFor, operatorProfessionFor } from "@/operatorPortraits"
 import type { OperBoxEntry, UserProfileAction } from "@/types";
 import { legacyTrainingTarget, trainingAdviceSkillSummary } from "@/components/training-advice/skill-selection";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 const DOMAIN_GROUPS: Record<string, string> = { trade: "trading", trading: "trading", manufacture: "manufacture", manu: "manufacture", power: "power", control: "control", general: "training" };
 
@@ -32,9 +33,10 @@ export function RecommendationCard({ action, entry, variant = "full", index = 0,
   const intl = useTranslations();
   const reduceMotion = useReducedMotion();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const priority = action.priority || (intl("components_RecommendationCard.unranked"));
-  const operatorName = localizedOperatorName(action.operator, locale) || (intl("components_RecommendationCard.unknownOperator"));
+  const operatorName = localizedOperatorName(action.operator, locale, gameCatalog) || (intl("components_RecommendationCard.unknownOperator"));
   const isHighPriority = /高|urgent|critical|p0|p1/i.test(priority);
   const skillSummary = trainingAdviceSkillSummary(
     action.operator,

--- a/src/components/ShiftComparisonCard.tsx
+++ b/src/components/ShiftComparisonCard.tsx
@@ -12,6 +12,7 @@ import { MOTION_DURATION, MOTION_EASE_OUT } from "@/motion";
 import { roomLightAccentFor } from "@/room-visuals";
 import type { ShiftAdjustment, ShiftAdjustmentIssue, ShiftComparison } from "@/types";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 const ISSUE_LABELS: Record<ShiftAdjustmentIssue, string> = { missing: "需换入", unexpected: "需换出", misplaced: "位置调整", tired: "疲劳" };
 const ISSUE_LABELS_EN: Record<ShiftAdjustmentIssue, string> = { missing: "Move in", unexpected: "Move out", misplaced: "Relocate", tired: "Fatigued" };
@@ -69,9 +70,10 @@ function RoomLabel({ roomKey }: { roomKey: string | null }) {
 
 function OperatorName({ adjustment, className }: { adjustment: ShiftAdjustment; className?: string }) {
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   return (
     <div className={cn("flex min-w-0 flex-wrap items-center gap-1.5", className)}>
-      <strong className="min-w-0 truncate">{localizedOperatorName(adjustment.operator, locale)}</strong>
+      <strong className="min-w-0 truncate">{localizedOperatorName(adjustment.operator, locale, gameCatalog)}</strong>
       {adjustment.issues.includes("tired") ? <IssueLabel issue="tired" /> : null}
     </div>
   );
@@ -104,6 +106,7 @@ function GroupHeading({ issue, count, id }: { issue: ActionIssue; count: number;
 function MobileAdjustmentGroups({ adjustments, reduceMotion }: { adjustments: ShiftAdjustment[]; reduceMotion: boolean }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const tiredOnly = adjustments.filter((adjustment) => adjustment.issues.includes("tired") && !ACTION_ISSUES.some((issue) => adjustment.issues.includes(issue)));
 
@@ -141,7 +144,7 @@ function MobileAdjustmentGroups({ adjustments, reduceMotion }: { adjustments: Sh
             <h4 id="mobile-adjustment-tired"><IssueLabel issue="tired" /></h4>
             <span className="font-number text-xs text-muted-foreground">{tiredOnly.length} {localize_components_ShiftComparisonCard.text(en, "additional2", { choice1: ((en)) && (tiredOnly.length === 1) ? "yes" : "no" })}</span>
           </div>
-          <p className="mt-2 bg-red-50 px-3 py-2.5 text-xs leading-5 text-red-800">{tiredOnly.map((adjustment) => localizedOperatorName(adjustment.operator, locale)).join(intl("components_ShiftComparisonCard.label"))}</p>
+          <p className="mt-2 bg-red-50 px-3 py-2.5 text-xs leading-5 text-red-800">{tiredOnly.map((adjustment) => localizedOperatorName(adjustment.operator, locale, gameCatalog)).join(intl("components_ShiftComparisonCard.label"))}</p>
         </section>
       ) : null}
     </div>

--- a/src/components/mastery/MasteryTargetPicker.tsx
+++ b/src/components/mastery/MasteryTargetPicker.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import { OperatorIdentity, OperatorSearch, OperatorRarityFilter, OperatorProfessionFilter, OperatorRosterGrid, OPERATOR_PAGE_SIZE } from "@/components/operators/OperatorPickerParts";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import { eligibleMasteryTargets } from "@/mastery";
 import { PROFESSION_LABELS, PROFESSION_LABELS_ENGLISH } from "@/operator-presentation";
 import catalog from "@/generated/arkntools/operator-catalog.json";
@@ -19,6 +20,7 @@ export function MasteryTargetPicker({ operbox, selectedId, onSelect, onClose }: 
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const [selected, setSelected] = useState(selectedId);
   const [query, setQuery] = useState("");
@@ -30,7 +32,7 @@ export function MasteryTargetPicker({ operbox, selectedId, onSelect, onClose }: 
   const filtered = eligible.filter((o) => {
     const meta = byId.get(o.id)!;
     return (rarity === "all" || o.rarity === Number(rarity)) && (profession === "all" || meta.profession === Number(profession))
-      && (!deferred || [o.name,o.id,localizedOperatorName(o.name,locale)].some((name) => name.toLocaleLowerCase().includes(deferred)));
+      && (!deferred || [o.name,o.id,localizedOperatorName(o.name,locale,gameCatalog)].some((name) => name.toLocaleLowerCase().includes(deferred)));
   }).sort((a,b) => b.rarity - a.rarity || byId.get(b.id)!.order - byId.get(a.id)!.order);
   return <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
     <DialogContent className="max-h-[90dvh] grid-rows-[auto_minmax(0,1fr)_auto] sm:max-w-[min(880px,calc(100vw-2rem))]" data-mastery-target-picker>
@@ -45,7 +47,7 @@ export function MasteryTargetPicker({ operbox, selectedId, onSelect, onClose }: 
           <div className="max-w-full overflow-x-auto"><OperatorProfessionFilter value={profession} onChange={(value) => { setProfession(value); setLimit(OPERATOR_PAGE_SIZE); }} /></div>
         </div>
         {filtered.length ? <OperatorRosterGrid hasMore={limit < filtered.length} onLoadMore={() => setLimit((value) => value + OPERATOR_PAGE_SIZE)}>
-          {filtered.slice(0,limit).map((o) => <button key={o.id} type="button" aria-label={intl("components_mastery_MasteryTargetPicker.select", { value1: (en) ? (localizedOperatorName(o.name,locale)) : "", name: (en) ? "" : (o.name) })} aria-pressed={selected === o.id}
+          {filtered.slice(0,limit).map((o) => <button key={o.id} type="button" aria-label={intl("components_mastery_MasteryTargetPicker.select", { value1: (en) ? (localizedOperatorName(o.name,locale,gameCatalog)) : "", name: (en) ? "" : (o.name) })} aria-pressed={selected === o.id}
             onClick={() => setSelected(o.id)} className={cn("flex min-w-0 items-center gap-3 rounded-[4px] border bg-background p-3 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring", selected === o.id ? "border-primary ring-1 ring-primary" : "border-border hover:bg-muted")}>
             <OperatorIdentity name={o.name} portrait={byId.get(o.id)?.portrait}>
               <span className="font-number text-xs text-muted-foreground">{o.rarity}★ · {intl("components_mastery_MasteryTargetPicker.e2")} · {(en ? PROFESSION_LABELS_ENGLISH : PROFESSION_LABELS)[byId.get(o.id)!.profession]}</span>

--- a/src/components/operators/OperatorPickerParts.tsx
+++ b/src/components/operators/OperatorPickerParts.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { LoadMore } from "@/components/ui/load-more";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import { PROFESSION_LABELS, PROFESSION_LABELS_ENGLISH } from "@/operator-presentation";
 import { cn } from "@/lib/utils";
 
@@ -20,7 +21,8 @@ export function OperatorIdentity({ name, portrait, compact = false, children }: 
 }) {
   const intl = useTranslations();
   const locale = useLocale();
-  const displayName = localizedOperatorName(name, locale);
+  const gameCatalog = useGameCatalog();
+  const displayName = localizedOperatorName(name, locale, gameCatalog);
   return <>
     <span className={cn("shrink-0 overflow-hidden border border-border bg-muted", compact ? "size-10" : "size-12 sm:size-14")}>
       {portrait ? <img src={portrait} alt={intl("components_operators_OperatorPickerParts.portrait", { displayName: displayName })} className="size-full object-cover" loading="lazy" decoding="async" /> : null}

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -22,6 +22,7 @@ import { Input } from "@/components/ui/input";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { downloadJson } from "@/download";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import {
   assignManualOperator,
   createManualScheduleDraft,
@@ -82,7 +83,8 @@ function ManualOperatorChoice({
   tooltipDisabled: boolean;
   onChoose: () => void;
 }) {
-  const displayName = localizedOperatorName(operator.name, en ? "en" : "zh");
+  const gameCatalog = useGameCatalog();
+  const displayName = localizedOperatorName(operator.name, en ? "en" : "zh", gameCatalog);
   const portrait = operatorPortraitFor(operator.name, operator.id);
   const card = (
     <button

--- a/src/components/pages/MasteryPlanner.tsx
+++ b/src/components/pages/MasteryPlanner.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/ui/input";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Skeleton } from "@/components/ui/skeleton";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import catalog from "@/generated/arkntools/operator-catalog.json";
 import type { OperBoxEntry } from "@/types";
 
@@ -39,6 +40,7 @@ export interface MasteryPlannerProps {
 export function MasteryPlanner({ operbox, sourceName, requiresAccount, pending, onOpenSetup, onRequestAccount, pickerRequested, onPickerRequestConsumed }: MasteryPlannerProps) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -61,7 +63,7 @@ export function MasteryPlanner({ operbox, sourceName, requiresAccount, pending, 
   const signature = JSON.stringify(input);
   const stale = !!calculation && calculation.signature !== signature;
   const plan = !stale ? calculation?.result[mode] : null;
-  const displayName = (name: string) => localizedOperatorName(name,locale);
+  const displayName = (name: string) => localizedOperatorName(name,locale,gameCatalog);
   const conditions = intl("components_pages_MasteryPlanner.assumesSufficientMoraleMaterialsAndTrainingRoomLevelEnvironment");
   const activeEnvironment = environmentKeys.map((key) => `${en ? MASTERY_ENVIRONMENTS[key]!.english : MASTERY_ENVIRONMENTS[key]!.label} ${input.environment[key]}`).join(" · ");
   const settingsSummary = `${intl("components_pages_MasteryPlanner.controlBonus")} ${controlBonus ? "+5%" : "0%"} · ${intl("components_pages_MasteryPlanner.buffer")} ${bufferMinutes} ${intl("components_pages_MasteryPlanner.min")}${activeEnvironment ? ` · ${activeEnvironment}` : ""}`;

--- a/src/components/pages/SklandStatus.tsx
+++ b/src/components/pages/SklandStatus.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/components/pages/StatusCenterShell";
 import { cn } from "@/lib/utils";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import { operatorPortraitFor, operatorProfessionFor } from "@/operatorPortraits";
 import { roomGridTone } from "@/schedule-view-presentation";
 import { SklandLoginPanel } from "@/skland-components";
@@ -360,6 +361,7 @@ function OverviewTab({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const { infrastructure, player, progress } = snapshot;
   const fullProductionRooms = infrastructure.rooms.filter(
@@ -547,7 +549,7 @@ function OverviewTab({
             </div>
             <div className="border-t border-white/10 pt-2">
               <dt className="text-white/50">{intl("components_pages_SklandStatus.assistant")}</dt>
-              <dd className="mt-1 font-medium text-white">{player.secretary?.name ? localizedOperatorName(player.secretary.name, locale) : (intl("components_pages_SklandStatus.notProvided"))}</dd>
+              <dd className="mt-1 font-medium text-white">{player.secretary?.name ? localizedOperatorName(player.secretary.name, locale, gameCatalog) : (intl("components_pages_SklandStatus.notProvided"))}</dd>
             </div>
             <div className="border-t border-white/10 pt-2">
               <dt className="text-white/50">{intl("components_pages_SklandStatus.monthlyCardExpires")}</dt>
@@ -926,6 +928,7 @@ function LayoutSyncControl({
 function InfrastructureTab({ snapshot }: { snapshot: SklandStatusSnapshot }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const { infrastructure } = snapshot;
   const now = useMinuteTimestamp(infrastructure.currentTs);
@@ -961,12 +964,12 @@ function InfrastructureTab({ snapshot }: { snapshot: SklandStatusSnapshot }) {
               {intl("components_pages_SklandStatus.trainingRoom")}
             </OverviewTechnicalHeading>
             <p className="mt-5 text-2xl font-semibold tracking-[-0.02em] text-[var(--room-accent)]">
-              {infrastructure.training?.trainee ? localizedOperatorName(infrastructure.training.trainee, locale) : (intl("components_pages_SklandStatus.currentlyIdle"))}
+              {infrastructure.training?.trainee ? localizedOperatorName(infrastructure.training.trainee, locale, gameCatalog) : (intl("components_pages_SklandStatus.currentlyIdle"))}
             </p>
             <div className="mt-auto pt-4 text-xs leading-5 text-white/58">
             {infrastructure.training ? (
               <>
-                <p className="font-number">{intl("components_pages_SklandStatus.skill")} {infrastructure.training.skillIndex} · {intl("components_pages_SklandStatus.trainer2")}: {infrastructure.training.trainer ? localizedOperatorName(infrastructure.training.trainer, locale) : (intl("components_pages_SklandStatus.none"))}</p>
+                <p className="font-number">{intl("components_pages_SklandStatus.skill")} {infrastructure.training.skillIndex} · {intl("components_pages_SklandStatus.trainer2")}: {infrastructure.training.trainer ? localizedOperatorName(infrastructure.training.trainer, locale, gameCatalog) : (intl("components_pages_SklandStatus.none"))}</p>
                 <p className="font-number">{intl("components_pages_SklandStatus.remaining")} {formatDuration(infrastructure.training.remainSecs, en)} · {intl("components_pages_SklandStatus.speed")} {Math.round(infrastructure.training.speed * 100)}%</p>
               </>
             ) : (intl("components_pages_SklandStatus.noTrainingTask"))}

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -20,6 +20,7 @@ import { OperatorSkillTooltip } from "@/components/OperatorSkillTooltip";
 import { SetupActionButton } from "@/components/setup/SetupActionButton";
 import type { AppLocale } from "@/i18n/config";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 import { cn } from "@/lib/utils";
 import {
   buildManualOperbox,
@@ -119,7 +120,8 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
   onStageChange: (id: string, stage: ManualOperboxStage) => void;
 }) {
   const en = locale === "en";
-  const displayName = localizedOperatorName(operator.name, locale);
+  const gameCatalog = useGameCatalog();
+  const displayName = localizedOperatorName(operator.name, locale, gameCatalog);
   const maxElite = maxEliteForRarity(operator.rarity);
   const selectedElite = stage === "none" ? null : stage === "e2" ? 2 : stage === "e1" ? 1 : 0;
   const selectedLevel = selectedElite === null ? undefined : manualLevelFor(operator.rarity, selectedElite);
@@ -241,6 +243,7 @@ export function ManualOperboxPicker({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const [query, setQuery] = useState("");
   const [onlyOwned, setOnlyOwned] = useState(false);
@@ -286,11 +289,11 @@ export function ManualOperboxPicker({
     if (rarity !== "all" && operator.rarity !== Number(rarity)) return false;
     if (showProfessionFilter && profession !== "all" && operator.profession !== Number(profession)) return false;
     if (!deferredQuery) return true;
-    const displayName = localizedOperatorName(operator.name, locale).toLocaleLowerCase((locale === "en" ? "en-US" : "zh-CN"));
+    const displayName = localizedOperatorName(operator.name, locale, gameCatalog).toLocaleLowerCase((locale === "en" ? "en-US" : "zh-CN"));
     return operator.name.toLocaleLowerCase("zh-CN").includes(deferredQuery)
       || displayName.includes(deferredQuery)
       || operator.id.toLocaleLowerCase("en-US").includes(deferredQuery);
-  }), [deferredQuery, hasScheduledOperators, locale, onlyOwned, profession, rarity, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, showProfessionFilter, stages]);
+  }), [deferredQuery, gameCatalog, hasScheduledOperators, locale, onlyOwned, profession, rarity, rosterScope, scheduledNames, scheduledOperatorShifts, scheduledShift, showProfessionFilter, stages]);
 
   function resetListView() {
     setVisibleLimit(PAGE_SIZE);

--- a/src/components/skill-query/SkillResultRow.tsx
+++ b/src/components/skill-query/SkillResultRow.tsx
@@ -23,6 +23,7 @@ import {
 import { skillAnnotationKey } from "@/skill-annotations";
 import type { SkillAnnotationData } from "@/types";
 import { localizedBuildingSkill, localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 /** 按「最后一个下划线之前」的前缀分组：同一族（基础 + 提升）分到同一组，行内按 index 升序。 */
 function groupSkillsByPrefix(skills: OperatorBuildingSkillRef[]): OperatorBuildingSkillRef[][] {
@@ -65,7 +66,8 @@ export function SkillResultRow({ operator, annotationIndex }: SkillResultRowProp
   const intl = useTranslations();
   const isMobile = useIsMobile();
   const locale = useLocale();
-  const displayName = localizedOperatorName(operator.name, locale);
+  const gameCatalog = useGameCatalog();
+  const displayName = localizedOperatorName(operator.name, locale, gameCatalog);
   const skills = [...operator.buildingSkills].sort((left, right) => left.index - right.index);
 
   return (
@@ -133,8 +135,9 @@ function SkillColumn({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const sourceSkill = BUILDING_SKILL_CATALOG[id];
-  const skill = sourceSkill ? localizedBuildingSkill(id, locale, sourceSkill) : undefined;
+  const skill = sourceSkill ? localizedBuildingSkill(id, locale, sourceSkill, gameCatalog) : undefined;
 
   if (!skill) {
     return (
@@ -194,6 +197,7 @@ function MobileSkillList({
   const intl = useTranslations();
   const [selected, setSelected] = useState<OperatorBuildingSkillRef | null>(null);
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
 
   return (
@@ -201,7 +205,7 @@ function MobileSkillList({
       {skills.length ? (
         skills.map((ref) => {
           const sourceSkill = BUILDING_SKILL_CATALOG[ref.id];
-          const skill = sourceSkill ? localizedBuildingSkill(ref.id, locale, sourceSkill) : undefined;
+          const skill = sourceSkill ? localizedBuildingSkill(ref.id, locale, sourceSkill, gameCatalog) : undefined;
           const annotation = annotationIndex.get(skillAnnotationKey(operatorId, ref.id))?.note;
           return (
             <button
@@ -253,9 +257,10 @@ function SkillDetailDialog({
 }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
 
   const sourceSkill = selected ? BUILDING_SKILL_CATALOG[selected.id] : undefined;
-  const skill = selected && sourceSkill ? localizedBuildingSkill(selected.id, locale, sourceSkill) : undefined;
+  const skill = selected && sourceSkill ? localizedBuildingSkill(selected.id, locale, sourceSkill, gameCatalog) : undefined;
   const unlockLabel = selected ? buildingSkillUnlockLabel(selected.elite, selected.level, enhanced) : "";
 
   return (

--- a/src/components/training-advice/TrainingAdviceActionCard.tsx
+++ b/src/components/training-advice/TrainingAdviceActionCard.tsx
@@ -13,6 +13,7 @@ import type {
   TrainingRecommendation,
 } from "@/types";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 import {
   trainingAcquisitionLabel,
@@ -39,11 +40,12 @@ export function TrainingAdviceActionCard({
   const intl = useTranslations();
   const reduceMotion = useReducedMotion();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const actionLabel = action.action === "acquire" || action.action === "train" ? intl(`components_training_advice_TrainingAdviceActionCard.${action.action}`) : action.action;
   const currentText = action.current ? `${intl("components_training_advice_TrainingAdviceActionCard.current")} ${trainingLevelText(action.current, en)} → ` : "";
   const targetText = trainingLevelText(action.target, en);
-  const operatorName = localizedOperatorName(action.operator, locale);
+  const operatorName = localizedOperatorName(action.operator, locale, gameCatalog);
   const skillSummary = trainingAdviceSkillSummary(action.operator, action.current, action.target);
 
   return (

--- a/src/components/training-advice/TrainingCombinationCard.tsx
+++ b/src/components/training-advice/TrainingCombinationCard.tsx
@@ -15,6 +15,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { TrainingCombination, TrainingAdviceMember } from "@/types";
 import { localizedOperatorName } from "@/i18n/game-data";
+import { useGameCatalog } from "@/i18n/game-data-client";
 
 import {
   trainingCombinationStateLabel,
@@ -42,6 +43,7 @@ const STATE_CLASSES: Record<string, string> = {
 function MemberRow({ member }: { member: TrainingAdviceMember }) {
   const intl = useTranslations();
   const locale = useLocale();
+  const gameCatalog = useGameCatalog();
   const en = locale === "en";
   const isReady = member.progress === "ready";
   const isMissing = member.progress === "missing";
@@ -91,7 +93,7 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
       <span className="size-8 shrink-0 overflow-hidden border border-white/10 bg-[#272A2B]">
         <img src={operatorPortraitFor(member.operator)} alt="" className="size-full object-cover" loading="lazy" />
       </span>
-      <span className="shrink truncate text-sm text-white/85">{localizedOperatorName(member.operator, locale)}</span>
+      <span className="shrink truncate text-sm text-white/85">{localizedOperatorName(member.operator, locale, gameCatalog)}</span>
       <span className={cn("shrink-0 border px-1.5 py-0.5 text-xs", roleClass)}>
         {trainingMemberRoleLabel(member.role, en)}
       </span>

--- a/src/i18n/client.tsx
+++ b/src/i18n/client.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useState, useTransition, type ReactNode } from "react";
+import { useEffect, useTransition, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { NextIntlClientProvider, useLocale, useMessages, useTranslations } from "next-intl";
-import { loadGameCatalog } from "./game-data";
 import { isAppLocale, LEGACY_LOCALE_STORAGE, LOCALE_COOKIE, type AppLocale } from "./config";
 
 function saveLocale(locale: AppLocale) {
@@ -13,16 +12,8 @@ function saveLocale(locale: AppLocale) {
 export function LocaleProvider({ children }: { children: ReactNode }) {
   const locale = useLocale();
   const sourceMessages = useMessages();
-  const [, setGameCatalogReady] = useState(false);
-  // Refresh locale consumers once the independently loaded game text is ready.
   const messages = { ...sourceMessages };
   const router = useRouter();
-  useEffect(() => {
-    if (locale !== "en") return;
-    let active = true;
-    void loadGameCatalog().then(() => { if (active) setGameCatalogReady(true); }).catch(() => { /* Original game text remains available; retry on the next language switch. */ });
-    return () => { active = false; };
-  }, [locale]);
   useEffect(() => {
     document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
     const cookie = document.cookie.split("; ").find((item) => item.startsWith(`${LOCALE_COOKIE}=`))?.split("=")[1];

--- a/src/i18n/config.test.ts
+++ b/src/i18n/config.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_LOCALE, isAppLocale, resolveLocale } from "./config.ts";
+import { createGameCatalogStore } from "./game-data-client.ts";
+import type { EnglishCatalog } from "./game-catalog.ts";
 
 test("only supported cookie locales override the deployment default", () => {
   assert.equal(resolveLocale("en"), "en");
@@ -9,4 +11,24 @@ test("only supported cookie locales override the deployment default", () => {
     assert.equal(isAppLocale(invalid), false);
     assert.equal(resolveLocale(invalid), DEFAULT_LOCALE);
   }
+});
+
+test("game catalog store keeps a null server snapshot after the client catalog loads", async () => {
+  const catalog = { roomLabels: {}, operatorNames: {}, buildingSkills: {} } as unknown as EnglishCatalog;
+  let loads = 0;
+  const store = createGameCatalogStore(async () => { loads += 1; return catalog; });
+  let notifications = 0;
+  const unsubscribe = store.subscribe(() => { notifications += 1; });
+
+  assert.equal(store.getSnapshot(), null);
+  assert.equal(store.getServerSnapshot(), null);
+  const first = store.ensureLoaded();
+  const second = store.ensureLoaded();
+  assert.equal(first, second);
+  await first;
+  assert.equal(loads, 1);
+  assert.equal(notifications, 1);
+  assert.equal(store.getSnapshot(), catalog);
+  assert.equal(store.getServerSnapshot(), null);
+  unsubscribe();
 });

--- a/src/i18n/game-data-client.ts
+++ b/src/i18n/game-data-client.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useSyncExternalStore } from "react";
+import { useLocale } from "next-intl";
+import { loadGameCatalog } from "./game-data.ts";
+import type { EnglishCatalog } from "./game-catalog.ts";
+
+type CatalogListener = () => void;
+
+export function createGameCatalogStore(loader: () => Promise<EnglishCatalog> = loadGameCatalog) {
+  let snapshot: EnglishCatalog | null = null;
+  let pending: Promise<EnglishCatalog> | null = null;
+  const listeners = new Set<CatalogListener>();
+  return {
+    subscribe(listener: CatalogListener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot: () => snapshot,
+    // React uses this for SSR and every consumer's first hydration render.
+    getServerSnapshot: () => null,
+    ensureLoaded() {
+      pending ??= loader().then((catalog) => {
+        if (snapshot !== catalog) {
+          snapshot = catalog;
+          listeners.forEach((listener) => listener());
+        }
+        return catalog;
+      }).catch((error) => {
+        pending = null;
+        throw error;
+      });
+      return pending;
+    },
+  };
+}
+
+const gameCatalogStore = createGameCatalogStore();
+
+/** A stable null server snapshot prevents cached game data from racing streamed hydration. */
+export function useGameCatalog(): EnglishCatalog | null {
+  const locale = useLocale();
+  const catalog = useSyncExternalStore(
+    gameCatalogStore.subscribe,
+    gameCatalogStore.getSnapshot,
+    gameCatalogStore.getServerSnapshot,
+  );
+  useEffect(() => {
+    if (locale === "en" && !catalog) void gameCatalogStore.ensureLoaded().catch(() => { /* Keep upstream text and retry after a later mount. */ });
+  }, [catalog, locale]);
+  return locale === "en" ? catalog : null;
+}

--- a/src/i18n/game-data.ts
+++ b/src/i18n/game-data.ts
@@ -3,28 +3,28 @@ import type { EnglishCatalog } from "./game-catalog";
 import type { AppLocale } from "./config";
 
 // Game text is data: keep upstream records and manual overrides out of UI messages.
-let englishCatalog: EnglishCatalog | null = null;
-let request: Promise<void> | null = null;
+let request: Promise<EnglishCatalog> | null = null;
+
 export function loadGameCatalog() {
-  request ??= import("./game-catalog").then(({ ENGLISH_CATALOG }) => { englishCatalog = ENGLISH_CATALOG; }).catch((error) => { request = null; throw error; });
+  request ??= import("./game-catalog").then(({ ENGLISH_CATALOG }) => ENGLISH_CATALOG).catch((error) => { request = null; throw error; });
   return request;
 }
-export function localizedOperatorName(name: string, locale: AppLocale) {
-  return locale === "en" ? englishCatalog?.operatorNames[name] ?? name : name;
+export function localizedOperatorName(name: string, locale: AppLocale, catalog: EnglishCatalog | null) {
+  return locale === "en" ? catalog?.operatorNames[name] ?? name : name;
 }
 
-export function localizedRoomTitle(title: string, group: string, locale: AppLocale) {
+export function localizedRoomTitle(title: string, group: string, locale: AppLocale, catalog: EnglishCatalog | null) {
   if (locale !== "en") return title;
-  const label = englishCatalog?.roomLabels[group];
+  const label = catalog?.roomLabels[group];
   if (!label) return title;
   const index = title.match(/\d+\s*$/)?.[0]?.trim();
   return index ? `${label} ${index}` : label;
 }
 
-export function localizedBuildingSkill<T extends { name: string; description: string; descriptionRich?: string }>(id: string, locale: AppLocale, fallback: T): T {
+export function localizedBuildingSkill<T extends { name: string; description: string; descriptionRich?: string }>(id: string, locale: AppLocale, fallback: T, catalog: EnglishCatalog | null): T {
   if (locale !== "en") return fallback;
-  if (!englishCatalog) return fallback;
-  const translated = englishCatalog.buildingSkills[id];
+  if (!catalog) return fallback;
+  const translated = catalog.buildingSkills[id];
   return translated
     ? { ...fallback, name: translated.name, description: translated.description, descriptionRich: translated.description }
     : { ...fallback, name: localize_Common.text(locale, "missingSkillName"), description: localize_Common.text(locale, "missingSkillText"), descriptionRich: localize_Common.text(locale, "missingSkillText") };


### PR DESCRIPTION
## Release scope
- promote the verified develop hydration hotfix to production
- preserve the existing main-only release announcement history
- no schema, migration, or environment changes

## Root cause and prevention
A module-global English catalog could resolve between SSR and streamed hydration, changing operator and skill text before a client boundary hydrated. The fix uses a client-only useSyncExternalStore adapter with a stable null server snapshot and explicit catalog dependencies, so post-hydration localization updates cannot alter the initial hydration render.

## Verification
- develop PR #191 merged at 55d250c3d1ce024b1ada7d22e8f09ce11374567b
- develop post-merge release and deployment succeeded: run 34010758571
- required quality gate passed: build, lint, security audit, unit/API/database tests, Chromium 4-way suite, WebKit release boundaries
- local production warm-cache reproduction: 10/10 clean
- targeted warm-catalog Playwright regression passed
- final architecture review found no blockers

## Compatibility note
An optional non-gating full WebKit run completed with 134 passes, one flaky retry, and three unrelated existing test failures (including unsupported clipboard-write permission). The required WebKit release boundary and production profile tests passed.