### PR TITLE
feat: group sidebar navigation by purpose

### DIFF
--- a/messages/records/en.json
+++ b/messages/records/en.json
@@ -193,6 +193,10 @@
     "Strong"
   ],
   "components_layout_AppSidebar_labels": {
+    "schedulingGroup": "Base Scheduling",
+    "progressionGroup": "Progression Planning",
+    "skillsGroup": "Skill Search",
+    "personalGroup": "Personal Center",
     "calculator": "Infrastructure Calculator",
     "manual": "Manual Scheduling",
     "training": "Training Advice",

--- a/messages/records/zh.json
+++ b/messages/records/zh.json
@@ -193,6 +193,10 @@
     "强"
   ],
   "components_layout_AppSidebar_labels": {
+    "schedulingGroup": "基建排班",
+    "progressionGroup": "养成规划",
+    "skillsGroup": "技能查询",
+    "personalGroup": "个人中心",
     "calculator": "基建计算器",
     "manual": "手动排班",
     "training": "练卡建议",

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -87,12 +88,28 @@ export function AppSidebar({ page, onPageChange }: AppSidebarProps) {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
+          <SidebarGroupLabel>{labels.schedulingGroup}</SidebarGroupLabel>
           <SidebarMenu>
             <AppNavigationItem page={page} target="calculator" label={labels.calculator} icon={Calculator} onPageChange={onPageChange} />
             <AppNavigationItem page={page} target="manual" label={labels.manual} icon={SquarePen} onPageChange={onPageChange} />
             <AppNavigationItem page={page} target="training" label={labels.training} icon={GraduationCap} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.progressionGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             <AppNavigationItem page={page} target="mastery" label={labels.mastery} icon={BookOpen} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.skillsGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             <AppNavigationItem page={page} target="skill-query" label={labels.skills} icon={Search} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.personalGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             {CLIENT_SKLAND_ENABLED ? (
               <AppNavigationItem page={page} target="skland" label={labels.skland} icon={Cloud} onPageChange={onPageChange} />
             ) : null}


### PR DESCRIPTION
## Changes
- Group sidebar pages under four small gray labels.
- Reuse SidebarGroupLabel and preserve navigation and collapsed mode.
- Include Chinese and English labels.

## Validation
- i18n checks passed.
- Scoped ESLint and git diff --check passed.
- Reviewed diff: no issues found.

Release develop first, verify deployment, then promote the same change to main.