### PR TITLE
release: grouped sidebar navigation

### DIFF
--- a/messages/records/en.json
+++ b/messages/records/en.json
@@ -193,6 +193,10 @@
     "Strong"
   ],
   "components_layout_AppSidebar_labels": {
+    "schedulingGroup": "Base Scheduling",
+    "progressionGroup": "Progression Planning",
+    "skillsGroup": "Skill Search",
+    "personalGroup": "Personal Center",
     "calculator": "Infrastructure Calculator",
     "manual": "Manual Scheduling",
     "training": "Training Advice",

--- a/messages/records/zh.json
+++ b/messages/records/zh.json
@@ -193,6 +193,10 @@
     "强"
   ],
   "components_layout_AppSidebar_labels": {
+    "schedulingGroup": "基建排班",
+    "progressionGroup": "养成规划",
+    "skillsGroup": "技能查询",
+    "personalGroup": "个人中心",
     "calculator": "基建计算器",
     "manual": "手动排班",
     "training": "练卡建议",

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
   SidebarContent,
   SidebarFooter,
   SidebarGroup,
+  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -87,12 +88,28 @@ export function AppSidebar({ page, onPageChange }: AppSidebarProps) {
       </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
+          <SidebarGroupLabel>{labels.schedulingGroup}</SidebarGroupLabel>
           <SidebarMenu>
             <AppNavigationItem page={page} target="calculator" label={labels.calculator} icon={Calculator} onPageChange={onPageChange} />
             <AppNavigationItem page={page} target="manual" label={labels.manual} icon={SquarePen} onPageChange={onPageChange} />
             <AppNavigationItem page={page} target="training" label={labels.training} icon={GraduationCap} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.progressionGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             <AppNavigationItem page={page} target="mastery" label={labels.mastery} icon={BookOpen} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.skillsGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             <AppNavigationItem page={page} target="skill-query" label={labels.skills} icon={Search} onPageChange={onPageChange} />
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>{labels.personalGroup}</SidebarGroupLabel>
+          <SidebarMenu>
             {CLIENT_SKLAND_ENABLED ? (
               <AppNavigationItem page={page} target="skland" label={labels.skland} icon={Cloud} onPageChange={onPageChange} />
             ) : null}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -415,7 +415,7 @@ function SidebarGroupLabel({
     props: mergeProps<"div">(
       {
         className: cn(
-          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
           className
         ),
       },


### PR DESCRIPTION
## Changes
- Add four sidebar categories with reusable small gray labels and bilingual copy.
- Prevent collapsed transparent labels from intercepting navigation clicks and tooltips.
- Preserve main-only release-announcement behavior; no unrelated features or version bump.

## Verification
- Develop PRs #193 and #194 merged.
- Develop release run 34012367039 passed all required checks and deployment.
- Four Chromium shards, browser boundaries, static/unit checks, database integration and build passed.
- Main diff: exactly four sidebar/translation files.

Requested sequence: develop verified first, then main.