### PR TITLE
feat: scroll mastery planner to generated results

### DIFF
--- a/e2e/mastery.spec.ts
+++ b/e2e/mastery.spec.ts
@@ -11,7 +11,7 @@ test.beforeEach(async ({page}) => {
 
 for (const mobile of [false,true]) {
   test.describe(mobile ? "mastery mobile" : "mastery desktop", () => {
-    test.use({viewport:mobile ? {width:390,height:844} : {width:1440,height:1000}});
+    test.use({viewport:mobile ? {width:390,height:844} : {width:1440,height:1000}, reducedMotion:mobile ? "reduce" : "no-preference"});
     test("owned E2 picker filters and complete mastery calculation", async ({page},testInfo) => {
       test.setTimeout(120000);
       await mockApis(page);
@@ -47,6 +47,13 @@ for (const mobile of [false,true]) {
       await page.getByRole("button",{name:"生成方案",exact:true}).click();
       const result = page.locator("[data-mastery-results]");
       await expect(result).toContainText("17:16:57");
+      const expectResultsAtTop = async () => {
+        await expect.poll(async () => Math.round((await result.boundingBox())?.y ?? -1)).toBe(24);
+      };
+      await expectResultsAtTop();
+      // Re-generating unchanged inputs must also return to the results.
+      await page.getByRole("button",{name:"生成方案",exact:true}).click();
+      await expectResultsAtTop();
       await expect(result.locator("[data-setup-action] svg")).toHaveCount(0);
       await expect(result).toContainText("保留艾丽妮，先开启专3，确认减半效果生效。");
       await expect(result).toContainText("减半生效后，立即换为W。");
@@ -72,6 +79,7 @@ for (const mobile of [false,true]) {
       await expect(page.getByText("输入或 Box 已变化，请重新生成方案。",{exact:true})).toBeVisible();
       await page.getByRole("button",{name:"生成方案",exact:true}).click();
       await expect(result).toBeVisible();
+      await expectResultsAtTop();
       await page.getByRole("tablist",{name:"当前专精等级",exact:true}).getByRole("tab",{name:"专2",exact:true}).click();
       await expect(page.getByRole("tablist",{name:"目标专精等级",exact:true}).getByRole("tab",{name:"专1",exact:true})).toBeDisabled();
       await page.getByRole("button",{name:"生成方案",exact:true}).click();

--- a/e2e/mastery.spec.ts
+++ b/e2e/mastery.spec.ts
@@ -11,9 +11,10 @@ test.beforeEach(async ({page}) => {
 
 for (const mobile of [false,true]) {
   test.describe(mobile ? "mastery mobile" : "mastery desktop", () => {
-    test.use({viewport:mobile ? {width:390,height:844} : {width:1440,height:1000}, reducedMotion:mobile ? "reduce" : "no-preference"});
+    test.use({viewport:mobile ? {width:390,height:844} : {width:1440,height:1000}});
     test("owned E2 picker filters and complete mastery calculation", async ({page},testInfo) => {
       test.setTimeout(120000);
+      await page.emulateMedia({reducedMotion:mobile ? "reduce" : "no-preference"});
       await mockApis(page);
       await seedV4Session(page,null,{operbox:testBox,boxSource:"sample"});
       await gotoStable(page,"/mastery");

--- a/src/components/pages/MasteryPlanner.tsx
+++ b/src/components/pages/MasteryPlanner.tsx
@@ -3,7 +3,7 @@ import { localize as localize_components_pages_MasteryPlanner } from "../../i18n
 
 import { useTranslations, useLocale } from "next-intl";
 
-import { lazy, Suspense, useMemo, useState, type ComponentProps } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, type ComponentProps } from "react";
 import { Timer } from "lucide-react";
 import { calculateMastery, eligibleMasteryTargets, normalizeMasteryBox, availableMasteryEnvironments, formatMasteryTime, MASTERY_ENVIRONMENTS, type MasteryInput, type MasteryResult } from "@/mastery";
 import { masteryClipboard, masteryInstructions } from "@/mastery-presentation";
@@ -53,6 +53,17 @@ export function MasteryPlanner({ operbox, sourceName, requiresAccount, pending, 
   const [calculation, setCalculation] = useState<{ signature: string; result: MasteryResult } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const resultsRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!calculation) return;
+    const frame = requestAnimationFrame(() => {
+      resultsRef.current?.scrollIntoView({
+        behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth",
+        block: "start",
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [calculation]);
   const normalizedBox = useMemo(() => normalizeMasteryBox(operbox ?? []),[operbox]);
   const eligible = useMemo(() => eligibleMasteryTargets(normalizedBox),[normalizedBox]);
   const selected = eligible.find((o) => o.id === selectedId) ?? null;
@@ -123,7 +134,7 @@ export function MasteryPlanner({ operbox, sourceName, requiresAccount, pending, 
 
     <p className="text-xs leading-5 text-muted-foreground">{conditions}</p>
     {stale ? <p role="status" className="rounded-[4px] border border-border p-4 text-sm">{intl("components_pages_MasteryPlanner.inputsOrBoxChangedGeneratePlansAgainToSee")}</p> : null}
-    {plan && calculation ? <div className="grid min-w-0 gap-4" data-mastery-results>
+    {plan && calculation ? <div ref={resultsRef} className="grid min-w-0 scroll-mt-6 gap-4" data-mastery-results>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Tabs value={mode} onValueChange={(value) => { setMode(value as "simple"|"fast"); setCopied(false); }}><TabsList aria-label={intl("components_pages_MasteryPlanner.planStyle")}><TabsTrigger value="simple">{intl("components_pages_MasteryPlanner.simple")}</TabsTrigger><TabsTrigger value="fast">{intl("components_pages_MasteryPlanner.fast")}</TabsTrigger></TabsList></Tabs>
         <SetupActionButton variant="outline" onClick={() => void copyPlan()}>{copied ? (intl("components_pages_MasteryPlanner.copied")) : (intl("components_pages_MasteryPlanner.copyInstructions"))}</SetupActionButton>


### PR DESCRIPTION
## Changes
- Scroll to mastery results after every successful generation, including unchanged-input regeneration.
- Respect reduced motion; avoid scrolling on plan-style changes or errors.
- Add desktop/mobile regression assertions for result position and regeneration.

## Validation
- Mastery unit tests: 12 passed.
- TypeScript noEmit and scoped ESLint passed.
- Local Chromium: desktop, reduced-motion mobile, guest cases passed. A transient Next development HMR initialization error passed on targeted rerun.
- Corrected Playwright reduced-motion setup to page.emulateMedia; full CI rerun 34014489409.

Scope: mastery page and existing E2E test only. Publish develop first, then main.