### PR TITLE
fix: keep mastery results clear of the mobile header

### DIFF
--- a/e2e/mastery.spec.ts
+++ b/e2e/mastery.spec.ts
@@ -49,7 +49,8 @@ for (const mobile of [false,true]) {
       const result = page.locator("[data-mastery-results]");
       await expect(result).toContainText("17:16:57");
       const expectResultsAtTop = async () => {
-        await expect.poll(async () => Math.round((await result.boundingBox())?.y ?? -1)).toBe(24);
+        await expect.poll(async () => Math.round((await result.boundingBox())?.y ?? -1)).toBe(mobile ? 80 : 24);
+        await expect(result.getByRole("tab",{name:"省操作",exact:true})).toBeInViewport();
       };
       await expectResultsAtTop();
       // Re-generating unchanged inputs must also return to the results.

--- a/src/components/pages/MasteryPlanner.tsx
+++ b/src/components/pages/MasteryPlanner.tsx
@@ -134,7 +134,7 @@ export function MasteryPlanner({ operbox, sourceName, requiresAccount, pending, 
 
     <p className="text-xs leading-5 text-muted-foreground">{conditions}</p>
     {stale ? <p role="status" className="rounded-[4px] border border-border p-4 text-sm">{intl("components_pages_MasteryPlanner.inputsOrBoxChangedGeneratePlansAgainToSee")}</p> : null}
-    {plan && calculation ? <div ref={resultsRef} className="grid min-w-0 scroll-mt-6 gap-4" data-mastery-results>
+    {plan && calculation ? <div ref={resultsRef} className="grid min-w-0 scroll-mt-[calc(5rem+env(safe-area-inset-top))] gap-4 md:scroll-mt-6" data-mastery-results>
       <div className="flex flex-wrap items-center justify-between gap-3">
         <Tabs value={mode} onValueChange={(value) => { setMode(value as "simple"|"fast"); setCopied(false); }}><TabsList aria-label={intl("components_pages_MasteryPlanner.planStyle")}><TabsTrigger value="simple">{intl("components_pages_MasteryPlanner.simple")}</TabsTrigger><TabsTrigger value="fast">{intl("components_pages_MasteryPlanner.fast")}</TabsTrigger></TabsList></Tabs>
         <SetupActionButton variant="outline" onClick={() => void copyPlan()}>{copied ? (intl("components_pages_MasteryPlanner.copied")) : (intl("components_pages_MasteryPlanner.copyInstructions"))}</SetupActionButton>


### PR DESCRIPTION
Production screenshot verification exposed the sticky 56px mobile navigation covering the result tabs. Use 80px plus safe-area inset mobile scroll margin, retaining 24px desktop margin. Update mobile regression position and require visible plan tabs. Same authorized mastery auto-scroll release scope.