### PR TITLE
test: 同步条款授权版本回归测试

### DIFF
--- a/e2e/production-readiness-foundation.spec.ts
+++ b/e2e/production-readiness-foundation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Route } from "@playwright/test";
+import { TERMS_VERSION, PRIVACY_VERSION } from "../src/legal-policy";
 import { amiyaPortrait, requestId, diagnosticId, layout243, waitForOwnAnimations, planData, twoShiftPlanData, fourShiftPlanData, adjacentPortraitPlanData, lazyPortraitPlanData, authenticatedSklandSnapshot, mockApis, mockAnonymousWebsiteSession, openSklandOverview, navigateToPrimaryPage, seedPreferences, seedV4Session } from "./production-readiness.fixture";
 
 test.beforeEach(async ({ page }) => {
@@ -1457,8 +1458,8 @@ for (const viewport of [
         expect(body).toMatchObject({
           termsAccepted: true,
           privacyAccepted: true,
-          termsVersion: "2026-08-21-cloud-workspace",
-          privacyVersion: "2026-09-03-solver-reproduction-retention",
+          termsVersion: TERMS_VERSION,
+          privacyVersion: PRIVACY_VERSION,
         });
         consentCurrent = true;
       } else if (route.request().method() === "DELETE") {
@@ -1468,8 +1469,8 @@ for (const viewport of [
       }
       return fulfill(route, {
         current: consentCurrent,
-        termsVersion: "2026-08-21-cloud-workspace",
-        privacyVersion: "2026-09-03-solver-reproduction-retention",
+        termsVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
         acceptedAt: consentCurrent ? timestamp : null,
         revokedAt: null,
         cloudSyncEnabled: true,

--- a/e2e/production-readiness-skland.spec.ts
+++ b/e2e/production-readiness-skland.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Locator } from "@playwright/test";
+import { TERMS_VERSION, PRIVACY_VERSION } from "../src/legal-policy";
 import { requestId, diagnosticId, expectUnifiedDialogTypography, expectUnifiedDialogAction, waitForOwnAnimations, planData, sampleData, authenticatedSklandSnapshot, productionHeavySklandSnapshot, primarySklandAccount, mockApis, openSklandOverview, seedPreferences, seedV4Session } from "./production-readiness.fixture";
 
 function relativeLuminance(cssColor: string) {
@@ -123,8 +124,8 @@ test("Skland login exposes both methods and starts QR only after explicit consen
       consent: {
         termsAccepted: true,
         privacyAccepted: true,
-        termsVersion: "2026-08-21-cloud-workspace",
-        privacyVersion: "2026-09-03-solver-reproduction-retention",
+        termsVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
       },
     });
     return route.fulfill({
@@ -404,8 +405,8 @@ test("credential import explains the risk, gates consent, recovers from errors, 
       consent: {
         termsAccepted: true,
         privacyAccepted: true,
-        termsVersion: "2026-08-21-cloud-workspace",
-        privacyVersion: "2026-09-03-solver-reproduction-retention",
+        termsVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
       },
     },
     {
@@ -413,8 +414,8 @@ test("credential import explains the risk, gates consent, recovers from errors, 
       consent: {
         termsAccepted: true,
         privacyAccepted: true,
-        termsVersion: "2026-08-21-cloud-workspace",
-        privacyVersion: "2026-09-03-solver-reproduction-retention",
+        termsVersion: TERMS_VERSION,
+        privacyVersion: PRIVACY_VERSION,
       },
     },
   ]);
@@ -521,8 +522,8 @@ test("credential import can add a second Skland account from the account dialog"
     consent: {
       termsAccepted: true,
       privacyAccepted: true,
-      termsVersion: "2026-08-21-cloud-workspace",
-      privacyVersion: "2026-09-03-solver-reproduction-retention",
+      termsVersion: TERMS_VERSION,
+      privacyVersion: PRIVACY_VERSION,
     },
   });
   await expect(page.locator("body")).not.toContainText(submittedCredential);


### PR DESCRIPTION
浏览器测试引用当前条款与隐私政策版本常量，保留完整授权请求断言，修复政策版本更新后旧测试数据导致的 CI 失败。