### PR TITLE
fix: align empty power station schedule cards

### DIFF
--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -166,7 +166,7 @@ function CompactRoomCard({
       )}
     </div>
   ) : null;
-  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture") ? (
+  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture" || isPower) ? (
     <div className="font-technical text-xs tracking-[0.01em] text-white/38">
       {intl("components_CompactScheduleView.awaitingSchedule")}
     </div>
@@ -204,7 +204,7 @@ function CompactRoomCard({
   const details = (
     <div className="relative z-10 min-w-0">
       {header}
-      {efficiencyContent ? <div className={row.group === "power" ? "mt-1" : "mt-2"}>{efficiencyContent}</div> : null}
+      {efficiencyContent ? <div className={isPower && efficiency ? "mt-1" : "mt-2"}>{efficiencyContent}</div> : null}
     </div>
   );
 


### PR DESCRIPTION
默认无求解结果时，一图流中的发电站现在与制造站一样显示“等待排班”占位，并使用相同的行高与上方间距，使干员槽位和卡片高度对齐。有求解结果时的发电效率及其间距不变。

复用现有 next-intl 中英文文案；仅修改 CompactScheduleView.tsx。

验证：相关现有布局与效率单元测试 18 项通过；组件 ESLint 和 git diff --check 通过。合并 develop 后等待完整发布检查与开发环境部署，再将本次修复发布至 main。
