### PR TITLE
fix: release aligned empty power station cards

### DIFF
--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -166,7 +166,7 @@ function CompactRoomCard({
       )}
     </div>
   ) : null;
-  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture") ? (
+  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture" || isPower) ? (
     <div className="font-technical text-xs tracking-[0.01em] text-white/38">
       {intl("components_CompactScheduleView.awaitingSchedule")}
     </div>
@@ -204,7 +204,7 @@ function CompactRoomCard({
   const details = (
     <div className="relative z-10 min-w-0">
       {header}
-      {efficiencyContent ? <div className={row.group === "power" ? "mt-1" : "mt-2"}>{efficiencyContent}</div> : null}
+      {efficiencyContent ? <div className={isPower && efficiency ? "mt-1" : "mt-2"}>{efficiencyContent}</div> : null}
     </div>
   );
 


### PR DESCRIPTION
默认无求解结果时，一图流发电站补上与制造站一致的“等待排班”占位，统一空状态的行高与上方间距，让干员槽位和卡片底部对齐。有结果时仍显示原有发电效率。

该修复已通过 #207 合并到 develop。本次按照用户要求，将同一修复从当前 main 单独发布，相对 main 仅改动 src/components/CompactScheduleView.tsx，不包含 develop 中尚未发布的公告行为改动。使用仓库现有 direct-main-release 选择性发布通道，保留完整 CI 与生产环境审批。

验证：相关现有布局与效率单元测试 18 项通过，组件 ESLint 与 git diff --check 通过；浏览器已确认默认空状态下发电站与制造站的占位、干员槽位、卡片高度对齐，并留存截图。等待 develop 发布检查通过后合并，随后监控 main 部署并验收线上页面。
