### PR TITLE
fix: permit explicit service-home diagnostic storage

### DIFF
--- a/src/server/request-diagnostics.test.ts
+++ b/src/server/request-diagnostics.test.ts
@@ -10,10 +10,16 @@ const input={code:"AIC-DATA-8003",status:422,route:"/api/workspace",requestId:"r
 
 test("diagnostics reject the public directory itself as well as descendants and broad roots",()=>{
   const cwd=path.resolve("fixture-app"); const home=path.resolve("fixture-home");
-  for(const root of [cwd,path.join(cwd,"public"),path.join(cwd,"public","logs"),home,path.parse(cwd).root]) {
+  for(const root of [cwd,path.join(cwd,"public"),path.join(cwd,"public","logs"),path.parse(cwd).root]) {
     assert.throws(()=>assertDiagnosticRoot(root,cwd,home));
   }
   assert.doesNotThrow(()=>assertDiagnosticRoot(path.resolve("fixture-private"),cwd,home));
+});
+
+test("an explicitly configured service HOME may hold the dedicated append-only log directory",()=>{
+  const cwd=path.resolve("fixture-app"); const serviceHome=path.resolve("fixture-service-state");
+  assert.doesNotThrow(()=>assertDiagnosticRoot(serviceHome,cwd,serviceHome));
+  assert.throws(()=>assertDiagnosticRoot(path.dirname(serviceHome),cwd,serviceHome));
 });
 
 test("API response keeps its contract while internal logs retain sanitized context",async context=>{

--- a/src/server/request-diagnostics.ts
+++ b/src/server/request-diagnostics.ts
@@ -73,7 +73,10 @@ export function makeDiagnostic(input: {
 
 export function assertDiagnosticRoot(root: string, cwd: string, home: string): void {
   const publicRoot = path.join(cwd,"public");
-  if (!isSafePrivateStorageRoot(root,[cwd,home]) || root === publicRoot || isPrivateStorageChild(publicRoot,root)) {
+  // systemd may deliberately set HOME to BETA_STORAGE_DIR. Only the dedicated
+  // diagnostic-logs child is touched; no operation prunes the configured base.
+  const disallowedRoots = root === path.resolve(home) ? [cwd] : [cwd,home];
+  if (!isSafePrivateStorageRoot(root,disallowedRoots) || root === publicRoot || isPrivateStorageChild(publicRoot,root)) {
     throw new Error("diagnostic_storage_must_be_private");
   }
 }


### PR DESCRIPTION
## Root cause

Develop b830949 deployed successfully, but the live diagnostic append check failed: systemd intentionally sets both HOME and BETA_STORAGE_DIR to the same persistent service-state directory. The new guard rejected that legitimate explicit configuration before creating diagnostic-logs. Original structured logs remained in journald; main promotion is held.

## Fix

Allow an explicitly configured base equal to service HOME while retaining rejection of filesystem roots, application roots/ancestors, public roots/descendants and symlink log directories. Only the dedicated diagnostic-logs child is used; no base-directory cleanup or deletion is introduced. Service permissions and environment are unchanged.

## Verification

- Added regression reproduced diagnostic_storage_must_be_private before the fix and passed afterwards.
- Diagnostics plus Worker tests: 22 passed; targeted lint and diff checks passed.
- Entire release merge tree passed npm run check immediately before this two-file adjustment.
- Normal develop post-merge checks and deployment must pass, followed by actual append/read verification, before main promotion.
