### PR TITLE
修复练卡建议组合技能悬浮的解锁状态

### DIFF
--- a/src/components/training-advice/TrainingCombinationCard.tsx
+++ b/src/components/training-advice/TrainingCombinationCard.tsx
@@ -111,7 +111,13 @@ function MemberRow({ member }: { member: TrainingAdviceMember }) {
   if (!hasSkills) return <div className={cardClassName}>{content}</div>;
   return (
     <Suspense fallback={cardButton}>
-      <OperatorSkillTooltip name={member.operator} trigger={cardButton} header={professionHeader} />
+      <OperatorSkillTooltip
+        name={member.operator}
+        trigger={cardButton}
+        header={professionHeader}
+        currentElite={member.owned ? member.current?.elite : null}
+        currentLevel={member.owned ? member.current?.level : undefined}
+      />
     </Suspense>
   );
 }


### PR DESCRIPTION
## 变更
练卡建议的组合成员技能悬浮此前未传练度，无法区分已解锁与未解锁技能。现在使用成员的当前精英阶段及等级判断：未拥有传 null，所有技能锁定；已拥有但缺少当前练度时保留未知状态，不用培养目标替代当前练度。

仅修改 TrainingCombinationCard，不包含教程视频、本地登录代码或换人弹窗改动。

## 验证
- 目标 develop，基于 da60c65。
- 单文件 ESLint、diff 检查通过。
- 练卡建议展示及数据契约相关测试：7 项通过。
- 5174 预览工作区已通过 TypeScript 检查。
- 本次未运行完整生产构建及浏览器回归。