### PR TITLE
fix: MAA 导入时自动纠正干员精英阶段和等级上限

### DIFF
--- a/src/operbox.test.ts
+++ b/src/operbox.test.ts
@@ -16,6 +16,28 @@ const entry = {
   rarity: 6,
 };
 
+test("MAA imports clamp every rarity's stage and level ceiling", async () => {
+  const limits = [[30], [30], [40, 55], [45, 60, 70], [50, 70, 80], [50, 80, 90]];
+  for (const [index, levels] of limits.entries()) {
+    const rarity = index + 1;
+    for (const [elite, maxLevel] of levels.entries()) {
+      const [result] = await readOperboxText(JSON.stringify([{ ...entry, rarity, elite, level: 999 }]));
+      assert.equal(result.elite, elite);
+      assert.equal(result.level, maxLevel);
+    }
+    const [result] = await readOperboxText(JSON.stringify([{ ...entry, rarity, elite: 3, level: 1 }]));
+    assert.equal(result.elite, levels.length - 1);
+    assert.equal(result.level, levels.at(-1));
+  }
+});
+
+test("MAA imports preserve valid levels and unowned placeholders", async () => {
+  const valid = { ...entry, elite: 0, level: 10 };
+  const placeholder = { ...entry, own: false, rarity: 1, elite: -1, level: 0, potential: 0 };
+  assert.deepEqual(await readOperboxText(JSON.stringify([valid])), [valid]);
+  assert.deepEqual(await readOperboxText(JSON.stringify([placeholder])), [placeholder]);
+});
+
 test("JSON imports do not load the XLSX parser", async () => {
   let xlsxRequested = false;
   const file = new File([JSON.stringify([entry])], "operators.json", { type: "application/json" });

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -89,6 +89,22 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
       "MAA JSON 无法解析，请确认粘贴了完整的 Arknights_OperBox_Export.json 内容。",
     );
   }
+  if (Array.isArray(parsed)) {
+    parsed = parsed.map((row) => {
+      if (!row || typeof row !== "object") return row;
+      const value = row as Record<string, unknown>;
+      const rarity = Number(value.rarity);
+      const elite = Number(value.elite);
+      if (Number.isInteger(rarity) && Number.isInteger(elite) && elite > maxEliteForRarity(rarity)) {
+        const safeElite = maxEliteForRarity(rarity);
+        return { ...value, elite: safeElite, level: manualLevelFor(rarity, safeElite) };
+      }
+      if (Number.isInteger(rarity) && Number.isInteger(elite) && Number.isFinite(Number(value.level))) {
+        return { ...value, level: Math.min(Number(value.level), manualLevelFor(rarity, elite)) };
+      }
+      return row;
+    });
+  }
   return normalizeImportedEntries(assertOperbox(parsed));
 }
 

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -91,10 +91,11 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
   }
   if (Array.isArray(parsed)) {
     parsed = parsed.map((row) => {
-      if (!row || typeof row !== "object") return row;
+      if (!row || typeof row !== "object" || Array.isArray(row)) return row;
       const value = row as Record<string, unknown>;
       const rarity = Number(value.rarity);
       const elite = Number(value.elite);
+      if (value.own !== true || !Number.isInteger(rarity) || rarity < 1 || rarity > 6) return row;
       if (Number.isInteger(rarity) && Number.isInteger(elite) && elite > maxEliteForRarity(rarity)) {
         const safeElite = maxEliteForRarity(rarity);
         return { ...value, elite: safeElite, level: manualLevelFor(rarity, safeElite) };


### PR DESCRIPTION
MAA JSON 导入时，根据星级对应的精英阶段和等级上限自动纠正超限练度。例如一星干员精英 2 会回退为精英 0、30 级，其余合法阶段的超限等级会裁剪到该阶段上限。

保留合法练度与未拥有占位数据，提交接口的严格校验保持不变。

验证：13 项导入及手动 Box 测试通过；相关文件 ESLint 通过。