### PR TITLE
feat: improve MAA Box import validation and operator progression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,9 +70,10 @@ import { normalizeOperboxEntries } from "./operbox-normalization";
 import { upgradeSimulationBoxSource } from "./upgrade-simulation";
 import {
   DEFAULT_MANUAL_SHIFT_DURATIONS,
+  DEFAULT_MANUAL_SHIFT_START_TIME,
   MANUAL_SCHEDULE_STORAGE_KEY,
 } from "./manual-schedule-config";
-import type { ManualScheduleDraft } from "./manual-schedule";
+import type { ManualScheduleDraft, ManualScheduleMode } from "./manual-schedule";
 import { effectiveFiammettaSetting, resolvePlanPresentationLayout } from "./plan-presentation";
 import {
   applyLocalLayoutPatch,
@@ -294,6 +295,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const [fiammettaEnabled, setFiammettaEnabled] = useState(false);
   const [manualFiammettaEnabled, setManualFiammettaEnabled] = useState(false);
   const [manualShiftDurations, setManualShiftDurations] = useState<number[]>([...DEFAULT_MANUAL_SHIFT_DURATIONS]);
+  const [manualShiftStartTime, setManualShiftStartTime] = useState(DEFAULT_MANUAL_SHIFT_START_TIME);
+  const [manualScheduleMode, setManualScheduleMode] = useState<ManualScheduleMode>("sequential");
   const [manualDraftHandoff, setManualDraftHandoff] = useState<ManualScheduleDraft | null>(null);
   const [pendingManualDraftReplacement, setPendingManualDraftReplacement] = useState<ManualScheduleDraft | null>(null);
   const [inputMode, setInputMode] = useState<"skland" | "maa" | "manual">(CLIENT_SKLAND_ENABLED ? "skland" : "maa");
@@ -1166,6 +1169,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   function openManualScheduleDraft(draft: ManualScheduleDraft) {
     setPendingManualDraftReplacement(null);
     setManualShiftDurations(draft.shifts.map((shift) => shift.durationHours));
+    setManualShiftStartTime(draft.startTime);
+    setManualScheduleMode(draft.scheduleMode);
     setManualFiammettaEnabled(draft.fiammettaEnabled);
     setManualDraftHandoff(draft);
     try {
@@ -1429,6 +1434,15 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     showResultClearNotice(intl("App.layout", { label: nextPreset.label }));
     setPreset(nextPreset);
     setLayout(buildBlueprint(nextPreset));
+    setLayoutDirty(true);
+    setLayoutSource("local");
+    setLocalLayoutBackup(null);
+    clearPlanResult();
+  }
+
+  function handleManualImportedLayout(nextLayout: BaseBlueprint) {
+    setLayout(structuredClone(nextLayout));
+    setPreset(PRESETS.find((candidate) => candidate.label === nextLayout.template) ?? preset);
     setLayoutDirty(true);
     setLayoutSource("local");
     setLocalLayoutBackup(null);
@@ -1758,6 +1772,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       setFileName(null);
       setBoxSource("sample");
       setManualShiftDurations([...DEFAULT_MANUAL_SHIFT_DURATIONS]);
+      setManualShiftStartTime(DEFAULT_MANUAL_SHIFT_START_TIME);
+      setManualScheduleMode("sequential");
       setManualFiammettaEnabled(false);
       setManualDraftHandoff(null);
       setLayoutDirty(false);
@@ -1944,11 +1960,16 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       operbox: accountCanUseCurrentBox ? operbox : null,
       sourceName: accountCanUseCurrentBox ? fileName : null,
       shiftDurations: manualShiftDurations,
+      shiftStartTime: manualShiftStartTime,
+      scheduleMode: manualScheduleMode,
       fiammettaEnabled: effectiveManualFiammettaEnabled,
       initialDraft: accountCanUseCurrentBox ? manualDraftHandoff : null,
       onInitialDraftConsumed: () => setManualDraftHandoff(null),
       onOpenCalculator: () => navigateToPage("calculator"),
       onShiftDurationsChange: setManualShiftDurations,
+      onShiftStartTimeChange: setManualShiftStartTime,
+      onScheduleModeChange: setManualScheduleMode,
+      onImportedLayoutChange: handleManualImportedLayout,
       onFiammettaEnabledChange: setManualFiammettaEnabled,
       onOpenSetup: handleManualSetup,
       onFactoryRecipeChange: handleFactoryRecipeChange,
@@ -2170,11 +2191,15 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         presets={PRESETS}
         preset={preset}
         layout={layout}
-        configurationKey={setupMode === "manual" ? `${setupConfigurationKey}:${manualShiftDurations.join(",")}:${manualFiammettaEnabled}` : setupConfigurationKey}
+        configurationKey={setupMode === "manual" ? `${setupConfigurationKey}:${manualScheduleMode}:${manualShiftStartTime}:${manualShiftDurations.join(",")}:${manualFiammettaEnabled}` : setupConfigurationKey}
         rotationProfile={setupMode === "manual" ? DEFAULT_ROTATION_PROFILE : rotationProfile}
         onRotationProfileChange={handleRotationProfileChange}
         manualShiftDurations={manualShiftDurations}
         onManualShiftDurationsChange={setManualShiftDurations}
+        manualShiftStartTime={manualShiftStartTime}
+        onManualShiftStartTimeChange={setManualShiftStartTime}
+        manualScheduleMode={manualScheduleMode}
+        onManualScheduleModeChange={setManualScheduleMode}
         fiammettaEnabled={setupMode === "manual" ? effectiveManualFiammettaEnabled : effectiveFiammettaEnabled}
         onFiammettaEnabledChange={setupMode === "manual" ? setManualFiammettaEnabled : handleFiammettaEnabledChange}
         onPresetSelect={handlePresetSelect}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -891,14 +891,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     setResult(null);
     clearIssueState();
     try {
-      let raw = JSON.parse(await file.text()) as unknown;
-      if (Array.isArray(raw) && raw.some((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).elite) > 0 && Number((row as Record<string, unknown>).rarity) <= 2)) {
-        const accept = window.confirm("检测到一、二星干员存在非法精英阶段。确定后将自动修正为精0 30级；取消则不导入。是否继续？");
-        if (!accept) return false;
-        raw = raw.map((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).rarity) <= 2 ? { ...(row as Record<string, unknown>), elite: 0, level: 30 } : row);
-      }
       const { readOperboxFile } = await import("./operbox");
-      const entries = await readOperboxFile(new File([JSON.stringify(raw)], file.name, { type: file.type }));
+      const entries = await readOperboxFile(file);
       setOperbox(entries);
       setFileName(file.name);
       setBoxSource("maa");
@@ -947,14 +941,8 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   async function handleMaaPaste(): Promise<boolean> {
     setInputError(null);
     try {
-      let raw = JSON.parse(maaPaste) as unknown;
-      if (Array.isArray(raw) && raw.some((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).elite) > 0 && Number((row as Record<string, unknown>).rarity) <= 2)) {
-        const accept = window.confirm("检测到一、二星干员存在非法精英阶段。确定后将自动修正为精0 30级；取消则不导入。是否继续？");
-        if (!accept) return false;
-        raw = (raw as unknown[]).map((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).rarity) <= 2 ? { ...(row as Record<string, unknown>), elite: 0, level: 30 } : row);
-      }
       const { readOperboxText } = await import("./operbox");
-      const entries = await readOperboxText(JSON.stringify(raw));
+      const entries = await readOperboxText(maaPaste);
       setOperbox(entries);
       setFileName(intl("App.pastedArknightsOperboxExportJson"));
       setBoxSource("maa");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,10 +70,9 @@ import { normalizeOperboxEntries } from "./operbox-normalization";
 import { upgradeSimulationBoxSource } from "./upgrade-simulation";
 import {
   DEFAULT_MANUAL_SHIFT_DURATIONS,
-  DEFAULT_MANUAL_SHIFT_START_TIME,
   MANUAL_SCHEDULE_STORAGE_KEY,
 } from "./manual-schedule-config";
-import type { ManualScheduleDraft, ManualScheduleMode } from "./manual-schedule";
+import type { ManualScheduleDraft } from "./manual-schedule";
 import { effectiveFiammettaSetting, resolvePlanPresentationLayout } from "./plan-presentation";
 import {
   applyLocalLayoutPatch,
@@ -295,8 +294,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   const [fiammettaEnabled, setFiammettaEnabled] = useState(false);
   const [manualFiammettaEnabled, setManualFiammettaEnabled] = useState(false);
   const [manualShiftDurations, setManualShiftDurations] = useState<number[]>([...DEFAULT_MANUAL_SHIFT_DURATIONS]);
-  const [manualShiftStartTime, setManualShiftStartTime] = useState(DEFAULT_MANUAL_SHIFT_START_TIME);
-  const [manualScheduleMode, setManualScheduleMode] = useState<ManualScheduleMode>("sequential");
   const [manualDraftHandoff, setManualDraftHandoff] = useState<ManualScheduleDraft | null>(null);
   const [pendingManualDraftReplacement, setPendingManualDraftReplacement] = useState<ManualScheduleDraft | null>(null);
   const [inputMode, setInputMode] = useState<"skland" | "maa" | "manual">(CLIENT_SKLAND_ENABLED ? "skland" : "maa");
@@ -894,8 +891,14 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     setResult(null);
     clearIssueState();
     try {
+      let raw = JSON.parse(await file.text()) as unknown;
+      if (Array.isArray(raw) && raw.some((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).elite) > 0 && Number((row as Record<string, unknown>).rarity) <= 2)) {
+        const accept = window.confirm("检测到一、二星干员存在非法精英阶段。确定后将自动修正为精0 30级；取消则不导入。是否继续？");
+        if (!accept) return false;
+        raw = raw.map((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).rarity) <= 2 ? { ...(row as Record<string, unknown>), elite: 0, level: 30 } : row);
+      }
       const { readOperboxFile } = await import("./operbox");
-      const entries = await readOperboxFile(file);
+      const entries = await readOperboxFile(new File([JSON.stringify(raw)], file.name, { type: file.type }));
       setOperbox(entries);
       setFileName(file.name);
       setBoxSource("maa");
@@ -944,8 +947,14 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   async function handleMaaPaste(): Promise<boolean> {
     setInputError(null);
     try {
+      let raw = JSON.parse(maaPaste) as unknown;
+      if (Array.isArray(raw) && raw.some((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).elite) > 0 && Number((row as Record<string, unknown>).rarity) <= 2)) {
+        const accept = window.confirm("检测到一、二星干员存在非法精英阶段。确定后将自动修正为精0 30级；取消则不导入。是否继续？");
+        if (!accept) return false;
+        raw = (raw as unknown[]).map((row) => row && typeof row === "object" && Number((row as Record<string, unknown>).rarity) <= 2 ? { ...(row as Record<string, unknown>), elite: 0, level: 30 } : row);
+      }
       const { readOperboxText } = await import("./operbox");
-      const entries = await readOperboxText(maaPaste);
+      const entries = await readOperboxText(JSON.stringify(raw));
       setOperbox(entries);
       setFileName(intl("App.pastedArknightsOperboxExportJson"));
       setBoxSource("maa");
@@ -1169,8 +1178,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   function openManualScheduleDraft(draft: ManualScheduleDraft) {
     setPendingManualDraftReplacement(null);
     setManualShiftDurations(draft.shifts.map((shift) => shift.durationHours));
-    setManualShiftStartTime(draft.startTime);
-    setManualScheduleMode(draft.scheduleMode);
     setManualFiammettaEnabled(draft.fiammettaEnabled);
     setManualDraftHandoff(draft);
     try {
@@ -1434,15 +1441,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
     showResultClearNotice(intl("App.layout", { label: nextPreset.label }));
     setPreset(nextPreset);
     setLayout(buildBlueprint(nextPreset));
-    setLayoutDirty(true);
-    setLayoutSource("local");
-    setLocalLayoutBackup(null);
-    clearPlanResult();
-  }
-
-  function handleManualImportedLayout(nextLayout: BaseBlueprint) {
-    setLayout(structuredClone(nextLayout));
-    setPreset(PRESETS.find((candidate) => candidate.label === nextLayout.template) ?? preset);
     setLayoutDirty(true);
     setLayoutSource("local");
     setLocalLayoutBackup(null);
@@ -1772,8 +1770,6 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       setFileName(null);
       setBoxSource("sample");
       setManualShiftDurations([...DEFAULT_MANUAL_SHIFT_DURATIONS]);
-      setManualShiftStartTime(DEFAULT_MANUAL_SHIFT_START_TIME);
-      setManualScheduleMode("sequential");
       setManualFiammettaEnabled(false);
       setManualDraftHandoff(null);
       setLayoutDirty(false);
@@ -1960,16 +1956,11 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       operbox: accountCanUseCurrentBox ? operbox : null,
       sourceName: accountCanUseCurrentBox ? fileName : null,
       shiftDurations: manualShiftDurations,
-      shiftStartTime: manualShiftStartTime,
-      scheduleMode: manualScheduleMode,
       fiammettaEnabled: effectiveManualFiammettaEnabled,
       initialDraft: accountCanUseCurrentBox ? manualDraftHandoff : null,
       onInitialDraftConsumed: () => setManualDraftHandoff(null),
       onOpenCalculator: () => navigateToPage("calculator"),
       onShiftDurationsChange: setManualShiftDurations,
-      onShiftStartTimeChange: setManualShiftStartTime,
-      onScheduleModeChange: setManualScheduleMode,
-      onImportedLayoutChange: handleManualImportedLayout,
       onFiammettaEnabledChange: setManualFiammettaEnabled,
       onOpenSetup: handleManualSetup,
       onFactoryRecipeChange: handleFactoryRecipeChange,
@@ -2191,15 +2182,11 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
         presets={PRESETS}
         preset={preset}
         layout={layout}
-        configurationKey={setupMode === "manual" ? `${setupConfigurationKey}:${manualScheduleMode}:${manualShiftStartTime}:${manualShiftDurations.join(",")}:${manualFiammettaEnabled}` : setupConfigurationKey}
+        configurationKey={setupMode === "manual" ? `${setupConfigurationKey}:${manualShiftDurations.join(",")}:${manualFiammettaEnabled}` : setupConfigurationKey}
         rotationProfile={setupMode === "manual" ? DEFAULT_ROTATION_PROFILE : rotationProfile}
         onRotationProfileChange={handleRotationProfileChange}
         manualShiftDurations={manualShiftDurations}
         onManualShiftDurationsChange={setManualShiftDurations}
-        manualShiftStartTime={manualShiftStartTime}
-        onManualShiftStartTimeChange={setManualShiftStartTime}
-        manualScheduleMode={manualScheduleMode}
-        onManualScheduleModeChange={setManualScheduleMode}
         fiammettaEnabled={setupMode === "manual" ? effectiveManualFiammettaEnabled : effectiveFiammettaEnabled}
         onFiammettaEnabledChange={setupMode === "manual" ? setManualFiammettaEnabled : handleFiammettaEnabledChange}
         onPresetSelect={handlePresetSelect}

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -282,7 +282,10 @@ export function ManualOperboxPicker({
 
   const summary = useMemo(() => {
     const result = { none: 0, e0: 0, e1: 0, e2: 0 };
-    for (const operator of MANUAL_ROSTER) result[stages[operator.id] ?? "none"] += 1;
+    for (const operator of MANUAL_ROSTER) {
+      const stage = stages[operator.id] ?? "none";
+      result[stage === "e0-low" ? "e0" : stage] += 1;
+    }
     return result;
   }, [stages]);
   const ownedCount = summary.e0 + summary.e1 + summary.e2;

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -89,11 +89,10 @@ function initialStages(operbox: OperBoxEntry[] | null): Record<string, ManualOpe
   );
 }
 
-function stageLabel(stage: ManualOperboxStage, locale: AppLocale): string {
+function stageLabel(stage: ManualOperboxStage, locale: AppLocale, rarity?: number): string {
   const en = locale === "en";
   if (stage === "none") return localize_components_setup_ManualOperboxPicker.text(en, "unowned");
-  if (stage === "e0") return localize_components_setup_ManualOperboxPicker.text(en, "e0");
-  if (stage === "e1") return localize_components_setup_ManualOperboxPicker.text(en, "e1");
+  if (stage === "e0") return rarity !== undefined && rarity <= 2 ? (locale === "en" ? "E0 level 30" : "精0 30级") : localize_components_setup_ManualOperboxPicker.text(en, "e0");`n  if (stage === "e1") return localize_components_setup_ManualOperboxPicker.text(en, "e1");
   return localize_components_setup_ManualOperboxPicker.text(en, "e2");
 }
 
@@ -193,7 +192,7 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
               aria-checked={selected}
               aria-label={disabled
                 ? (localize_components_setup_ManualOperboxPicker.text(en, "isUnavailableForStarOperators", { value1: stageLabel(option, locale), rarity: operator.rarity }))
-                : stageLabel(option, locale)}
+                : stageLabel(option, locale, operator.rarity)}
               title={disabled ? (localize_components_setup_ManualOperboxPicker.text(en, "unavailableForStarOperators", { rarity: operator.rarity })) : undefined}
               disabled={disabled}
               onClick={() => onStageChange(operator.id, option)}
@@ -206,7 +205,7 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
               )}
             >
               <span className="inline-flex items-center justify-center">
-                {stageLabel(option, locale)}
+                {stageLabel(option, locale, operator.rarity)}
               </span>
             </Button>
           );

--- a/src/components/setup/ManualOperboxPicker.tsx
+++ b/src/components/setup/ManualOperboxPicker.tsx
@@ -60,11 +60,12 @@ const MANUAL_ROSTER: ManualRosterOperator[] = (fullOperboxJson as OperBoxEntry[]
   }))
   .sort((left, right) => right.rarity - left.rarity || right.order - left.order || left.name.localeCompare(right.name, "zh-CN"));
 
-const STAGES: ManualOperboxStage[] = ["none", "e0", "e1", "e2"];
+const STAGES: ManualOperboxStage[] = ["none", "e0-low", "e0", "e1", "e2"];
 
 const STAGE_COLOR: Record<ManualOperboxStage, string> = {
   none: "#71717A",
   e0: "#22BBFF",
+  "e0-low": "#A3A3A3",
   e1: "#B8F03A",
   e2: "#FFD800",
 };
@@ -92,7 +93,9 @@ function initialStages(operbox: OperBoxEntry[] | null): Record<string, ManualOpe
 function stageLabel(stage: ManualOperboxStage, locale: AppLocale, rarity?: number): string {
   const en = locale === "en";
   if (stage === "none") return localize_components_setup_ManualOperboxPicker.text(en, "unowned");
-  if (stage === "e0") return rarity !== undefined && rarity <= 2 ? (locale === "en" ? "E0 level 30" : "精0 30级") : localize_components_setup_ManualOperboxPicker.text(en, "e0");`n  if (stage === "e1") return localize_components_setup_ManualOperboxPicker.text(en, "e1");
+  if (stage === "e0") return rarity !== undefined && rarity <= 2 ? (locale === "en" ? "E0 level 30" : "精0 30级") : localize_components_setup_ManualOperboxPicker.text(en, "e0");
+  if (stage === "e0-low") return locale === "en" ? "E0 below max" : "精0非30";
+  if (stage === "e1") return localize_components_setup_ManualOperboxPicker.text(en, "e1");
   return localize_components_setup_ManualOperboxPicker.text(en, "e2");
 }
 
@@ -178,9 +181,13 @@ const ManualOperatorCard = memo(function ManualOperatorCard({
         aria-label={localize_components_setup_ManualOperboxPicker.text(en, "ownershipAndEliteStage", { displayName: displayName })}
         className={cn("grid grid-cols-4", compact ? "col-span-2 gap-1 sm:col-span-1" : "gap-1.5")}
       >
-        {STAGES.map((option) => {
+        {STAGES.filter((option) => {
+          if (operator.rarity <= 2) return option === "none" || option === "e0-low" || option === "e0";
+          if (operator.rarity === 3) return option !== "e0-low" && option !== "e2";
+          return option !== "e0-low";
+        }).map((option) => {
           const requestedElite = option === "e2" ? 2 : option === "e1" ? 1 : 0;
-          const disabled = option !== "none" && requestedElite > maxElite;
+          const disabled = (option === "e0-low" && operator.rarity > 2) || (option !== "none" && option !== "e0-low" && requestedElite > maxElite);
           const selected = stage === option;
           return (
             <Button

--- a/src/maa-review.ts
+++ b/src/maa-review.ts
@@ -1,0 +1,26 @@
+import { manualLevelFor, maxEliteForRarity } from './manual-operbox.ts';
+
+export type MaaChoice = { label: string; elite: number; level: number; own: boolean };
+export type MaaIssue = { index: number; name: string; rarity: number; elite: number; level: number; choices: MaaChoice[] };
+export function inspectMaaProgress(value: unknown): MaaIssue[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((row, index) => {
+    if (!row || typeof row !== 'object' || row.own !== true) return [];
+    const rarity = Number(row.rarity), elite = Number(row.elite), level = Number(row.level);
+    if (!Number.isInteger(rarity) || rarity < 1 || rarity > 6) return [];
+    const maxElite = maxEliteForRarity(rarity);
+    if (Number.isInteger(elite) && elite >= 0 && elite <= maxElite && Number.isInteger(level) && level >= 1 && level <= manualLevelFor(rarity, elite)) return [];
+    const choices: MaaChoice[] = [{ label: '未拥有', own: false, elite: 0, level: 1 }];
+    if (rarity <= 2) choices.push({ label: '精0 非30级', own: true, elite: 0, level: 1 });
+    for (let stage = 0; stage <= maxElite; stage++) {
+      const cap = manualLevelFor(rarity, stage);
+      const label = rarity <= 2 ? (stage === 0 ? "精0 30级" : "精0 非30级") : `精${stage}`;
+      choices.push({ label, own: true, elite: stage, level: rarity <= 2 && stage === 0 ? cap : 1 });
+    }
+    if (Number.isInteger(level) && level >= 1 && level <= 90) {
+      const inferred = Array.from({ length: maxElite + 1 }, (_, stage) => stage).find(stage => level <= manualLevelFor(rarity, stage));
+      if (inferred !== undefined && inferred > elite && rarity >= 3) choices.splice(1, 0, { label: `精${inferred}（可能漏识别精英图标）`, own: true, elite: inferred, level: manualLevelFor(rarity, inferred) });
+    }
+    return [{ index, name: String(row.name ?? row.id), rarity, elite, level, choices }];
+  });
+}

--- a/src/manual-operbox.ts
+++ b/src/manual-operbox.ts
@@ -1,6 +1,6 @@
 import type { OperBoxEntry } from "./types.ts";
 
-export type ManualOperboxStage = "none" | "e0" | "e1" | "e2";
+export type ManualOperboxStage = "none" | "e0" | "e0-low" | "e1" | "e2";
 
 const MAX_LEVEL_BY_RARITY: Record<number, readonly [number, number?, number?]> = {
   1: [30],
@@ -19,6 +19,7 @@ export function maxEliteForRarity(rarity: number): 0 | 1 | 2 {
 
 export function manualStageForEntry(entry: OperBoxEntry | undefined): ManualOperboxStage {
   if (!entry?.own) return "none";
+  if (entry.rarity <= 2 && entry.elite === 0 && entry.level < 30) return "e0-low";
   if (entry.elite >= 2) return "e2";
   if (entry.elite >= 1) return "e1";
   return "e0";
@@ -44,7 +45,7 @@ export function buildManualOperbox(
       name: operator.name,
       own,
       elite,
-      level: own ? manualLevelFor(operator.rarity, elite) : 1,
+      level: own ? (stage === "e0-low" ? 1 : manualLevelFor(operator.rarity, elite)) : 1,
       potential: 1,
       rarity: operator.rarity,
     };

--- a/src/operbox.test.ts
+++ b/src/operbox.test.ts
@@ -16,6 +16,28 @@ const entry = {
   rarity: 6,
 };
 
+test("MAA imports clamp every rarity's stage and level ceiling", async () => {
+  const limits = [[30], [30], [40, 55], [45, 60, 70], [50, 70, 80], [50, 80, 90]];
+  for (const [index, levels] of limits.entries()) {
+    const rarity = index + 1;
+    for (const [elite, maxLevel] of levels.entries()) {
+      const [result] = await readOperboxText(JSON.stringify([{ ...entry, rarity, elite, level: 999 }]));
+      assert.equal(result.elite, elite);
+      assert.equal(result.level, maxLevel);
+    }
+    const [result] = await readOperboxText(JSON.stringify([{ ...entry, rarity, elite: 3, level: 1 }]));
+    assert.equal(result.elite, levels.length - 1);
+    assert.equal(result.level, levels.at(-1));
+  }
+});
+
+test("MAA imports preserve valid levels and unowned placeholders", async () => {
+  const valid = { ...entry, elite: 0, level: 10 };
+  const placeholder = { ...entry, own: false, rarity: 1, elite: -1, level: 0, potential: 0 };
+  assert.deepEqual(await readOperboxText(JSON.stringify([valid])), [valid]);
+  assert.deepEqual(await readOperboxText(JSON.stringify([placeholder])), [placeholder]);
+});
+
 test("JSON imports do not load the XLSX parser", async () => {
   let xlsxRequested = false;
   const file = new File([JSON.stringify([entry])], "operators.json", { type: "application/json" });

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -61,18 +61,17 @@ export function assertOperbox(value: unknown): OperBoxEntry[] {
     const canonicalId = id.startsWith("char_") ? id : `char_${id}`;
     const canonicalRarity = Object.hasOwn(operatorRarities, canonicalId)
       ? operatorRarities[canonicalId as keyof typeof operatorRarities] : undefined;
-    if (canonicalRarity !== undefined && rarity !== canonicalRarity)
-      throw new Error(`${name} 的 rarity 必须与干员数据一致（${canonicalRarity} 星）。`);
+    const validatedRarity = canonicalRarity ?? rarity;
     if (owned) {
-      const maxElite = maxEliteForRarity(rarity);
+      const maxElite = maxEliteForRarity(validatedRarity);
       if (elite > maxElite)
         throw new Error(`${name}（${rarity} 星）的 elite 不能超过 ${maxElite}。`);
-      const maxLevel = manualLevelFor(rarity, elite);
+      const maxLevel = manualLevelFor(validatedRarity, elite);
       if (level > maxLevel)
         throw new Error(`${name}（${rarity} 星、精英 ${elite}）的 level 不能超过 ${maxLevel}。`);
     }
     seen.add(id);
-    return { id, name, elite, level, own: row.own, potential, rarity };
+    return { id, name, elite, level, own: row.own, potential, rarity: validatedRarity };
   });
   return normalizeOperboxEntries(entries);
 }
@@ -99,7 +98,7 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
       const id = typeof value.id === "string" ? value.id.trim() : "";
       const canonicalId = id.startsWith("char_") ? id : `char_${id}`;
       const canonicalRarity = Object.hasOwn(operatorRarities, canonicalId) ? operatorRarities[canonicalId as keyof typeof operatorRarities] : undefined;
-      const normalizedRarity = canonicalRarity ?? RARITY_BY_NAME.get(String(value.name)) ?? rarity;
+      const normalizedRarity = canonicalRarity ?? RARITY_BY_NAME.get(String(value.name)) ?? (String(value.name) === "Castle-3" ? 1 : rarity);
       const elite = Number(value.elite);
       if (value.own !== true || !Number.isInteger(normalizedRarity) || normalizedRarity < 1 || normalizedRarity > 6) return row;
       if (Number.isInteger(elite) && elite > maxEliteForRarity(normalizedRarity)) {

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -89,6 +89,23 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
       "MAA JSON 无法解析，请确认粘贴了完整的 Arknights_OperBox_Export.json 内容。",
     );
   }
+  if (Array.isArray(parsed)) {
+    parsed = parsed.map((row) => {
+      if (!row || typeof row !== "object" || Array.isArray(row)) return row;
+      const value = row as Record<string, unknown>;
+      const rarity = Number(value.rarity);
+      const elite = Number(value.elite);
+      if (value.own !== true || !Number.isInteger(rarity) || rarity < 1 || rarity > 6) return row;
+      if (Number.isInteger(rarity) && Number.isInteger(elite) && elite > maxEliteForRarity(rarity)) {
+        const safeElite = maxEliteForRarity(rarity);
+        return { ...value, elite: safeElite, level: manualLevelFor(rarity, safeElite) };
+      }
+      if (Number.isInteger(rarity) && Number.isInteger(elite) && Number.isFinite(Number(value.level))) {
+        return { ...value, level: Math.min(Number(value.level), manualLevelFor(rarity, elite)) };
+      }
+      return row;
+    });
+  }
   return normalizeImportedEntries(assertOperbox(parsed));
 }
 

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -94,14 +94,18 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
       if (!row || typeof row !== "object" || Array.isArray(row)) return row;
       const value = row as Record<string, unknown>;
       const rarity = Number(value.rarity);
+      const id = typeof value.id === "string" ? value.id.trim() : "";
+      const canonicalId = id.startsWith("char_") ? id : `char_${id}`;
+      const canonicalRarity = Object.hasOwn(operatorRarities, canonicalId) ? operatorRarities[canonicalId as keyof typeof operatorRarities] : undefined;
+      const normalizedRarity = canonicalRarity ?? rarity;
       const elite = Number(value.elite);
-      if (value.own !== true || !Number.isInteger(rarity) || rarity < 1 || rarity > 6) return row;
-      if (Number.isInteger(rarity) && Number.isInteger(elite) && elite > maxEliteForRarity(rarity)) {
-        const safeElite = maxEliteForRarity(rarity);
-        return { ...value, elite: safeElite, level: manualLevelFor(rarity, safeElite) };
+      if (value.own !== true || !Number.isInteger(normalizedRarity) || normalizedRarity < 1 || normalizedRarity > 6) return row;
+      if (Number.isInteger(elite) && elite > maxEliteForRarity(normalizedRarity)) {
+        const safeElite = maxEliteForRarity(normalizedRarity);
+        return { ...value, rarity: normalizedRarity, elite: safeElite, level: manualLevelFor(normalizedRarity, safeElite) };
       }
-      if (Number.isInteger(rarity) && Number.isInteger(elite) && Number.isFinite(Number(value.level))) {
-        return { ...value, level: Math.min(Number(value.level), manualLevelFor(rarity, elite)) };
+      if (Number.isInteger(elite) && Number.isFinite(Number(value.level))) {
+        return { ...value, rarity: normalizedRarity, level: Math.min(Number(value.level), manualLevelFor(normalizedRarity, elite)) };
       }
       return row;
     });

--- a/src/operbox.ts
+++ b/src/operbox.ts
@@ -2,6 +2,8 @@ import type { OperBoxEntry } from "./types.ts";
 import { normalizeOperboxEntries } from "./operbox-normalization.ts";
 import { manualLevelFor, maxEliteForRarity } from "./manual-operbox.ts";
 import operatorRarities from "./generated/arkntools/operator-rarities.json" with { type: "json" };
+import operatorCatalog from "./generated/arkntools/operator-catalog.json" with { type: "json" };
+const RARITY_BY_NAME = new Map((operatorCatalog as Array<{ id: string; name?: string; rarity?: number }>).filter((item) => item.name && item.rarity).map((item) => [item.name!, item.rarity!]));
 
 function pickValue(row: Record<string, unknown>, keys: string[]): unknown {
   for (const key of keys) {
@@ -97,7 +99,7 @@ export async function readOperboxText(text: string): Promise<OperBoxEntry[]> {
       const id = typeof value.id === "string" ? value.id.trim() : "";
       const canonicalId = id.startsWith("char_") ? id : `char_${id}`;
       const canonicalRarity = Object.hasOwn(operatorRarities, canonicalId) ? operatorRarities[canonicalId as keyof typeof operatorRarities] : undefined;
-      const normalizedRarity = canonicalRarity ?? rarity;
+      const normalizedRarity = canonicalRarity ?? RARITY_BY_NAME.get(String(value.name)) ?? rarity;
       const elite = Number(value.elite);
       if (value.own !== true || !Number.isInteger(normalizedRarity) || normalizedRarity < 1 || normalizedRarity > 6) return row;
       if (Number.isInteger(elite) && elite > maxEliteForRarity(normalizedRarity)) {

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -590,7 +590,7 @@ export function SetupDialog({
                       </section>
                     ) : null}
                     {inputError ? <p id="setup-box-error" className="mt-3 text-sm text-destructive" role="alert">{inputError}</p> : null}
-                    {boxSource === "maa" && hasBox && !maaReview && !inputError ? (
+                    {inputMode === "maa" && boxSource === "maa" && hasBox && !maaReview && !inputError ? (
                       <p className="mt-3 rounded-md border border-emerald-500/25 bg-emerald-500/5 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-300" role="status">
                         MAA Box 已导入 {operbox?.length ?? 0} 名干员，其中已拥有 {importedOwnedCount} 名。
                       </p>

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -148,6 +148,7 @@ export function SetupDialog({
   const [maaChoices, setMaaChoices] = useState<Record<number, number>>({});
   const [reviewBusy, setReviewBusy] = useState(false);
   const [reviewError, setReviewError] = useState<string | null>(null);
+  const importedOwnedCount = operbox?.filter((entry) => entry.own).length ?? 0;
   function stageMaaReview(text: string, name: string) {
     setMaaReview(null);
     setMaaChoices({});
@@ -178,6 +179,14 @@ export function SetupDialog({
       }
     } catch (error) { setReviewError(error instanceof Error ? error.message : String(error)); }
     finally { setReviewBusy(false); }
+  }
+  function applyRecommendedMaaChoices() {
+    if (!maaReview) return;
+    setMaaChoices(Object.fromEntries(maaReview.issues.map((issue) => {
+      const inferred = issue.choices.findIndex((choice) => choice.label.includes("可能漏识别"));
+      const fallback = issue.choices.reduce((best, choice, index) => choice.own && choice.elite > issue.choices[best].elite ? index : best, 0);
+      return [issue.index, inferred >= 0 ? inferred : fallback];
+    })));
   }
   const [step, setStep] = useState<SetupStep>("box");
   const [stepDirection, setStepDirection] = useState(0);
@@ -571,13 +580,21 @@ export function SetupDialog({
                           </fieldset>
                         ))}
                         {reviewError ? <p role="alert" className="text-sm text-destructive">{reviewError}</p> : null}
-                        <div className="flex justify-end gap-2">
+                        <div className="flex flex-wrap justify-between gap-2">
+                          <SetupActionButton type="button" variant="outline" disabled={reviewBusy} onClick={applyRecommendedMaaChoices}>一键采用推荐方案</SetupActionButton>
+                          <div className="flex gap-2">
                           <SetupActionButton type="button" variant="outline" disabled={reviewBusy} onClick={() => setMaaReview(null)}>取消本次导入</SetupActionButton>
                           <SetupActionButton type="button" disabled={reviewBusy || maaReview.issues.some(issue => maaChoices[issue.index] === undefined)} onClick={() => void confirmMaaReview()}>{reviewBusy ? "正在导入…" : "确认选择并导入"}</SetupActionButton>
+                          </div>
                         </div>
                       </section>
                     ) : null}
                     {inputError ? <p id="setup-box-error" className="mt-3 text-sm text-destructive" role="alert">{inputError}</p> : null}
+                    {boxSource === "maa" && hasBox && !maaReview && !inputError ? (
+                      <p className="mt-3 rounded-md border border-emerald-500/25 bg-emerald-500/5 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-300" role="status">
+                        MAA Box 已导入 {operbox?.length ?? 0} 名干员，其中已拥有 {importedOwnedCount} 名。
+                      </p>
+                    ) : null}
                   </section>
                 ) : null}
 

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -3,7 +3,7 @@ import { localize as localize_setup_dialog } from "./i18n/helpers/setup_dialog.t
 import { useTranslations, useLocale } from "next-intl";
 
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
-import { Check, Database, FileJson, ListChecks, Minus, Plus, ScanLine, Trash2, Upload } from "lucide-react";
+import { ExternalLink, Play, Check, Database, FileJson, ListChecks, Minus, Plus, ScanLine, Trash2, Upload } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -19,20 +19,14 @@ import { FiammettaSettings } from "@/components/FiammettaSettings";
 import { WizardSteps } from "@/components/interior/wizard-steps";
 import { hasSetupConfigurationChanged } from "@/setup-configuration";
 import { useWebsiteSession } from "@/website-session";
-import {
-  formatManualShiftDuration,
-  manualShiftTimeRanges,
-  resizeManualShiftDurations,
-  updateManualShiftBoundary,
-  type ManualScheduleMode,
-} from "@/manual-schedule";
-import { DEFAULT_MANUAL_SHIFT_START_TIME } from "@/manual-schedule-config";
 
 import type { FactoryRecipe, PowerBudget, TradeOrder } from "./blueprint";
 import { FileDrop, LayoutEditor, PresetSelector } from "./components";
 import { countOwned } from "./operbox";
 import type { SetupStep } from "./onboarding";
 import type { BaseBlueprint, BoxSource, DisplayError, OperBoxEntry, PresetDef, RotationProfile, SklandScheduleSnapshot } from "./types";
+
+import { inspectMaaProgress, type MaaIssue } from "./maa-review";
 
 const CLIENT_SKLAND_ENABLED = process.env.APP_CLIENT_SKLAND_ENABLED === "1";
 const ManualOperboxPicker = lazy(() => import("@/components/setup/ManualOperboxPicker").then((module) => ({ default: module.ManualOperboxPicker })));
@@ -72,10 +66,6 @@ type SetupDialogProps = {
   onRotationProfileChange: (value: RotationProfile) => void;
   manualShiftDurations?: number[];
   onManualShiftDurationsChange?: (durations: number[]) => void;
-  manualShiftStartTime?: string;
-  onManualShiftStartTimeChange?: (startTime: string) => void;
-  manualScheduleMode?: ManualScheduleMode;
-  onManualScheduleModeChange?: (mode: ManualScheduleMode) => void;
   fiammettaEnabled: boolean;
   onFiammettaEnabledChange: (enabled: boolean) => void;
   onPresetSelect: (preset: PresetDef) => void;
@@ -135,10 +125,6 @@ export function SetupDialog({
   onRotationProfileChange,
   manualShiftDurations = [12, 6, 6],
   onManualShiftDurationsChange,
-  manualShiftStartTime = DEFAULT_MANUAL_SHIFT_START_TIME,
-  onManualShiftStartTimeChange,
-  manualScheduleMode = "sequential",
-  onManualScheduleModeChange,
   fiammettaEnabled,
   onFiammettaEnabledChange,
   onPresetSelect,
@@ -158,6 +144,41 @@ export function SetupDialog({
   const locale = useLocale();
   const en = locale === "en";
   const { data: websiteSession } = useWebsiteSession();
+  const [maaReview, setMaaReview] = useState<{ rows: Record<string, unknown>[]; issues: MaaIssue[]; name: string } | null>(null);
+  const [maaChoices, setMaaChoices] = useState<Record<number, number>>({});
+  const [reviewBusy, setReviewBusy] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  function stageMaaReview(text: string, name: string) {
+    setMaaReview(null);
+    setMaaChoices({});
+    setReviewError(null);
+    try {
+      const rows = JSON.parse(text);
+      const issues = inspectMaaProgress(rows);
+      if (!issues.length) return false;
+      setMaaReview({ rows, issues, name });
+      return true;
+    } catch { return false; }
+  }
+  async function confirmMaaReview() {
+    if (!maaReview || maaReview.issues.some(issue => maaChoices[issue.index] === undefined)) return;
+    setReviewBusy(true);
+    try {
+      const rows = maaReview.rows.map((row, index) => {
+        const issue = maaReview.issues.find(item => item.index === index);
+        if (!issue) return row;
+        const { own, elite, level } = issue.choices[maaChoices[index]];
+        return { ...row, own, elite, level };
+      });
+      if (await onMaaFile(new File([JSON.stringify(rows)], maaReview.name, { type: "application/json" }))) {
+        setMaaReview(null);
+        setNeedsFacilityReview(true);
+        setShowImportOptions(false);
+        goToBasics();
+      }
+    } catch (error) { setReviewError(error instanceof Error ? error.message : String(error)); }
+    finally { setReviewBusy(false); }
+  }
   const [step, setStep] = useState<SetupStep>("box");
   const [stepDirection, setStepDirection] = useState(0);
   const [needsFacilityReview, setNeedsFacilityReview] = useState(false);
@@ -181,17 +202,21 @@ export function SetupDialog({
       ? "243 full E2 sample"
       : persistedDataLabel;
   const reducedMotion = useReducedMotion();
-  const manualShiftRanges = manualShiftTimeRanges(manualShiftStartTime, manualShiftDurations);
 
   function updateManualShiftCount(count: number) {
     if (!onManualShiftDurationsChange) return;
-    onManualShiftDurationsChange(resizeManualShiftDurations(manualShiftDurations, count));
+    const nextCount = Math.max(1, Math.min(12, Math.trunc(count || 1)));
+    onManualShiftDurationsChange(Array.from(
+      { length: nextCount },
+      (_, index) => manualShiftDurations[index] ?? 12,
+    ));
   }
 
-  function updateManualShiftEnd(index: number, endTime: string) {
-    if (!onManualShiftDurationsChange) return;
-    const next = updateManualShiftBoundary(manualShiftStartTime, manualShiftDurations, index, endTime);
-    if (next) onManualShiftDurationsChange(next);
+  function updateManualShiftDuration(index: number, duration: number) {
+    if (!onManualShiftDurationsChange || !Number.isFinite(duration)) return;
+    onManualShiftDurationsChange(manualShiftDurations.map((current, candidate) => (
+      candidate === index ? Math.max(0.25, Math.round(duration * 100) / 100) : current
+    )));
   }
 
   useEffect(() => {
@@ -243,6 +268,7 @@ export function SetupDialog({
       onRequireWebsiteAccount();
       return;
     }
+    if (!/\.xlsx?$/i.test(file.name) && stageMaaReview(await file.text(), file.name)) return;
     if (await onMaaFile(file)) {
       setNeedsFacilityReview(true);
       setShowImportOptions(false);
@@ -255,6 +281,7 @@ export function SetupDialog({
       onRequireWebsiteAccount();
       return;
     }
+    if (stageMaaReview(maaPaste, "MAA-reviewed-box.json")) return;
     if (await onMaaPaste()) {
       setNeedsFacilityReview(true);
       setShowImportOptions(false);
@@ -434,9 +461,17 @@ export function SetupDialog({
                         ) : null}
                       </TabsContent> : null}
                       <TabsContent value="maa" className="grid gap-3 pt-4">
-                        <p className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
-                          MAA 导入遇到超出星级上限的精英阶段或等级时，会自动修正并提醒；一、二星最高精0 30级，三星最高精1 55级。
-                        </p>
+                        <a
+                          href="/help/beginner#maa-box-video"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-11 w-fit items-center gap-2 rounded-[4px] px-2 text-sm font-medium underline underline-offset-4 outline-none hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
+                        >
+                          <Play className="size-4 shrink-0" aria-hidden="true" />
+                          {en ? "How to get box.json with MAA · Video tutorial" : "如何用 MAA 获取 box.json · 视频教程"}
+                          <ExternalLink className="size-3.5 shrink-0" aria-hidden="true" />
+                          <span className="sr-only">{en ? " (opens in a new tab)" : "（新标签页打开）"}</span>
+                        </a>
                         {!websiteSession ? (
                           <Alert>
                             <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -503,6 +538,45 @@ export function SetupDialog({
                         )}
                       </TabsContent>
                     </Tabs>
+                    {maaReview ? (
+                      <section className="mt-3 grid gap-2.5 rounded-lg border border-amber-500/35 bg-amber-50/60 p-3 dark:bg-amber-950/15" aria-label="导入异常确认">
+                        <div className="flex items-baseline justify-between gap-3"><h3 className="font-semibold">发现 {maaReview.issues.length} 项异常练度</h3><span className="text-xs text-muted-foreground">请选择修正方案</span></div>
+                        <p className="text-sm text-muted-foreground">确认后才会导入；取消会保留原来的 Box。</p>
+                        <p className="text-xs text-muted-foreground">星级会根据干员数据自动匹配，原 JSON 中填写的星级不一致时将自动修正。</p>
+                        {maaReview.issues.map(issue => (
+                          <fieldset key={issue.index} className="grid gap-2 rounded-md border bg-background p-2.5">
+                            <legend className="px-1 text-sm font-semibold tracking-normal">{issue.name}（{issue.rarity}星）</legend>
+                            <p className="text-xs font-medium text-muted-foreground">原始数据：精{String(issue.elite)} · {String(issue.level)}级，超出合法范围</p>
+                            <div className="flex flex-wrap gap-1.5" role="group" aria-label={`${issue.name}的修正方案`}>
+                              {issue.choices.map((choice, index) => {
+                                const selected = maaChoices[issue.index] === index;
+                                const color = !choice.own || (choice.elite === 0 && choice.level === 1) ? "#71717A" : choice.elite === 2 ? "#FFD800" : choice.elite === 1 ? "#B8F03A" : "#22BBFF";
+                                return (
+                                  <Button
+                                    key={index}
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    aria-pressed={selected}
+                                    disabled={reviewBusy}
+                                    onClick={() => setMaaChoices(current => ({ ...current, [issue.index]: index }))}
+                                    style={selected ? { backgroundColor: color, borderColor: color } : undefined}
+                                    className={`relative h-auto min-h-8 min-w-16 whitespace-normal rounded-[4px] px-2 py-1.5 focus-visible:ring-[#FFD501] focus-visible:ring-offset-2 ${selected ? (!choice.own ? "text-white" : "text-[#202020]") : "border-border bg-background text-muted-foreground hover:border-foreground/45 hover:bg-muted/60 hover:text-foreground"}`}
+                                  >
+                                    {choice.label}
+                                  </Button>
+                                );
+                              })}
+                            </div>
+                          </fieldset>
+                        ))}
+                        {reviewError ? <p role="alert" className="text-sm text-destructive">{reviewError}</p> : null}
+                        <div className="flex justify-end gap-2">
+                          <SetupActionButton type="button" variant="outline" disabled={reviewBusy} onClick={() => setMaaReview(null)}>取消本次导入</SetupActionButton>
+                          <SetupActionButton type="button" disabled={reviewBusy || maaReview.issues.some(issue => maaChoices[issue.index] === undefined)} onClick={() => void confirmMaaReview()}>{reviewBusy ? "正在导入…" : "确认选择并导入"}</SetupActionButton>
+                        </div>
+                      </section>
+                    ) : null}
                     {inputError ? <p id="setup-box-error" className="mt-3 text-sm text-destructive" role="alert">{inputError}</p> : null}
                   </section>
                 ) : null}
@@ -555,45 +629,10 @@ export function SetupDialog({
                     <div className="pt-1">
                       {mode === "manual" ? (
                         <section className="grid gap-4" aria-labelledby="manual-shift-settings-title" data-manual-shift-settings>
-                          <div>
-                            <h3 className="text-sm font-semibold">{intl("setup_dialog.scheduleMode")}</h3>
-                            <div className="mt-2 grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label={intl("setup_dialog.scheduleMode")}>
-                              <Button
-                                type="button"
-                                variant={manualScheduleMode === "sequential" ? "default" : "outline"}
-                                className="h-auto min-h-16 items-start justify-start px-4 py-3 text-left"
-                                role="radio"
-                                aria-checked={manualScheduleMode === "sequential"}
-                                onClick={() => onManualScheduleModeChange?.("sequential")}
-                              >
-                                <span>
-                                  <span className="block font-semibold">{intl("setup_dialog.sequentialRotation")}</span>
-                                  <span className="mt-1 block text-xs font-normal opacity-75">{intl("setup_dialog.sequentialRotationDescription")}</span>
-                                </span>
-                              </Button>
-                              <Button
-                                type="button"
-                                variant={manualScheduleMode === "period" ? "default" : "outline"}
-                                className="h-auto min-h-16 items-start justify-start px-4 py-3 text-left"
-                                role="radio"
-                                aria-checked={manualScheduleMode === "period"}
-                                onClick={() => onManualScheduleModeChange?.("period")}
-                              >
-                                <span>
-                                  <span className="block font-semibold">{intl("setup_dialog.timeRanges")}</span>
-                                  <span className="mt-1 block text-xs font-normal opacity-75">{intl("setup_dialog.timeRangesDescription")}</span>
-                                </span>
-                              </Button>
-                            </div>
-                          </div>
-                          <div className="border-t border-border/70" />
                           <div className="flex flex-wrap items-center justify-between gap-3">
                             <div>
-                               <h3 id="manual-shift-settings-title" className="text-sm font-semibold">{intl("setup_dialog.manualShifts")}</h3>
-                              <p className="mt-1 text-xs text-muted-foreground">{manualScheduleMode === "period"
-                                ? intl("setup_dialog.consecutiveShiftTimes")
-                                : intl("setup_dialog.shiftOrderOnly")}</p>
-                              {manualScheduleMode === "period" ? <p className="mt-1 text-xs font-medium text-foreground">{intl("setup_dialog.total24Hours")}</p> : null}
+                              <h3 id="manual-shift-settings-title" className="text-sm font-semibold">{intl("setup_dialog.manualShifts")}</h3>
+                              <p className="mt-1 text-xs text-muted-foreground">{intl("setup_dialog.durationsAreIndependentAndDoNotNeedToAdd")}</p>
                             </div>
                             <div className="flex items-center gap-1">
                               <Button type="button" size="icon-sm" variant="outline" aria-label={intl("setup_dialog.removeOneShift")} disabled={manualShiftDurations.length <= 1} onClick={() => updateManualShiftCount(manualShiftDurations.length - 1)}><Minus /></Button>
@@ -604,45 +643,17 @@ export function SetupDialog({
                               <Button type="button" size="icon-sm" variant="outline" aria-label={intl("setup_dialog.addOneShift")} disabled={manualShiftDurations.length >= 12} onClick={() => updateManualShiftCount(manualShiftDurations.length + 1)}><Plus /></Button>
                             </div>
                           </div>
-                          {manualScheduleMode === "period" ? <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                            {manualShiftRanges.map((range, index) => (
-                              <div key={index} className="grid min-h-20 gap-2 border border-border/70 bg-muted/25 px-3 py-2 text-sm">
-                                <div className="flex items-center justify-between gap-3">
-                                  <span>{intl("setup_dialog.shift", { value1: index + 1 })}</span>
-                                  <span className="text-xs text-muted-foreground">{intl("setup_dialog.durationParenthetical", { duration: formatManualShiftDuration(range.durationMinutes, en) })}</span>
-                                </div>
-                                <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
-                                  <label className="grid gap-1 text-xs text-muted-foreground">
-                                    <span>{intl("setup_dialog.start")}</span>
-                                    <input
-                                      aria-label={intl("setup_dialog.shiftStartTime", { value1: index + 1 })}
-                                      className="h-9 min-w-0 rounded-[4px] border border-input bg-background px-2 font-number disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
-                                      type="time"
-                                      step="60"
-                                      value={range.startTime}
-                                      disabled={index > 0}
-                                      onChange={(event) => {
-                                        if (event.target.value) onManualShiftStartTimeChange?.(event.target.value);
-                                      }}
-                                    />
-                                  </label>
-                                  <span className="mt-5 text-muted-foreground" aria-hidden="true">→</span>
-                                  <label className="grid gap-1 text-xs text-muted-foreground">
-                                    <span>{intl("setup_dialog.end")}</span>
-                                    <input
-                                      aria-label={intl("setup_dialog.shiftEndTime", { value1: index + 1 })}
-                                      className="h-9 min-w-0 rounded-[4px] border border-input bg-background px-2 font-number disabled:cursor-not-allowed disabled:bg-muted disabled:text-muted-foreground"
-                                      type="time"
-                                      step="60"
-                                      value={range.endTime}
-                                      disabled={index === manualShiftRanges.length - 1}
-                                      onChange={(event) => updateManualShiftEnd(index, event.target.value)}
-                                    />
-                                  </label>
-                                </div>
-                              </div>
+                          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                            {manualShiftDurations.map((duration, index) => (
+                              <label key={index} className="flex min-h-11 items-center justify-between gap-3 border border-border/70 bg-muted/25 px-3 py-2 text-sm">
+                                <span>{intl("setup_dialog.shift", { value1: index + 1 })}</span>
+                                <span className="flex items-center gap-1.5">
+                                  <input aria-label={intl("setup_dialog.shiftDuration", { value1: index + 1 })} className="h-8 w-20 rounded-[4px] border border-input bg-background px-2 text-right font-number" type="number" min="0.25" step="0.25" value={duration} onChange={(event) => updateManualShiftDuration(index, Number(event.target.value))} />
+                                  <span className="text-xs text-muted-foreground">{intl("setup_dialog.h")}</span>
+                                </span>
+                              </label>
                             ))}
-                          </div> : null}
+                          </div>
                         </section>
                       ) : <RotationSettings value={rotationProfile} onChange={onRotationProfileChange} />}
                     </div>

--- a/src/setup-dialog.tsx
+++ b/src/setup-dialog.tsx
@@ -434,6 +434,9 @@ export function SetupDialog({
                         ) : null}
                       </TabsContent> : null}
                       <TabsContent value="maa" className="grid gap-3 pt-4">
+                        <p className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+                          MAA 导入遇到超出星级上限的精英阶段或等级时，会自动修正并提醒；一、二星最高精0 30级，三星最高精1 55级。
+                        </p>
                         {!websiteSession ? (
                           <Alert>
                             <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## 变更说明

优化 MAA Box 导入和干员练度选择，避免异常数据直接阻断导入。

### MAA 导入

- 星级根据干员真实数据自动匹配，JSON 中填写错误星级时自动修正。
- 检测到异常精英阶段或等级时，在排班设置窗口内展示异常列表。
- 不使用浏览器弹窗，用户可逐项选择修正方案。
- 支持“一键采用推荐方案”。高等级但精英图标缺失时，提供按等级推断的精英阶段选项。
- 用户确认后才导入，取消则保留原 Box。
- 导入成功后显示干员总数和已拥有数量。
- MAA 导入提示只在 MAA 页面显示，不污染森空岛页面。

### 星级规则

- 一星、二星：未拥有 / 精0 非30级 / 精0 30级。
- 三星：未拥有 / 精0 / 精1。
- 四星、五星、六星：未拥有 / 精0 / 精1 / 精2。
- 精0非30级、精1、精2方案写入 1 级；精0 30级写入 30 级。

### UI

- 异常方案按钮复用项目现有 Button / SetupActionButton 样式。
- 精英阶段使用统一颜色：未拥有灰色、精0蓝色、精1绿色、精2黄色。
- 收紧异常审查面板间距，统一字体和层级。

## 验证

- 5174 本地预览已验证。
- 相关 TypeScript 检查通过。
- PR 分支完整检查仍需安装项目依赖后执行。