### PR TITLE
修复移动端登录弹窗布局

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -369,7 +369,7 @@
   }
 }
 
-@media (max-width: 639px) {
+@media (max-width: 767px) {
   .dialog-acrylic {
     -webkit-backdrop-filter: blur(28px) saturate(1.06);
     backdrop-filter: blur(28px) saturate(1.06);
@@ -377,6 +377,12 @@
 
   .dialog-acrylic::before {
     opacity: 0.24;
+  }
+
+  .dialog-acrylic[data-website-account-dialog] {
+    background-color: var(--background);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
   }
 }
 

--- a/src/components/auth/WebsiteAccountDialog.tsx
+++ b/src/components/auth/WebsiteAccountDialog.tsx
@@ -28,13 +28,13 @@ export function WebsiteAccountDialog({
       <DialogContent
         data-website-account-dialog
         finalFocus={false}
-        className="max-h-[calc(100dvh-1rem)] overflow-y-auto sm:max-w-[min(880px,calc(100vw-2rem))]"
+        className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] min-w-0 overflow-x-hidden overflow-y-auto max-md:inset-0 max-md:h-dvh max-md:max-h-none max-md:!w-screen max-md:!max-w-none max-md:translate-x-0 max-md:translate-y-0 max-md:!rounded-none sm:w-full sm:max-w-[min(880px,calc(100vw-2rem))]"
       >
         <DialogHeader className="sr-only">
           <DialogTitle>{intl("components_auth_WebsiteAccountDialog.websiteAccountSignIn")}</DialogTitle>
           <DialogDescription>{intl("components_auth_WebsiteAccountDialog.signInToManageYourWebsiteAccount")}</DialogDescription>
         </DialogHeader>
-        <div className="relative z-[1]">
+        <div className="relative z-[1] min-w-0 max-w-full">
           <WebsiteAccountPanel loadingMode="dialog" onSessionChanged={onSessionChanged} />
         </div>
       </DialogContent>

--- a/src/components/auth/WebsiteAccountDialogLoading.tsx
+++ b/src/components/auth/WebsiteAccountDialogLoading.tsx
@@ -52,13 +52,13 @@ export function WebsiteAccountDialogLoading({
         data-website-account-dialog-loading
         aria-busy="true"
         finalFocus={false}
-        className="max-h-[calc(100dvh-1rem)] overflow-y-auto sm:max-w-[min(880px,calc(100vw-2rem))]"
+        className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] min-w-0 overflow-x-hidden overflow-y-auto max-md:inset-0 max-md:h-dvh max-md:max-h-none max-md:!w-screen max-md:!max-w-none max-md:translate-x-0 max-md:translate-y-0 max-md:!rounded-none sm:w-full sm:max-w-[min(880px,calc(100vw-2rem))]"
       >
         <DialogHeader className="sr-only">
           <DialogTitle>{intl("components_auth_WebsiteAccountDialogLoading.websiteAccountSignIn")}</DialogTitle>
           <DialogDescription>{intl("components_auth_WebsiteAccountDialogLoading.theSignInInterfaceIsLoading")}</DialogDescription>
         </DialogHeader>
-        <div className="relative z-[1]">
+        <div className="relative z-[1] min-w-0 max-w-full">
           <WebsiteAccountLoadingStatus />
         </div>
       </DialogContent>

--- a/src/components/auth/WebsiteAccountPanel.tsx
+++ b/src/components/auth/WebsiteAccountPanel.tsx
@@ -421,9 +421,9 @@ export function WebsiteAccountPanel({
   ];
 
   return (
-    <Card className="surface-shadow overflow-hidden rounded-none ring-0" data-website-account-panel data-auth-wizard>
-      <div className="grid lg:grid-cols-[minmax(16rem,0.75fr)_minmax(0,1.25fr)]">
-        <div className="border-b border-border/70 px-6 py-7 lg:border-b-0 lg:border-r lg:px-8 lg:py-9">
+    <Card className="surface-shadow w-full min-w-0 max-w-full overflow-hidden rounded-none ring-0" data-website-account-panel data-auth-wizard>
+      <div className="grid min-w-0 lg:grid-cols-[minmax(16rem,0.75fr)_minmax(0,1.25fr)]">
+        <div className="min-w-0 border-b border-border/70 px-5 py-6 lg:border-b-0 lg:border-r lg:px-8 lg:py-9">
           <div className="mb-6 grid size-10 place-items-center rounded-lg bg-primary text-primary-foreground">
             <UserRound className="size-5" aria-hidden="true" />
           </div>
@@ -432,7 +432,7 @@ export function WebsiteAccountPanel({
           <p className="mt-3 max-w-sm text-sm leading-6 text-muted-foreground">{modeCopy[mode].description}</p>
         </div>
 
-        <CardContent className={mode === "forgot" ? "grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] p-0" : "p-0"}>
+        <CardContent className={mode === "forgot" ? "grid h-full min-h-0 min-w-0 grid-rows-[auto_minmax(0,1fr)] p-0" : "min-w-0 p-0"}>
           {mode === "forgot" ? (
             <div className="border-b border-border/70 px-5 pb-4 pt-5 sm:px-8 sm:pb-5 sm:pt-7">
               <WizardSteps


### PR DESCRIPTION
## 变更
- 移动端登录弹窗改为全屏单栏布局
- 限制面板宽度，避免横向溢出
- 登录加载状态同步适配
- 窄屏下使用不透明背景，内容保持可滚动

## 验证
- ESLint 通过
- TypeScript 检查通过
- 5174 本地窄屏截图确认无横向溢出