### PR TITLE
fix(deploy): retain the server solver in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       DEPLOY_INTERNAL_PORT: ${{ vars.DEPLOY_INTERNAL_PORT }}
       DEPLOY_DEBUG_TOOLS_ENABLED: ${{ vars.DEPLOY_DEBUG_TOOLS_ENABLED || '0' }}
       DEPLOY_RATE_LIMIT_ENABLED: ${{ vars.DEPLOY_RATE_LIMIT_ENABLED || '1' }}
-      DEPLOY_APPROVED_SOLVER_SHA256: ${{ vars.DEPLOY_APPROVED_SOLVER_SHA256 }}
+      DEPLOY_APPROVED_SOLVER_SHA256: ${{ github.ref_name == 'develop' && vars.DEPLOY_APPROVED_SOLVER_SHA256 || '' }}
       DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix/RIIC-Web
       DEPLOY_RELEASE_HELPER_CONTRACT: "6"
 
@@ -101,7 +101,9 @@ jobs:
           [[ "$DEPLOY_INTERNAL_PORT" =~ ^[0-9]{2,5}$ ]]
           [[ "$DEPLOY_DEBUG_TOOLS_ENABLED" =~ ^[01]$ ]]
           [[ "$DEPLOY_RATE_LIMIT_ENABLED" =~ ^[01]$ ]]
-          [[ "$DEPLOY_APPROVED_SOLVER_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          if [[ "$DEPLOYMENT_ENV" != "production" ]]; then
+            [[ "$DEPLOY_APPROVED_SOLVER_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          fi
           test "$DEPLOY_EXPECTED_REPOSITORY" = "KnightCodeSquareMatrix/RIIC-Web"
           [[ "$DEPLOY_RELEASE_HELPER_CONTRACT" =~ ^[1-9][0-9]*$ ]]
           if [[ "$DEPLOYMENT_ENV" == "production" ]]; then
@@ -254,6 +256,34 @@ jobs:
           verify_helper deploy /usr/local/sbin/arknights-infra-deploy \
             "$DEPLOY_RELEASE_HELPER_CONTRACT"
 
+      - name: Resolve solver for deployment
+        shell: bash
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+        run: |
+          set -euo pipefail
+          solver_sha256="$DEPLOY_APPROVED_SOLVER_SHA256"
+          if [[ "$DEPLOYMENT_ENV" == "production" ]]; then
+            test "$DEPLOY_APP_ROOT" = "/opt/arknights-infra"
+            solver_sha256="$(timeout --kill-after=5s 30s ssh -o BatchMode=yes -o ConnectTimeout=15 \
+              "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
+              "set -eu
+               test -f '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'
+               test ! -L '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'
+               cat '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'")"
+            [[ "$solver_sha256" =~ ^[0-9a-f]{64}$ ]]
+            # The root-owned helper validates ownership, the sidecar, the current
+            # release/configuration, and the Worker's fingerprint before trusting it.
+            timeout --kill-after=10s 60s ssh -o BatchMode=yes -o ConnectTimeout=15 \
+              "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
+              "sudo -n /usr/local/sbin/arknights-infra-deploy --preflight \
+               production '$DEPLOY_APP_ROOT' '$DEPLOY_EXPECTED_REPOSITORY' '$solver_sha256'"
+          fi
+          [[ "$solver_sha256" =~ ^[0-9a-f]{64}$ ]]
+          printf 'DEPLOY_SOLVER_SHA256=%s\n' "$solver_sha256" >> "$GITHUB_ENV"
+          printf 'Deployment solver SHA-256: %s\n' "$solver_sha256" >> "$GITHUB_STEP_SUMMARY"
+
       - name: Sync standalone release tree and assemble verified archive
         shell: bash
         env:
@@ -402,7 +432,7 @@ jobs:
             '$DEPLOY_DEBUG_TOOLS_ENABLED' \
             '$DEPLOY_RATE_LIMIT_ENABLED' \
             '$DEPLOY_EXPECTED_REPOSITORY' \
-            '$DEPLOY_APPROVED_SOLVER_SHA256' \
+            '$DEPLOY_SOLVER_SHA256' \
             '$DEPLOY_TREE_SHA'"
 
       - name: Remove staged release artifacts from the runner

--- a/.github/workflows/deployment-preflight.yml
+++ b/.github/workflows/deployment-preflight.yml
@@ -39,7 +39,7 @@ jobs:
       DEPLOY_INTERNAL_PORT: ${{ vars.DEPLOY_INTERNAL_PORT }}
       DEPLOY_ENVIRONMENT: ${{ inputs.environment }}
       PREFLIGHT_MODE: ${{ inputs.mode }}
-      DEPLOY_APPROVED_SOLVER_SHA256: ${{ vars.DEPLOY_APPROVED_SOLVER_SHA256 }}
+      DEPLOY_APPROVED_SOLVER_SHA256: ${{ inputs.environment == 'development' && vars.DEPLOY_APPROVED_SOLVER_SHA256 || '' }}
       DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix/RIIC-Web
       DEPLOY_RELEASE_HELPER_CONTRACT: "6"
 
@@ -67,7 +67,7 @@ jobs:
           [[ "$DEPLOY_INTERNAL_PORT" =~ ^[0-9]{2,5}$ ]]
           [[ "$PREFLIGHT_MODE" == "baseline" || "$PREFLIGHT_MODE" == "cutover-ready" ]]
           test "$DEPLOY_EXPECTED_REPOSITORY" = "KnightCodeSquareMatrix/RIIC-Web"
-          if [[ "$PREFLIGHT_MODE" == "cutover-ready" ]]; then
+          if [[ "$PREFLIGHT_MODE" == "cutover-ready" && "$DEPLOY_ENVIRONMENT" == "development" ]]; then
             [[ "$DEPLOY_APPROVED_SOLVER_SHA256" =~ ^[0-9a-f]{64}$ ]]
           fi
 
@@ -125,6 +125,17 @@ jobs:
 
           verify_helper deploy /usr/local/sbin/arknights-infra-deploy \
             "$DEPLOY_RELEASE_HELPER_CONTRACT"
+
+          if [[ "$PREFLIGHT_MODE" == "cutover-ready" && "$DEPLOY_ENVIRONMENT" == "production" ]]; then
+            test "$DEPLOY_APP_ROOT" = "/opt/arknights-infra"
+            DEPLOY_APPROVED_SOLVER_SHA256="$(timeout --kill-after=5s 30s ssh "${ssh_options[@]}" \
+              "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \
+              "set -eu
+               test -f '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'
+               test ! -L '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'
+               cat '$DEPLOY_APP_ROOT/shared/bin/infra-cli.sha256'")"
+            [[ "$DEPLOY_APPROVED_SOLVER_SHA256" =~ ^[0-9a-f]{64}$ ]]
+          fi
 
           timeout --kill-after=10s 60s ssh "${ssh_options[@]}" \
             "${DEPLOY_SSH_USER}@${DEPLOY_HOST}" \

--- a/docs/REPOSITORY_ADMIN_CHECKLIST.md
+++ b/docs/REPOSITORY_ADMIN_CHECKLIST.md
@@ -51,7 +51,7 @@ Enter these non-sensitive variables separately in each Environment:
 - `DEPLOY_INTERNAL_PORT`
 - `DEPLOY_DEBUG_TOOLS_ENABLED`
 - `DEPLOY_RATE_LIMIT_ENABLED`
-- `DEPLOY_APPROVED_SOLVER_SHA256`
+- `DEPLOY_APPROVED_SOLVER_SHA256` (development only)
 
 Do not copy values out of old GitHub secrets; re-enter them from the owner-controlled secure store. In particular, the development health URL is an Environment secret, never a repository variable or committed value.
 
@@ -64,7 +64,9 @@ Restrict `development` to `develop`. Restrict `production` to `main` and require
 - [ ] Run `Deployment preflight` in `baseline` mode for a read-only report of the installed deploy helper contract and available disk space; root-only solver details remain hidden in this mode.
 - [ ] After private server maintenance, rerun preflight in `cutover-ready` mode.
 
-Set `DEPLOY_APPROVED_SOLVER_SHA256` to the independently verified digest of the approved shared solver for each Environment. The cutover-ready preflight requires a root-owned `shared/bin` solver and independent SHA-256 sidecar, verifies the Environment-approved digest, and compares both with the solver's Worker `ping` fingerprint. Prepare those private server assets from the owner-controlled release record; never derive and trust a digest solely from a runtime-user-writable file.
+Production retains the server's current solver. Its deployment and cutover-ready preflight read `shared/bin/infra-cli.sha256` from the server; no GitHub production solver approval variable is required. The root-owned deployment helper must verify the solver and sidecar ownership, their matching SHA-256, the current release and runtime configuration, and the Worker's `ping` fingerprint before deployment proceeds. The resolved digest is pinned for that deployment, so a concurrent solver change fails validation instead of silently changing the release.
+
+Development still requires `DEPLOY_APPROVED_SOLVER_SHA256` to match its independently approved shared solver. Prepare private server assets from the owner-controlled release record; never derive and trust a digest solely from a runtime-user-writable file. Neither workflow installs a new solver or weakens the server's integrity checks.
 - [ ] Disable automatic deployment in the old private repository before setting the public repository variable to `1`.
 - [ ] Change `deploy/PUBLIC_DEPLOYMENT_SOURCE` in a PR to `public-automation-v1` and merge it to `develop`. This path is intentionally classified as deploy-required.
 - [ ] Complete development acceptance, then create a same-repository `release/develop-to-main-YYYYMMDD` PR.

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -385,7 +385,7 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.doesNotMatch(deployWorkflow, /allow_workflow_dispatch|github\.event_name/);
   assert.match(deployWorkflow, /deployment_authorized:[\s\S]+type: boolean[\s\S]+deploy_required:[\s\S]+type: boolean/);
   assert.match(deployWorkflow, /inputs\.deployment_authorized &&[\s\S]+inputs\.deploy_required &&[\s\S]+github\.ref_name == 'main'[\s\S]+vars\.DEPLOY_AUTOMATION_ENABLED == '1'[\s\S]+github\.repository == 'KnightCodeSquareMatrix\/RIIC-Web'/);
-  assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
+  assert.match(deployWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ github\.ref_name == 'develop' && vars\.DEPLOY_APPROVED_SOLVER_SHA256 \|\| '' \}\}[\s\S]+DEPLOY_EXPECTED_REPOSITORY: KnightCodeSquareMatrix\/RIIC-Web[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PREPARE_HELPER_CONTRACT|arknights-infra-prepare-release/);
   assert.match(deployWorkflow, /DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}/);
   assert.doesNotMatch(deployWorkflow, /DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ vars\./);
@@ -396,7 +396,8 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   assert.match(preflightWorkflow, /PREFLIGHT_MODE: \$\{\{ inputs\.mode \}\}/);
   assert.match(preflightWorkflow, /DEPLOY_ENVIRONMENT: \$\{\{ inputs\.environment \}\}/);
   assert.match(preflightWorkflow, /if \[\[ "\$PREFLIGHT_MODE" == "cutover-ready" \]\][\s\S]+test "\$actual_contract" = "\$expected_contract"/);
-  assert.match(preflightWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ vars\.DEPLOY_APPROVED_SOLVER_SHA256 \}\}[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
+  assert.match(preflightWorkflow, /DEPLOY_APPROVED_SOLVER_SHA256: \$\{\{ inputs\.environment == 'development' && vars\.DEPLOY_APPROVED_SOLVER_SHA256 \|\| '' \}\}[\s\S]+DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
+  assert.match(preflightWorkflow, /"\$PREFLIGHT_MODE" == "cutover-ready" && "\$DEPLOY_ENVIRONMENT" == "production"[\s\S]+cat '\$DEPLOY_APP_ROOT\/shared\/bin\/infra-cli\.sha256'[\s\S]+sudo -n \/usr\/local\/sbin\/arknights-infra-deploy/);
   assert.match(preflightWorkflow, /Inspect deploy helper, solver, and disk[\s\S]+verify_helper deploy \/usr\/local\/sbin\/arknights-infra-deploy/);
   assert.match(preflightWorkflow, /sudo -n \/usr\/local\/sbin\/arknights-infra-deploy[\s\S]+--preflight "\$deployment_environment" "\$app_root"[\s\S]+"\$expected_repository" "\$approved_solver_sha256"/);
   assert.match(preflightWorkflow, /solver_source=not-inspected-root-only/);
@@ -413,7 +414,7 @@ test("public deployment automation is repository-bound, opt-in, and secret-safe"
   );
   assert.match(preflightWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);
   assert.match(deployWorkflow, /printf '%s\\n' "\$DEPLOY_PUBLIC_HEALTH_URL" \| ssh[\s\S]+'\$public_health_argument'/);
-  assert.match(deployWorkflow, /'\$DEPLOY_EXPECTED_REPOSITORY'[\s\S]+'\$DEPLOY_APPROVED_SOLVER_SHA256'[\s\S]+'\$DEPLOY_TREE_SHA'/);
+  assert.match(deployWorkflow, /'\$DEPLOY_EXPECTED_REPOSITORY'[\s\S]+'\$DEPLOY_SOLVER_SHA256'[\s\S]+'\$DEPLOY_TREE_SHA'/);
   assert.doesNotMatch(deployWorkflow, /'\$DEPLOY_PUBLIC_HEALTH_URL'/);
   assert.match(deployWorkflow, /Remove SSH credentials from the runner[\s\S]+rm -f -- "\$HOME\/\.ssh\/id_ed25519" "\$HOME\/\.ssh\/known_hosts"/);
   assert.match(deployWorkflow, /Verify public response compression[\s\S]+DEPLOY_PUBLIC_HEALTH_URL: \$\{\{ secrets\.DEPLOY_PUBLIC_HEALTH_URL \}\}[\s\S]+node scripts\/verify-public-compression\.mjs/);
@@ -458,9 +459,77 @@ test("CI builds once and deploy transfers the verified solver-free standalone ar
   assert.doesNotMatch(deployWorkflow, /archive_cache=|remote_prefix_sha256|upload_chunk_bytes/);
   assert.doesNotMatch(deployWorkflow, /\bscp\b/);
   assert.match(deployWorkflow, /DEPLOY_RELEASE_HELPER_CONTRACT: "6"/);
-  assert.match(deployWorkflow, /'\$DEPLOY_APPROVED_SOLVER_SHA256' \\\n\s+'\$DEPLOY_TREE_SHA'/);
+  assert.match(deployWorkflow, /'\$DEPLOY_SOLVER_SHA256' \\\n\s+'\$DEPLOY_TREE_SHA'/);
   assert.match(deployWorkflow, /Remove staged release artifacts from the runner[\s\S]+if: always\(\)[\s\S]+"\$RUNNER_TEMP"\/riic-web-release-\[0-9\]\*-\[0-9\]\*/);
-  assert.doesNotMatch(deployWorkflow, /git (?:archive|bundle)|repository\.git|DEPLOY_PREVIOUS_SHA|remote_bundle|bin\/infra-cli/);
+  assert.doesNotMatch(deployWorkflow, /git (?:archive|bundle)|repository\.git|DEPLOY_PREVIOUS_SHA|remote_bundle/);
+  const transfer = deployWorkflow.slice(deployWorkflow.indexOf("      - name: Sync standalone release tree"));
+  assert.doesNotMatch(transfer, /bin\/infra-cli/);
+});
+
+test("production pins the server solver only after preflight and development retains its approved digest", async () => {
+  const workflow = (await readRepoFile(".github/workflows/deploy.yml")).replaceAll("\r\n", "\n");
+  const section = workflow.split("      - name: Resolve solver for deployment\n")[1]?.split("\n      - name:")[0];
+  const body = section?.split("        run: |\n")[1]?.replace(/^ {10}/gm, "");
+  assert.ok(body);
+  const gitExecPath = process.platform === "win32"
+    ? spawnSync("git", ["--exec-path"], { encoding: "utf8" }).stdout?.trim()
+    : null;
+  const gitBash = gitExecPath ? resolve(gitExecPath, "../../../bin/bash.exe") : null;
+  const bash = process.env.TEST_BASH_PATH ?? (gitBash && existsSync(gitBash) ? gitBash : "bash");
+  const script = [
+    "set -euo pipefail",
+    'GITHUB_ENV="$(mktemp)"',
+    'trap \'cat "$GITHUB_ENV"; rm -f -- "$GITHUB_ENV"\' EXIT',
+    'timeout() { shift 2; "$@"; }',
+    "ssh() {",
+    "  printf 'SSH_CALL\\n' >&2",
+    "  local remote_command; for remote_command; do :; done",
+    '  if [[ "$remote_command" == *"--preflight"* ]]; then',
+    "    printf 'PREFLIGHT_CALL\\n' >&2",
+    '    return "$PREFLIGHT_EXIT"',
+    "  fi",
+    '  printf "%s" "$SERVER_DIGEST"',
+    '  return "$SSH_EXIT"',
+    "}",
+    body,
+  ].join("\n");
+  const serverDigest = "a".repeat(64);
+  const approvedDigest = "b".repeat(64);
+  const run = (overrides = {}) => spawnSync(bash, ["--noprofile", "--norc", "-c", script], {
+    encoding: "utf8", timeout: 10_000,
+    env: {
+      ...process.env, DEPLOYMENT_ENV: "production", DEPLOY_APP_ROOT: "/opt/arknights-infra",
+      DEPLOY_EXPECTED_REPOSITORY: "KnightCodeSquareMatrix/RIIC-Web",
+      DEPLOY_APPROVED_SOLVER_SHA256: "", DEPLOY_HOST: "example.invalid", DEPLOY_SSH_USER: "fixture",
+      SERVER_DIGEST: serverDigest, SSH_EXIT: "0", PREFLIGHT_EXIT: "0",
+      GITHUB_STEP_SUMMARY: "/dev/null", ...overrides,
+    },
+  });
+  for (const configured of ["", approvedDigest]) {
+    const result = run({ DEPLOY_APPROVED_SOLVER_SHA256: configured });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), "DEPLOY_SOLVER_SHA256=" + serverDigest);
+    assert.match(result.stderr, /PREFLIGHT_CALL/);
+  }
+  for (const overrides of [
+    { SERVER_DIGEST: "" }, { SERVER_DIGEST: "invalid" },
+    { SERVER_DIGEST: serverDigest + "\n" + approvedDigest }, { SSH_EXIT: "1" },
+    { DEPLOY_APP_ROOT: "/opt/arknights-infra-dev" },
+  ]) {
+    const result = run(overrides);
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(result.stdout, /DEPLOY_SOLVER_SHA256=/);
+    assert.doesNotMatch(result.stderr, /PREFLIGHT_CALL/);
+  }
+  const rejected = run({ PREFLIGHT_EXIT: "1" });
+  assert.notEqual(rejected.status, 0);
+  assert.match(rejected.stderr, /PREFLIGHT_CALL/);
+  assert.doesNotMatch(rejected.stdout, /DEPLOY_SOLVER_SHA256=/);
+  const development = run({ DEPLOYMENT_ENV: "development", DEPLOY_APPROVED_SOLVER_SHA256: approvedDigest });
+  assert.equal(development.status, 0, development.stderr);
+  assert.equal(development.stdout.trim(), "DEPLOY_SOLVER_SHA256=" + approvedDigest);
+  assert.doesNotMatch(development.stderr, /SSH_CALL/);
+  assert.notEqual(run({ DEPLOYMENT_ENV: "development" }).status, 0);
 });
 
 test("asset synchronization isolates untrusted generation from repository write credentials", async () => {


### PR DESCRIPTION
Production releases were blocked when the server's current solver changed but GitHub's separate approved SHA-256 variable remained stale. Production now reads the server's solver sidecar and runs the installed root-owned helper's preflight before pinning that digest for deployment. This retains the current solver while preserving ownership, integrity, runtime configuration, Worker fingerprint, and concurrent-change checks.

The production preflight follows the same policy. Development retains its existing approved digest configuration. This unblocks deployment of the Aliyun authentication email fallback already merged in #227; enabling actual Aliyun delivery still requires runtime credentials and a verified sender.

Validation: deployment tooling tests pass (49 tests), including missing/stale production variables, malformed server responses, SSH/preflight failures, and development behavior. ESLint, workflow YAML parsing, public repository hygiene, and diff checks pass. Required post-merge quality and deployment checks remain in place.
