### PR TITLE
fix(deploy): recover cache permissions after interrupted transfers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -336,6 +336,10 @@ jobs:
              else
                install -d -m 700 -- \"\$remote_cache_path\"
              fi
+             test \"\$(stat -c '%U' -- \"\$remote_cache_path\")\" = \"\$(id -un)\"
+             # An interrupted rsync --perms may leave the source directory mode.
+             # Restore privacy only after validating the owned, non-symlink cache.
+             chmod 700 -- \"\$remote_cache_path\"
              test \"\$(stat -c '%U:%a' -- \"\$remote_cache_path\")\" = \"\$(id -un):700\"
              test -z \"\$(find \"\$remote_cache_path\" -mindepth 1 ! -type f ! -type d -print -quit)\""
 

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -466,6 +466,40 @@ test("CI builds once and deploy transfers the verified solver-free standalone ar
   assert.doesNotMatch(transfer, /bin\/infra-cli/);
 });
 
+test("deployment resumes an interrupted cache without accepting symlinks or non-directories", { skip: process.platform === "win32" }, async () => {
+  const workflow = (await readRepoFile(".github/workflows/deploy.yml")).replaceAll("\r\n", "\n");
+  const section = workflow.split("      - name: Sync standalone release tree")[1].split("\n      - name:")[0];
+  const body = section.split("        run: |\n")[1].replace(/^ {10}/gm, "");
+  const setup = body.slice(body.indexOf("timeout --kill-after=5s 30s ssh"), body.indexOf("timeout --kill-after=10s 5400s rsync"));
+  assert.ok(setup);
+  const script = [
+    "set -euo pipefail",
+    'export REVIEWER_CACHE_HOME="$(mktemp -d)"',
+    'trap \'rm -rf -- "$REVIEWER_CACHE_HOME"\' EXIT',
+    'release_tree_cache=".cache/riic-web/production-standalone-tree"',
+    'cache="$REVIEWER_CACHE_HOME/$release_tree_cache"',
+    'mkdir -p "$cache"',
+    'chmod 700 "$(dirname "$cache")"',
+    // rsync --perms can copy the source root's 755 mode before cancellation.
+    'chmod 755 "$cache"',
+    'printf partial > "$cache/retained-file"',
+    'rsync() { :; }; export -f rsync',
+    'timeout() { shift 2; "$@"; }',
+    'ssh_options=(); ssh_target=fixture',
+    'ssh() { local remote; for remote; do :; done; printf "%s" "$remote" | sed \'s/\\$HOME/\\$REVIEWER_CACHE_HOME/g\' | bash; }',
+    setup,
+    'test "$(stat -c %a "$cache")" = 700',
+    'test "$(cat "$cache/retained-file")" = partial',
+    'mv "$cache" "${cache}-saved"',
+    'ln -s "${cache}-saved" "$cache"',
+    'if ( set -e; ' + setup + ' ); then echo "Accepted symlink" >&2; exit 1; fi',
+    'rm "$cache"; touch "$cache"',
+    'if ( set -e; ' + setup + ' ); then echo "Accepted regular file" >&2; exit 1; fi',
+  ].join("\n");
+  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", script], { encoding: "utf8", timeout: 10_000 });
+  assert.equal(result.status, 0, result.stderr);
+});
+
 test("production pins the server solver only after preflight and development retains its approved digest", async () => {
   const workflow = (await readRepoFile(".github/workflows/deploy.yml")).replaceAll("\r\n", "\n");
   const section = workflow.split("      - name: Resolve solver for deployment\n")[1]?.split("\n      - name:")[0];


### PR DESCRIPTION
修复中断的 rsync 传输导致后续生产发布在缓存目录检查阶段退出的问题：`--perms` 会将来源目录权限带到缓存根目录，取消传输时可能来不及执行后续的 `chmod 700`。

缓存重用前先确认目录归属当前部署用户且不是符号链接，再恢复 700 权限；保留现有路径、归属、目录内容和产物校验，不改动线上业务数据。

Linux 隔离环境已复现原流程失败，修复后验证 755 缓存可恢复、已有文件保留、符号链接和普通文件仍被拒绝。部署工具测试与 ESLint 已通过。

这是已授权审阅人上线的必要发布修复，从 main 创建并使用 direct-main-release。审阅人应用代码已在前一轮完整 CI 中通过。
