### PR TITLE
release: 移除练卡建议检查通过提示卡

### DIFF
--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -733,9 +733,8 @@ test("calculator owns scheduling controls and training advice uses a single tech
   await expect(calculatorControls).toHaveCount(0);
   await expect(page.getByText("这里只展示求解器给出的结构化建议", { exact: false })).toHaveCount(0);
   await expect(page.locator('[data-slot="training-summary"]')).toHaveClass(/infra-room-surface/);
-  await expect(page.locator('[data-slot="training-data-check"]')).toHaveClass(/infra-room-surface/);
+  await expect(page.locator('[data-slot="training-data-check"]')).toHaveCount(0);
   await expect(page.locator('[data-slot="training-summary"] svg')).toHaveCount(1);
-  await expect(page.locator('[data-slot="training-data-check"] svg')).toHaveCount(1);
   await expect(page.locator('[data-slot^="training-"] .infra-room-emblem')).toHaveCount(0);
   const adviceCards = page.locator('[data-slot="training-advice-card"]');
   await expect(adviceCards).toHaveCount(2);

--- a/src/components/pages/TrainingAdvice.tsx
+++ b/src/components/pages/TrainingAdvice.tsx
@@ -2,7 +2,7 @@ import { localize as localize_components_pages_TrainingAdvice } from "../../i18n
 import { useTranslations, useLocale } from "next-intl";
 import { messageRecord } from "@/i18n/translate";
 import { lazy, Suspense, useEffect, useState, type ReactNode } from "react";
-import { CircleAlert, ClipboardCheck, ChevronDown, GraduationCap } from "lucide-react";
+import { CircleAlert, ChevronDown, GraduationCap } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
 import { InfraTechnicalCard, InfraTechnicalHeading } from "@/components/InfraTechnicalCard";
@@ -305,14 +305,7 @@ export function TrainingAdvice({
             </div>
           </div>
         </InfraTechnicalCard>
-      ) : (
-        <InfraTechnicalCard group="power" dataSlot="training-data-check" showEmblem={false}>
-          <div className="flex gap-3 text-sm" aria-label={intl("components_pages_TrainingAdvice.dataValidation")}>
-            <ClipboardCheck className="mt-0.5 size-5 shrink-0 text-[var(--room-accent)]" aria-hidden="true" />
-            <p className="text-white/76">{intl("components_pages_TrainingAdvice.infrastructureAndOperatorDataPassedTheBasicChecks")}</p>
-          </div>
-        </InfraTechnicalCard>
-      )}
+      ) : null}
 
       <div className="grid min-w-0 gap-1" data-training-filters>
         <SkillFilterRow label={intl("SkillFilters.rarity")}>


### PR DESCRIPTION
移除练卡建议页中“当前基建设施与干员数据已通过基础检查，可以生成排班”的成功提示卡，让建议内容和筛选更直接。数据缺失时的校验问题提示保持不变。

同步更新现有页面端到端测试，验证有效数据下不再出现该卡片，其他建议与操作仍可用。

验证：相关 ESLint 通过；Chromium 页面用例通过。首次本地冷启动在页面切换处超时，复测通过，未降低断言或超时标准。
