### PR TITLE
feat(admin): display verified user count

### DIFF
--- a/e2e/admin-reviewer.spec.ts
+++ b/e2e/admin-reviewer.spec.ts
@@ -65,6 +65,7 @@ test("reviewer sees only overview and issues, and direct admin routes remain pro
     // exercise the role controls here with a bootstrap user's response.
     await pool.query('UPDATE "user" SET role=$1 WHERE id=$2', ["admin", id]);
     let isReviewer = false;
+    let verifiedUsers = 45549;
     await page.route("**/api/admin/users**", async route => {
       if (route.request().method() === "PATCH") {
         const body = route.request().postDataJSON();
@@ -74,6 +75,7 @@ test("reviewer sees only overview and issues, and direct admin routes remain pro
       } else {
         await route.fulfill({ json: { success: true, data: {
           permissions: { canManageAdminRoles: true },
+          summary: { verifiedUsers },
           users: [{ id: "role-control-test", name: "Role control test", email: "reviewer@example.test",
             emailVerified: true, banned: false, banReason: null, createdAt: new Date().toISOString(),
             isAdmin: false, isReviewer, isBootstrapAdmin: false,
@@ -83,6 +85,7 @@ test("reviewer sees only overview and issues, and direct admin routes remain pro
     });
     await context.addCookies([{ name: "riic-locale", value: "zh", domain: new URL(baseURL!).hostname, path: "/" }]);
     await page.goto("/admin/users");
+    await expect(page.locator("[data-admin-verified-users]")).toContainText("45,549");
     await page.getByRole("button", { name: /设为审阅人|Grant reviewer/, exact: true }).click();
     await page.getByRole("dialog").getByRole("button", { name: /确认设为审阅人|Confirm reviewer/, exact: true }).click();
     await expect(page.getByRole("button", { name: /撤销审阅人|Revoke reviewer/, exact: true })).toBeVisible();
@@ -91,6 +94,9 @@ test("reviewer sees only overview and issues, and direct admin routes remain pro
     await page.getByRole("dialog").getByRole("button", { name: /确认取消|Confirm revocation/, exact: true }).click();
     await expect(page.getByRole("button", { name: /设为审阅人|Grant reviewer/, exact: true })).toBeVisible();
     expect(isReviewer).toBe(false);
+    verifiedUsers = 0;
+    await page.getByRole("button", { name: /搜索|Search/, exact: true }).click();
+    await expect(page.locator("[data-admin-verified-users] dd").first()).toHaveText("0");
     await pool.query('UPDATE "user" SET role=$1 WHERE id=$2', ["user", id]);
     expect((await context.request.get("/api/admin/solver-metrics", { headers: apiHeaders })).status()).toBe(403);
     await page.goto("/admin");

--- a/messages/en.json
+++ b/messages/en.json
@@ -521,6 +521,8 @@
     "actionCompleted": "Action completed.",
     "couldNotLoadSessions": "Could not load sessions",
     "userManagement": "User management",
+    "verifiedUsers": "Email-verified users",
+    "verifiedUsersScope": "Site-wide total · Unaffected by search",
     "searchSuspendInspectOrRevokeSessions": "Search, suspend, inspect, or revoke sessions.",
     "theBootstrapAdministratorCanAlsoChangeAdministratorRoles": " Administrators can assign administrator and reviewer roles. Bootstrap administrator access cannot be changed here.",
     "administratorRolesCanBeChangedOnlyByTheBootstrap": " Your account does not have permission to assign administrative roles.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -521,6 +521,8 @@
     "actionCompleted": "操作已完成。",
     "couldNotLoadSessions": "无法读取 Session",
     "userManagement": "用户管理",
+    "verifiedUsers": "已验证邮箱用户",
+    "verifiedUsersScope": "全站总数 · 不受搜索影响",
     "searchSuspendInspectOrRevokeSessions": "搜索、封禁、查看或撤销 Session。",
     "theBootstrapAdministratorCanAlsoChangeAdministratorRoles": " 管理员可以设置管理员和审阅人角色，初始管理员权限不能在此调整。",
     "administratorRolesCanBeChangedOnlyByTheBootstrap": " 当前账号没有分配后台角色的权限。",

--- a/src/app/admin/users/users-client.tsx
+++ b/src/app/admin/users/users-client.tsx
@@ -17,6 +17,7 @@ export function AdminUserManagement() {
   const locale = useLocale();
   const en = locale === "en";
   const [users, setUsers] = useState<AdminUserData[]>([]);
+  const [verifiedUsers, setVerifiedUsers] = useState<number | null>(null);
   const [canManageAdminRoles, setCanManageAdminRoles] = useState<boolean | null>(null);
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(true);
@@ -27,11 +28,13 @@ export function AdminUserManagement() {
 
   const load = useCallback(async (search: string) => {
     setLoading(true);
+    setVerifiedUsers(null);
     try {
       const response = await fetch(`/api/admin/users?q=${encodeURIComponent(search)}`, { cache: "no-store" });
       const body = await response.json();
       if (!response.ok) throw new Error(body.error?.message ?? (intl("app_admin_users_users_client.couldNotLoadUsers")));
       setUsers(body.data.users);
+      setVerifiedUsers(body.data.summary.verifiedUsers);
       setCanManageAdminRoles(body.data.permissions.canManageAdminRoles);
     } finally {
       setLoading(false);
@@ -97,14 +100,21 @@ export function AdminUserManagement() {
 
   return (
     <section id="users" className="scroll-mt-24 overflow-hidden rounded-2xl border bg-card" data-admin-user-management>
-      <header className="border-b px-5 py-5 sm:px-6">
-        <div>
+      <header className="flex flex-col gap-5 border-b px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="min-w-0">
           <h2 className="text-lg font-semibold tracking-tight">{intl("app_admin_users_users_client.userManagement")}</h2>
           <p className="mt-1 text-sm text-muted-foreground">
             {intl("app_admin_users_users_client.searchSuspendInspectOrRevokeSessions")}
             {canManageAdminRoles === true ? (intl("app_admin_users_users_client.theBootstrapAdministratorCanAlsoChangeAdministratorRoles")) : canManageAdminRoles === false ? (intl("app_admin_users_users_client.administratorRolesCanBeChangedOnlyByTheBootstrap")) : ""}
           </p>
         </div>
+        <dl className="shrink-0 rounded-xl border bg-muted/30 px-5 py-3 sm:text-right" data-admin-verified-users aria-busy={loading}>
+          <dt className="text-sm text-muted-foreground">{intl("app_admin_users_users_client.verifiedUsers")}</dt>
+          <dd className="mt-1 font-number text-3xl font-semibold tabular-nums tracking-tight" aria-live="polite">
+            {verifiedUsers === null ? "—" : new Intl.NumberFormat(locale).format(verifiedUsers)}
+          </dd>
+          <dd className="mt-1 text-xs text-muted-foreground">{intl("app_admin_users_users_client.verifiedUsersScope")}</dd>
+        </dl>
       </header>
 
       <div className="grid gap-5 px-5 py-5 sm:px-6">

--- a/src/server/admin-users-api.ts
+++ b/src/server/admin-users-api.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, desc, eq, gt, ilike, or } from "drizzle-orm";
+import { and, count, desc, eq, gt, ilike, or } from "drizzle-orm";
 
 import type {
   AdminSessionsData,
@@ -137,6 +137,8 @@ export async function handleListAdminUsers(request: Request, route: AdminUserRou
       banReason: user.banReason,
       createdAt: user.createdAt,
     }).from(user).where(where).orderBy(desc(user.createdAt)).limit(100);
+    const [summary] = await getDatabase().select({ verifiedUsers: count() })
+      .from(user).where(eq(user.emailVerified, true));
     const bindingSummaries = await sklandBindingSummariesByUserIds(records.map((record) => record.id));
     const bootstrapAdminIds = configuredAdminIds();
     return successResponse<AdminUsersData>({
@@ -150,6 +152,7 @@ export async function handleListAdminUsers(request: Request, route: AdminUserRou
         }, bootstrapAdminIds);
       }),
       permissions: { canManageAdminRoles: actor.canManageAdminRoles },
+      summary,
     }, requestId);
   } catch (error) {
     return failureResponse(error, requestId, route, startedAt);

--- a/src/server/reviewer-role.integration.test.mjs
+++ b/src/server/reviewer-role.integration.test.mjs
@@ -66,6 +66,11 @@ test("reviewer roles enforce real-session API boundaries and take effect without
     await status(await handleUpdateAdminUser(request(targetCookie, { isAdmin: true }), targetId), 403);
     const adminUsers = await status(await handleListAdminUsers(request(adminCookie)));
     assert.equal(adminUsers.data.permissions.canManageAdminRoles, true);
+    assert.ok(Number.isInteger(adminUsers.data.summary.verifiedUsers));
+    assert.ok(adminUsers.data.summary.verifiedUsers >= 3);
+    const emptySearch = await status(await handleListAdminUsers(request(adminCookie, undefined, `/api/admin/users?q=missing-${randomUUID()}`)));
+    assert.equal(emptySearch.data.users.length, 0);
+    assert.ok(emptySearch.data.summary.verifiedUsers >= 3, "verified total is global even when no users match the search");
     await status(await handleUpdateAdminUser(request(adminCookie, { isAdmin: false }), bootstrapId), 403);
     await status(await handleUpdateAdminUser(request(adminCookie, { isReviewer: true }), bootstrapId), 403);
     await status(await handleUpdateAdminUser(request(adminCookie, { isAdmin: true }), targetId));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1254,6 +1254,7 @@ export interface AdminUserData {
 
 export interface AdminUsersData {
   users: AdminUserData[];
+  summary: { verifiedUsers: number };
   permissions: {
     canManageAdminRoles: boolean;
   };


### PR DESCRIPTION
后台用户管理页此前只能查看最多 100 条用户记录，无法直观看到全站已验证邮箱人数。现在在标题旁显示带千位分隔符的已验证邮箱用户总数，并注明不受搜索影响。

统计在管理员鉴权后直接查询数据库 email_verified=true 的账号，随列表加载或刷新更新。加载及失败状态显示占位符，真实零值显示 0。包含中英文文案，沿用现有后台样式。

验证：77 项 API 契约测试、中英文检查、相关 ESLint、diff 检查通过。补充搜索无结果时仍返回全站统计的数据库集成断言，以及人数格式和零值显示的浏览器测试，由发布流水线执行完整验证。

按用户授权使用 direct-main-release，仅发布该功能，不包含其他工作区改动。
