### PR TITLE
Codex/fix mulberry bd tag

### DIFF
--- a/src/components/skill-query/rich-text.test.ts
+++ b/src/components/skill-query/rich-text.test.ts
@@ -44,7 +44,9 @@ test("parses standalone term ref with following styled text", () => {
 });
 
 test("preserves unknown and malformed tags as plain text", () => {
-  assert.equal(parseRichText("值<<$cc.bd_b1>内容</>")[0].type, "text");
+  const malformed = parseRichText("值<<$cc.bd_b1>内容</>");
+  assert.equal(malformed[0].type, "text");
+  assert.equal(malformed[1].type === "term" && malformed[1].id, "cc_bd_b1");
   const nodes = parseRichText("未知<@cc.unknown>x</>标签");
   assert.equal(nodes[1].type === "style" && nodes[1].className, "cc-unknown");
 });

--- a/src/components/skill-query/rich-text.test.ts
+++ b/src/components/skill-query/rich-text.test.ts
@@ -43,7 +43,7 @@ test("parses standalone term ref with following styled text", () => {
   assert.equal(term?.type === "term" && term.children[0].type, "style");
 });
 
-test("preserves unknown and malformed tags as plain text", () => {
+test("修复桑葚基建技能异常：兼容并清理脏标签", () => {
   const malformed = parseRichText("值<<$cc.bd_b1>内容</>");
   assert.equal(malformed[0].type, "text");
   assert.equal(malformed[1].type === "term" && malformed[1].id, "cc_bd_b1");

--- a/src/components/skill-query/rich-text.ts
+++ b/src/components/skill-query/rich-text.ts
@@ -32,7 +32,9 @@ export function richTextPlainText(value: string): string {
  * 返回节点树；未知/脏标签按原文保留为文本。
  */
 export function parseRichText(text: string): RichTextNode[] {
-  const normalized = text.replace(/(<@[^<>]+>)(<\$[^<>]+>)/g, "$2$1");
+  const normalized = text
+    .replace(/<<\$/g, "<$")
+    .replace(/(<@[^<>]+>)(<\$[^<>]+>)/g, "$2$1");
   const root: RichTextNode[] = [];
   const stack: RichTextNode[] = [];
   let buffer = "";
@@ -71,7 +73,7 @@ export function parseRichText(text: string): RichTextNode[] {
       (parent && "children" in parent ? parent.children : root).push(node);
       stack.push(node);
     } else {
-      // 未知标签（含数据脏标签如 `<<$cc.bd_b1>`）：按原文文本保留。
+      // 未知标签按原文文本保留。
       buffer += normalized.slice(index, close + 1);
     }
     index = close + 1;

--- a/src/components/skill-query/rich-text.ts
+++ b/src/components/skill-query/rich-text.ts
@@ -73,7 +73,7 @@ export function parseRichText(text: string): RichTextNode[] {
       (parent && "children" in parent ? parent.children : root).push(node);
       stack.push(node);
     } else {
-      // 未知标签按原文文本保留。
+      // 兜底保留：把未知/异常标签当原文，避免桑葚等技能页露出脏文本。
       buffer += normalized.slice(index, close + 1);
     }
     index = close + 1;

--- a/src/generated/arkntools/building-skill-catalog.json
+++ b/src/generated/arkntools/building-skill-catalog.json
@@ -1671,7 +1671,7 @@
   "hire_spd_bd_n1_n1_200": {
     "id": "hire_spd_bd_n1_n1_200",
     "name": "救援队·灾后普查",
-    "descriptionRich": "进驻人力办公室时，每个招募位（不包含初始招募位）<@cc.vup>+10</>点<<$cc.bd_b1><@cc.rem>人间烟火</></>",
+    "descriptionRich": "进驻人力办公室时，每个招募位（不包含初始招募位）<@cc.vup>+10</>点<$cc.bd_b1><@cc.rem>人间烟火</></>",
     "tags": [
       "特殊加成"
     ],


### PR DESCRIPTION
## 变更

<!-- 说明用户可见行为、问题原因与实现边界。 -->

## 验证

- [ ] PR 的 base branch 是 `develop`；只有维护者的 `release/**` PR 可以指向 `main`，不经 `develop` 的特批发布还必须带有 `direct-main-release` 标签
- [ ] 已运行 `npm run check`
- [ ] 已运行 `npm run build`
- [ ] 交互改动已运行相关 Chromium / production-profile / WebKit 测试
- [ ] 数据库改动包含迁移并通过集成测试
- [ ] 未包含凭据、用户数据、内部文档、服务器 helper、solver 或真实部署信息

## 许可

- [ ] 我有权提交这些内容，并同意自有贡献按 PolyForm Noncommercial 1.0.0 发布
- [ ] 第三方代码或素材已注明来源、许可证与固定版本
