### PR TITLE
fix: 修复整合发布检查与排班布局回归

### DIFF
--- a/e2e/production-readiness-foundation.spec.ts
+++ b/e2e/production-readiness-foundation.spec.ts
@@ -1252,7 +1252,7 @@ test("two-shift output drives product estimates, room formulas, and profile deta
 
   await page.getByRole("button", { name: "练卡建议" }).click();
   await expect(page.getByText("练度提升", { exact: true })).toBeVisible();
-  await expect(page.getByText("当前 精1 → 目标 精2", { exact: true })).toBeVisible();
+  await expect(page.getByText("目前精一 · 目标精二", { exact: true })).toBeVisible();
 });
 
 test("old sessions normalize duplicate operator names before training advice renders", async ({ page }) => {

--- a/e2e/production-readiness-interface.spec.ts
+++ b/e2e/production-readiness-interface.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Locator } from "@playwright/test";
 import arkntoolsSource from "../src/generated/arkntools/source.json" with { type: "json" };
+import { twoShiftPlanData } from "./production-readiness.fixture";
 import { requestId, diagnosticId, waitForOwnAnimations, gotoStable, expectVisibleNumbersUseNumberFont, profile, planData, scheduleVisualPlanData, sampleData, authenticatedSklandSnapshot, mockApis, openSklandOverview, seedPreferences, seedV4Session } from "./production-readiness.fixture";
 
 const fullOperatorCount = arkntoolsSource.counts.operators;
@@ -24,6 +25,36 @@ async function expectSetupAction(button: Locator) {
   await expect(button).toHaveCSS("border-radius", "18px");
   await expect(button).toHaveCSS("font-size", "12px");
 }
+
+test("drone selection updates exports and restores automatic allocation without solving", async ({ page }) => {
+  await mockApis(page);
+  await seedV4Session(page, twoShiftPlanData, { rotationProfile: "main_backup_12_12" });
+  let solves = 0;
+  page.on("request", request => { if (request.method() === "POST" && /\/api\/plan(?:-tasks)?$/.test(new URL(request.url()).pathname)) solves++; });
+  await page.goto("/");
+  async function exportedDrones() {
+    const pending = page.waitForEvent("download");
+    await page.getByRole("button", { name: "导出到 MAA", exact: true }).click();
+    const stream = await (await pending).createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")).plans[0].drones;
+  }
+  const automatic = await exportedDrones();
+  await page.getByRole("button", { name: "切换到手动", exact: true }).click();
+  const picker = page.getByRole("dialog", { name: "选择无人机去向" });
+  await picker.getByRole("button", { name: "贸易站 1", exact: true }).click();
+  await expect(picker).toHaveCount(0);
+  expect(await exportedDrones()).toMatchObject({ room: "trading", index: 1, enable: true });
+  await page.getByRole("button", { name: "切换到自动", exact: true }).click();
+  expect(await exportedDrones()).toEqual(automatic);
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.getByRole("button", { name: "切换到手动", exact: true }).click();
+  await expect(picker).toBeVisible();
+  await picker.getByRole("button", { name: "不使用无人机", exact: true }).click();
+  expect(await exportedDrones()).toBeUndefined();
+  expect(solves).toBe(0);
+});
 
 test("mobile interactive targets remain at least 44 CSS pixels", async ({ page }) => {
   await mockApis(page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "drizzle-orm": "^0.45.2",
         "lucide-react": "^0.475.0",
         "motion": "^13.0.0",
-        "next": "16.3.0",
+        "next": "16.3.4",
         "next-intl": "^4.14.2",
         "overlayscrollbars": "^2.16.0",
         "pg": "^8.23.0",
@@ -53,7 +53,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^15.15.0",
         "react-test-renderer": "^19.2.8",
-        "sharp": "0.35.3",
+        "sharp": "0.35.4",
         "tailwindcss": "4.3.3",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.65.0"
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
@@ -1697,13 +1697,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
@@ -1720,13 +1720,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -1734,7 +1734,7 @@
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1744,9 +1744,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
@@ -1778,9 +1778,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
@@ -1795,9 +1795,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
@@ -1812,9 +1812,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
@@ -1829,9 +1829,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1846,9 +1846,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
@@ -1863,9 +1863,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
@@ -1880,9 +1880,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
@@ -1914,9 +1914,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
@@ -1933,13 +1933,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
@@ -1956,13 +1956,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1979,13 +1979,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
@@ -2002,13 +2002,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
@@ -2025,13 +2025,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
@@ -2048,13 +2048,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
@@ -2071,13 +2071,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
@@ -2094,18 +2094,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2115,9 +2115,9 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
@@ -2125,7 +2125,7 @@
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -2135,9 +2135,9 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
@@ -2155,9 +2155,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
@@ -2175,9 +2175,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
@@ -2302,15 +2302,15 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
-      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
+      "integrity": "sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
-      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.4.tgz",
+      "integrity": "sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==",
       "cpu": [
         "arm64"
       ],
@@ -2324,9 +2324,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
-      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.4.tgz",
+      "integrity": "sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==",
       "cpu": [
         "x64"
       ],
@@ -2340,9 +2340,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
-      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.4.tgz",
+      "integrity": "sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==",
       "cpu": [
         "arm64"
       ],
@@ -2356,9 +2356,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
-      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.4.tgz",
+      "integrity": "sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==",
       "cpu": [
         "arm64"
       ],
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
-      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.4.tgz",
+      "integrity": "sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==",
       "cpu": [
         "x64"
       ],
@@ -2388,9 +2388,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
-      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.4.tgz",
+      "integrity": "sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==",
       "cpu": [
         "x64"
       ],
@@ -2404,9 +2404,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
-      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.4.tgz",
+      "integrity": "sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==",
       "cpu": [
         "arm64"
       ],
@@ -2420,9 +2420,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
-      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.4.tgz",
+      "integrity": "sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==",
       "cpu": [
         "x64"
       ],
@@ -6084,9 +6084,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
-      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6452,9 +6452,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -7177,13 +7177,13 @@
       }
     },
     "node_modules/next": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
-      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.4.tgz",
+      "integrity": "sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.3.0",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.4",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.5.23",
@@ -7196,15 +7196,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.0",
-        "@next/swc-darwin-x64": "16.3.0",
-        "@next/swc-linux-arm64-gnu": "16.3.0",
-        "@next/swc-linux-arm64-musl": "16.3.0",
-        "@next/swc-linux-x64-gnu": "16.3.0",
-        "@next/swc-linux-x64-musl": "16.3.0",
-        "@next/swc-win32-arm64-msvc": "16.3.0",
-        "@next/swc-win32-x64-msvc": "16.3.0",
-        "sharp": "^0.35.3"
+        "@next/swc-darwin-arm64": "16.3.4",
+        "@next/swc-darwin-x64": "16.3.4",
+        "@next/swc-linux-arm64-gnu": "16.3.4",
+        "@next/swc-linux-arm64-musl": "16.3.4",
+        "@next/swc-linux-x64-gnu": "16.3.4",
+        "@next/swc-linux-x64-musl": "16.3.4",
+        "@next/swc-win32-arm64-msvc": "16.3.4",
+        "@next/swc-win32-x64-msvc": "16.3.4",
+        "sharp": "^0.35.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7301,15 +7301,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -8600,9 +8591,9 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8617,31 +8608,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^0.475.0",
     "motion": "^13.0.0",
-    "next": "16.3.0",
+    "next": "16.3.4",
     "next-intl": "^4.14.2",
     "overlayscrollbars": "^2.16.0",
     "pg": "^8.23.0",
@@ -88,7 +88,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^15.15.0",
     "react-test-renderer": "^19.2.8",
-    "sharp": "0.35.3",
+    "sharp": "0.35.4",
     "tailwindcss": "4.3.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.65.0"
@@ -96,6 +96,6 @@
   "overrides": {
     "postcss": "8.5.24",
     "esbuild": "0.25.12",
-    "sharp": "0.35.3"
+    "sharp": "0.35.4"
   }
 }

--- a/scripts/build-tooling.test.mjs
+++ b/scripts/build-tooling.test.mjs
@@ -318,7 +318,7 @@ test("CI gates releases on Chromium and a WebKit Skland smoke test, then schedul
   assert.doesNotMatch(workflow, /^\s*pull_request\s*:/m);
   assert.match(workflow, /cancel-in-progress: false/);
   assert.equal(readinessSpecs.length, 4);
-  assert.equal(readinessTestCount, 101);
+  assert.equal(readinessTestCount, 103);
   assert.equal(e2eFiles.includes("production-readiness.spec.ts"), false);
   assert.match(playwrightConfig, /fullyParallel: true/);
   assert.match(playwrightConfig, /workers: process\.env\.CI \? 2 : undefined/);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,8 +138,8 @@ const WebsiteAccountDialog = lazy(() => loadWebsiteAccountDialog().then((module)
   default: module.WebsiteAccountDialog,
 })));
 const SetupDialog = lazy(() => loadSetupDialog().then((module) => ({ default: module.SetupDialog })));
-const IssueNoteModal = lazy(() => loadComponents().then((module) => ({ default: module.IssueNoteModal })));
-const ProductChangeConfirmModal = lazy(() => loadComponents().then((module) => ({
+const IssueNoteModal = lazy(() => import("@/components/ScheduleFeedbackDialogs").then((module) => ({ default: module.IssueNoteModal })));
+const ProductChangeConfirmModal = lazy(() => import("@/components/ScheduleFeedbackDialogs").then((module) => ({
   default: module.ProductChangeConfirmModal,
 })));
 const ManualDraftReplaceDialog = lazy(() => import("@/components/ManualDraftReplaceDialog").then((module) => ({

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -2,7 +2,6 @@ import { localize as rotationText } from "./i18n/helpers/RotationLabels.ts";
 import { localize as localize_components } from "./i18n/helpers/components.ts";
 import { useTranslations, useLocale } from "next-intl";
 import {
-  AlertTriangle,
   Check,
   ChevronDown,
   ChevronLeft,
@@ -10,8 +9,6 @@ import {
   FileWarning,
   Loader2,
   Play,
-  RotateCcw,
-  Save,
   Smile,
 } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
@@ -22,10 +19,8 @@ import { Accordion, AccordionItem, AccordionPanel, AccordionTrigger } from "@/co
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogBody,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -40,7 +35,6 @@ import { Input } from "@/components/ui/input";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
@@ -109,7 +103,6 @@ import {
 } from "./schedule-list-layout";
 import {
   BaseBlueprint,
-  FeedbackKind,
   MaaJson,
   MaaPlan,
   PresetDef,
@@ -975,11 +968,10 @@ export function PlanTelemetry({
 const ROOM_SLOT_COUNT = 5;
 const AUXILIARY_ROOM_GROUPS = new Set(["dormitory", "hire", "meeting", "processing", "training"]);
 
-function scheduleIssueTriggerId(row: RoomRow) {
+export function scheduleIssueTriggerId(row: RoomRow) {
   return `schedule-issue-${row.key}`;
 }
 
-const PLAN_RESULT_PRIMARY_TRIGGER_SELECTOR = "[data-plan-primary-details-trigger]";
 
 function roomSlotCountFor(group: string) {
   if (group === "trading" || group === "manufacture") return 3;
@@ -1587,7 +1579,8 @@ export function ScheduleBoard({
   const preferredViewMode = useRef<ScheduleViewMode | null>(null);
   const scheduleBoardRef = useRef<HTMLDivElement | null>(null);
   const shouldReduceMotion = useReducedMotion();
-  const editableSchedule = Boolean(onSlotClick || onClearRoom || onDormAutofillChange || onDroneTargetChange);
+  // Drone allocation alone must not hide the calculator's schedule view switcher.
+  const editableSchedule = Boolean(onSlotClick || onClearRoom || onDormAutofillChange);
 
   useLayoutEffect(() => {
     const board = scheduleBoardRef.current;
@@ -2071,164 +2064,6 @@ export function ShortcutGuideDialog({
             <KbdGroup className="shrink-0" aria-label={intl("components.controlPlusB")}><Kbd>Ctrl</Kbd><span aria-hidden="true">+</span><Kbd>B</Kbd></KbdGroup>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-export function IssueNoteModal({
-  open,
-  kind,
-  row,
-  note,
-  saving,
-  onNoteChange,
-  onSave,
-  onCancel,
-}: {
-  open: boolean;
-  kind: FeedbackKind;
-  row: RoomRow | null;
-  note: string;
-  saving: boolean;
-  onNoteChange: (value: string) => void;
-  onSave: () => void;
-  onCancel: () => void;
-}) {
-  const intl = useTranslations();
-
-  const [consented, setConsented] = useState(false);
-  const returnFocusId = useRef<string | null>(null);
-  const returnToPlanSummary = useRef(false);
-  const isPerformance = kind === "performance_issue";
-
-  useEffect(() => {
-    if (open) setConsented(false);
-  }, [kind, open, row?.key]);
-
-  useEffect(() => {
-    if (row) {
-      returnFocusId.current = scheduleIssueTriggerId(row);
-      returnToPlanSummary.current = false;
-    } else if (open && isPerformance) {
-      returnFocusId.current = null;
-      returnToPlanSummary.current = true;
-    }
-  }, [isPerformance, open, row]);
-
-  return (
-    <Dialog
-      open={open && (isPerformance || Boolean(row))}
-      triggerId={row ? scheduleIssueTriggerId(row) : null}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) onCancel();
-      }}
-    >
-      <DialogContent
-        className="max-w-[min(620px,calc(100vw-2rem))] sm:max-w-xl"
-        finalFocus={() => {
-          if (returnFocusId.current) return document.getElementById(returnFocusId.current);
-          if (returnToPlanSummary.current) return document.querySelector<HTMLElement>(PLAN_RESULT_PRIMARY_TRIGGER_SELECTOR) ?? true;
-          return true;
-        }}
-      >
-        <DialogHeader>
-          <DialogTitle>{isPerformance ? (intl("components.submitPerformanceFeedback")) : row?.title ?? (intl("components.reportScheduleIssue2"))}</DialogTitle>
-          <DialogDescription>{isPerformance ? (intl("components.shareFeedbackAboutThisSolve")) : (intl("components.reportAScheduleIssue"))}</DialogDescription>
-        </DialogHeader>
-        <DialogBody>
-          <p className="text-[13px] leading-5 text-muted-foreground">
-            {isPerformance
-              ? (intl("components.thisSubmitsYourNotePlusAPrivateReproductionSnapshot"))
-              : (intl("components.thisSubmitsTheRoomIssueAndAPrivateReproduction"))}
-          </p>
-          <Textarea
-            autoFocus
-            value={note}
-            onChange={(event) => onNoteChange(event.target.value)}
-            placeholder={isPerformance ? (intl("components.exampleThisSameBoxUsuallyCompletedFasterBefore")) : (intl("components.exampleThisTeamShouldUseClosureTheCurrentPlacement"))}
-            className="min-h-36 text-[13px]"
-            maxLength={1000}
-          />
-          <label className="flex min-h-11 cursor-pointer items-center gap-3 text-[13px]">
-            <input
-              type="checkbox"
-              checked={consented}
-              onChange={(event) => setConsented(event.target.checked)}
-              className="size-4"
-            />
-            <span>{intl("Common.consentFeedback", { kind: isPerformance ? "performance" : "issue" })}</span>
-          </label>
-        </DialogBody>
-        <DialogFooter>
-          <Button className="max-sm:min-w-16 sm:min-w-[88px]" size="dialog" variant="ghost" onClick={onCancel}>
-            {intl("components.cancel")}
-          </Button>
-          <Button size="dialog" onClick={onSave} disabled={!note.trim() || note.trim().length > 1000 || !consented || saving}>
-            {saving ? <Loader2 className="animate-spin" /> : <Save />}
-            {saving ? (intl("components.submitting")) : (intl("components.submitFeedback"))}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-export function ProductChangeConfirmModal({
-  open,
-  roomLabel,
-  changeKind,
-  nextValueLabel,
-  busy,
-  onConfirm,
-  onCancel,
-}: {
-  open: boolean;
-  roomLabel: string;
-  changeKind: "制造配方" | "贸易策略";
-  nextValueLabel: string;
-  busy: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
-}) {
-  const intl = useTranslations();
-  const locale = useLocale();
-  const en = locale === "en";
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen && !busy) onCancel();
-      }}
-    >
-      <DialogContent
-        role="alertdialog"
-        aria-busy={busy}
-        showCloseButton={!busy}
-        className="max-w-[min(520px,calc(100vw-2rem))] sm:max-w-lg"
-        data-product-change-confirm
-      >
-        <DialogHeader>
-          <DialogTitle>{intl("components.changeSettingsAndRegenerate")}</DialogTitle>
-          <DialogDescription>
-            {intl("components.sWillChangeToTheCurrentResultWillBe", { roomLabel: roomLabel, value2: (en) ? (changeKind === "制造配方" ? "factory recipe" : "trade strategy") : "", nextValueLabel: nextValueLabel, changeKind: (en) ? "" : (changeKind) })}
-          </DialogDescription>
-        </DialogHeader>
-        <DialogBody className="py-2">
-          <p className="flex items-start gap-2 text-[13px] leading-5 text-muted-foreground">
-            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
-            {intl("components.settingsRemainLockedUntilRegenerationCompletes")}
-          </p>
-        </DialogBody>
-        <DialogFooter>
-          <Button className="max-sm:min-w-16 sm:min-w-[88px]" type="button" size="dialog" variant="ghost" disabled={busy} autoFocus onClick={onCancel}>
-            {intl("components.cancel")}
-          </Button>
-          <Button type="button" size="dialog" variant="destructive" disabled={busy} onClick={onConfirm}>
-            {busy ? <Loader2 className="animate-spin" /> : <RotateCcw />}
-            {busy ? (intl("components.regenerating")) : (intl("components.confirmAndRegenerate"))}
-          </Button>
-        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/DroneTargetPicker.tsx
+++ b/src/components/DroneTargetPicker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import type { RoomRow } from "@/schedule";
+
+export function DroneTargetPicker({ rows, targetRoomId, manualSelection, onTargetChange, onAutoAllocation, onOpenChange }: {
+  rows: RoomRow[];
+  targetRoomId?: string | null;
+  manualSelection: boolean;
+  onTargetChange?: (row: RoomRow) => void;
+  onAutoAllocation: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return <Dialog open onOpenChange={onOpenChange}>
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>选择无人机去向</DialogTitle>
+        <DialogDescription>选择当前班次的目标房间，点击当前目标可取消。</DialogDescription>
+      </DialogHeader>
+      <div className="grid gap-2 p-4">
+        {rows.filter(row => row.group === "trading" || row.group === "manufacture").map(row => <Button key={row.roomId} type="button" variant={targetRoomId === row.roomId ? "default" : "outline"} className="justify-start" onClick={() => { onTargetChange?.(row); onOpenChange(false); }}>{row.title}</Button>)}
+        <Button type="button" variant="ghost" className="justify-start" onClick={() => { const current = rows.find(row => row.roomId === targetRoomId); if (current) onTargetChange?.(current); onOpenChange(false); }}>不使用无人机</Button>
+      </div>
+      <DialogFooter>
+        {manualSelection && <Button type="button" variant="outline" onClick={() => { onAutoAllocation(); onOpenChange(false); }}>恢复自动分配</Button>}
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>取消</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>;
+}

--- a/src/components/MaaImportDialog.tsx
+++ b/src/components/MaaImportDialog.tsx
@@ -54,4 +54,3 @@ export function MaaImportDialog({ maaImportPreview, confirmMaaImport, onCancel }
       </Dialog>
   );
 }
-

--- a/src/components/MaaImportDialog.tsx
+++ b/src/components/MaaImportDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export function MaaImportDialog({ maaImportPreview, confirmMaaImport, onCancel }: {
+  maaImportPreview: { fileName: string; sourceShiftCount: number; importedShiftCount: number; sourceAssignmentCount: number; importedAssignmentCount: number };
+  confirmMaaImport: () => void;
+  onCancel: () => void;
+}) {
+  const intl = useTranslations();
+  return (
+      <Dialog open onOpenChange={open => { if (!open) onCancel(); }}>
+        <DialogContent className="max-w-[min(520px,calc(100vw-2rem))]">
+          <DialogHeader>
+            <DialogTitle>{intl("components_pages_ManualSchedulePage.importMaaScheduleQuestion")}</DialogTitle>
+            <DialogDescription>
+              {intl("components_pages_ManualSchedulePage.importMaaScheduleDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2 px-5 py-2 text-sm sm:px-7">
+            <p className="truncate"><span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.fileLabel")}</span>{maaImportPreview?.fileName}</p>
+            <p>
+              <span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.shiftsLabel")}</span>
+              <span className="font-number">{maaImportPreview?.importedShiftCount}</span>
+              {maaImportPreview && maaImportPreview.sourceShiftCount !== maaImportPreview.importedShiftCount ? (
+                <span className="ml-2 text-muted-foreground">
+                  {intl("components_pages_ManualSchedulePage.expandedFromPlans", { count: maaImportPreview.sourceShiftCount })}
+                </span>
+              ) : null}
+            </p>
+            <p>
+              <span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.assignmentsLabel")}</span>
+              <span className="font-number">{maaImportPreview?.importedAssignmentCount}</span>
+              <span className="text-muted-foreground"> / </span>
+              <span className="font-number">{maaImportPreview?.sourceAssignmentCount}</span>
+              {maaImportPreview && maaImportPreview.sourceAssignmentCount > maaImportPreview.importedAssignmentCount ? (
+                <span className="ml-2 text-amber-700">
+                  {intl("components_pages_ManualSchedulePage.unmappedAssignments", { count: maaImportPreview.sourceAssignmentCount - maaImportPreview.importedAssignmentCount })}
+                </span>
+              ) : null}
+            </p>
+            <p className="text-xs leading-5 text-muted-foreground">
+              {intl("components_pages_ManualSchedulePage.importMaaScheduleDetails")}
+            </p>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={onCancel}>{intl("components_pages_ManualSchedulePage.cancel")}</Button>
+            <Button type="button" onClick={confirmMaaImport}><Upload />{intl("components_pages_ManualSchedulePage.replaceDraft")}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+  );
+}
+

--- a/src/components/PlanActionsDialog.tsx
+++ b/src/components/PlanActionsDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ArrowRight, FlaskConical, PencilLine } from "lucide-react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+export function PlanActionsDialog({ hasBox, visibleVariantLabel, onOpenChange, onProgression, onManual }: {
+  hasBox: boolean;
+  visibleVariantLabel: string;
+  onOpenChange: (open: boolean) => void;
+  onProgression: () => void;
+  onManual: () => void;
+}) {
+  const intl = useTranslations();
+  return (
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent className="gap-5 max-sm:bottom-0 max-sm:top-auto max-sm:max-w-none max-sm:translate-y-0 max-sm:rounded-t-[24px] max-sm:rounded-b-none sm:max-w-lg sm:p-6" data-plan-actions-dialog>
+          <DialogHeader className="gap-1.5 px-1 sm:px-2">
+            <DialogTitle className="text-lg font-semibold">{intl("components_pages_InfraCalculator.adjustThisPlan")}</DialogTitle>
+            <DialogDescription className="text-sm leading-6">
+              {intl("components_pages_InfraCalculator.youAreViewingTheChooseWhetherToChangeThe", { visibleVariantLabel: visibleVariantLabel })}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2 px-1 sm:px-2">
+            {hasBox ? (
+              <button
+                type="button"
+                className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
+                onClick={onProgression}
+                data-plan-action="progression"
+              >
+                <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-[#313131] text-[#FFD800]" aria-hidden="true"><FlaskConical className="size-5" /></span>
+                <span className="min-w-0 flex-1">
+                  <strong className="block text-sm font-semibold">{intl("components_pages_InfraCalculator.modifyProgressionAndRecalculate")}</strong>
+                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">{intl("components_pages_InfraCalculator.updateTheCurrentBoxKeepTheOriginalPlanAnd")}</span>
+                </span>
+                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
+              onClick={onManual}
+              data-plan-action="manual"
+            >
+              <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-muted text-foreground" aria-hidden="true"><PencilLine className="size-5" /></span>
+              <span className="min-w-0 flex-1">
+                <strong className="block text-sm font-semibold">{intl("components_pages_InfraCalculator.editTheCurrentPlanManually")}</strong>
+                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{intl("components_pages_InfraCalculator.copyThePlanYouAreViewingAndContinueIn")}</span>
+              </span>
+              <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
+  );
+}

--- a/src/components/ScheduleFeedbackDialogs.tsx
+++ b/src/components/ScheduleFeedbackDialogs.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useTranslations, useLocale } from "next-intl";
+import { useEffect, useRef, useState } from "react";
+import { AlertTriangle, Loader2, RotateCcw, Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogBody, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { scheduleIssueTriggerId } from "@/components";
+import type { RoomRow } from "@/schedule";
+import type { FeedbackKind } from "@/types";
+
+const PLAN_RESULT_PRIMARY_TRIGGER_SELECTOR = "[data-plan-primary-details-trigger]";
+
+export function IssueNoteModal({
+  open,
+  kind,
+  row,
+  note,
+  saving,
+  onNoteChange,
+  onSave,
+  onCancel,
+}: {
+  open: boolean;
+  kind: FeedbackKind;
+  row: RoomRow | null;
+  note: string;
+  saving: boolean;
+  onNoteChange: (value: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  const intl = useTranslations();
+
+  const [consented, setConsented] = useState(false);
+  const returnFocusId = useRef<string | null>(null);
+  const returnToPlanSummary = useRef(false);
+  const isPerformance = kind === "performance_issue";
+
+  useEffect(() => {
+    if (open) setConsented(false);
+  }, [kind, open, row?.key]);
+
+  useEffect(() => {
+    if (row) {
+      returnFocusId.current = scheduleIssueTriggerId(row);
+      returnToPlanSummary.current = false;
+    } else if (open && isPerformance) {
+      returnFocusId.current = null;
+      returnToPlanSummary.current = true;
+    }
+  }, [isPerformance, open, row]);
+
+  return (
+    <Dialog
+      open={open && (isPerformance || Boolean(row))}
+      triggerId={row ? scheduleIssueTriggerId(row) : null}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onCancel();
+      }}
+    >
+      <DialogContent
+        className="max-w-[min(620px,calc(100vw-2rem))] sm:max-w-xl"
+        finalFocus={() => {
+          if (returnFocusId.current) return document.getElementById(returnFocusId.current);
+          if (returnToPlanSummary.current) return document.querySelector<HTMLElement>(PLAN_RESULT_PRIMARY_TRIGGER_SELECTOR) ?? true;
+          return true;
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>{isPerformance ? (intl("components.submitPerformanceFeedback")) : row?.title ?? (intl("components.reportScheduleIssue2"))}</DialogTitle>
+          <DialogDescription>{isPerformance ? (intl("components.shareFeedbackAboutThisSolve")) : (intl("components.reportAScheduleIssue"))}</DialogDescription>
+        </DialogHeader>
+        <DialogBody>
+          <p className="text-[13px] leading-5 text-muted-foreground">
+            {isPerformance
+              ? (intl("components.thisSubmitsYourNotePlusAPrivateReproductionSnapshot"))
+              : (intl("components.thisSubmitsTheRoomIssueAndAPrivateReproduction"))}
+          </p>
+          <Textarea
+            autoFocus
+            value={note}
+            onChange={(event) => onNoteChange(event.target.value)}
+            placeholder={isPerformance ? (intl("components.exampleThisSameBoxUsuallyCompletedFasterBefore")) : (intl("components.exampleThisTeamShouldUseClosureTheCurrentPlacement"))}
+            className="min-h-36 text-[13px]"
+            maxLength={1000}
+          />
+          <label className="flex min-h-11 cursor-pointer items-center gap-3 text-[13px]">
+            <input
+              type="checkbox"
+              checked={consented}
+              onChange={(event) => setConsented(event.target.checked)}
+              className="size-4"
+            />
+            <span>{intl("Common.consentFeedback", { kind: isPerformance ? "performance" : "issue" })}</span>
+          </label>
+        </DialogBody>
+        <DialogFooter>
+          <Button className="max-sm:min-w-16 sm:min-w-[88px]" size="dialog" variant="ghost" onClick={onCancel}>
+            {intl("components.cancel")}
+          </Button>
+          <Button size="dialog" onClick={onSave} disabled={!note.trim() || note.trim().length > 1000 || !consented || saving}>
+            {saving ? <Loader2 className="animate-spin" /> : <Save />}
+            {saving ? (intl("components.submitting")) : (intl("components.submitFeedback"))}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export function ProductChangeConfirmModal({
+  open,
+  roomLabel,
+  changeKind,
+  nextValueLabel,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  roomLabel: string;
+  changeKind: "制造配方" | "贸易策略";
+  nextValueLabel: string;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const intl = useTranslations();
+  const locale = useLocale();
+  const en = locale === "en";
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !busy) onCancel();
+      }}
+    >
+      <DialogContent
+        role="alertdialog"
+        aria-busy={busy}
+        showCloseButton={!busy}
+        className="max-w-[min(520px,calc(100vw-2rem))] sm:max-w-lg"
+        data-product-change-confirm
+      >
+        <DialogHeader>
+          <DialogTitle>{intl("components.changeSettingsAndRegenerate")}</DialogTitle>
+          <DialogDescription>
+            {intl("components.sWillChangeToTheCurrentResultWillBe", { roomLabel: roomLabel, value2: (en) ? (changeKind === "制造配方" ? "factory recipe" : "trade strategy") : "", nextValueLabel: nextValueLabel, changeKind: (en) ? "" : (changeKind) })}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogBody className="py-2">
+          <p className="flex items-start gap-2 text-[13px] leading-5 text-muted-foreground">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0 text-destructive" aria-hidden="true" />
+            {intl("components.settingsRemainLockedUntilRegenerationCompletes")}
+          </p>
+        </DialogBody>
+        <DialogFooter>
+          <Button className="max-sm:min-w-16 sm:min-w-[88px]" type="button" size="dialog" variant="ghost" disabled={busy} autoFocus onClick={onCancel}>
+            {intl("components.cancel")}
+          </Button>
+          <Button type="button" size="dialog" variant="destructive" disabled={busy} onClick={onConfirm}>
+            {busy ? <Loader2 className="animate-spin" /> : <RotateCcw />}
+            {busy ? (intl("components.regenerating")) : (intl("components.confirmAndRegenerate"))}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/ScheduleFeedbackDialogs.tsx
+++ b/src/components/ScheduleFeedbackDialogs.tsx
@@ -109,7 +109,6 @@ export function IssueNoteModal({
     </Dialog>
   );
 }
-
 export function ProductChangeConfirmModal({
   open,
   roomLabel,
@@ -169,4 +168,3 @@ export function ProductChangeConfirmModal({
     </Dialog>
   );
 }
-

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -40,6 +40,8 @@ import type {
 const PlanResultSummary = lazy(() => loadClientFeature("planResultSummary").then((module) => ({ default: module.PlanResultSummary })));
 const ShortcutGuideDialog = lazy(() => loadClientFeature("sharedComponents").then((module) => ({ default: module.ShortcutGuideDialog })));
 const UpgradeSimulationDialog = lazy(() => import("@/components/UpgradeSimulationDialog").then((module) => ({ default: module.UpgradeSimulationDialog })));
+const DroneTargetPicker = lazy(() => import("@/components/DroneTargetPicker").then(module => ({ default: module.DroneTargetPicker })));
+const PlanActionsDialog = lazy(() => import("@/components/PlanActionsDialog").then(module => ({ default: module.PlanActionsDialog })));
 
 function DeferredResultLoading() {
   return <PlanResultSummarySkeleton />;
@@ -721,28 +723,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
         </section>
       </section>
 
-      <Dialog open={dronePickerOpen} onOpenChange={setDronePickerOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>选择无人机去向</DialogTitle>
-            <DialogDescription>选择当前班次的目标房间，点击当前目标可取消。</DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-2 p-4">
-            {rows.filter((row) => row.group === "trading" || row.group === "manufacture").map((row) => (
-              <Button key={row.roomId} type="button" variant={droneTargetRoomId === row.roomId ? "default" : "outline"} className="justify-start" onClick={() => { onDroneTargetChange?.(row); setDronePickerOpen(false); }}>
-                {row.title}
-              </Button>
-            ))}
-            <Button type="button" variant="ghost" className="justify-start" onClick={() => { const current = rows.find((row) => row.roomId === droneTargetRoomId); if (current) onDroneTargetChange?.(current); setDronePickerOpen(false); }}>
-              不使用无人机
-            </Button>
-          </div>
-          <DialogFooter>
-            {manualDroneSelection ? <Button type="button" variant="outline" onClick={() => { onAutoDroneAllocation(); setDronePickerOpen(false); }}>恢复自动分配</Button> : null}
-            <Button type="button" variant="outline" onClick={() => setDronePickerOpen(false)}>取消</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {dronePickerOpen && <Suspense fallback={null}><DroneTargetPicker rows={rows} targetRoomId={droneTargetRoomId} manualSelection={manualDroneSelection} onTargetChange={onDroneTargetChange} onAutoAllocation={onAutoDroneAllocation} onOpenChange={setDronePickerOpen} /></Suspense>}
 
       {resultClearNotice ? (
         <aside className="fixed left-1/2 top-[max(5rem,calc(env(safe-area-inset-top)+5rem))] z-[70] w-[min(720px,calc(100vw-2rem))] -translate-x-1/2 border border-[#FFD800]/70 bg-[#313131] px-4 py-3 text-white shadow-[0_16px_44px_rgba(0,0,0,0.35)]" aria-live="polite">
@@ -772,46 +753,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
           />
         </Suspense>
       ) : null}
-      <Dialog open={planActionsOpen} onOpenChange={setPlanActionsOpen}>
-        <DialogContent className="gap-5 max-sm:bottom-0 max-sm:top-auto max-sm:max-w-none max-sm:translate-y-0 max-sm:rounded-t-[24px] max-sm:rounded-b-none sm:max-w-lg sm:p-6" data-plan-actions-dialog>
-          <DialogHeader className="gap-1.5 px-1 sm:px-2">
-            <DialogTitle className="text-lg font-semibold">{intl("components_pages_InfraCalculator.adjustThisPlan")}</DialogTitle>
-            <DialogDescription className="text-sm leading-6">
-              {intl("components_pages_InfraCalculator.youAreViewingTheChooseWhetherToChangeThe", { visibleVariantLabel: visibleVariantLabel })}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-2 px-1 sm:px-2">
-            {operbox ? (
-              <button
-                type="button"
-                className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
-                onClick={openProgressionAction}
-                data-plan-action="progression"
-              >
-                <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-[#313131] text-[#FFD800]" aria-hidden="true"><FlaskConical className="size-5" /></span>
-                <span className="min-w-0 flex-1">
-                  <strong className="block text-sm font-semibold">{intl("components_pages_InfraCalculator.modifyProgressionAndRecalculate")}</strong>
-                  <span className="mt-1 block text-xs leading-5 text-muted-foreground">{intl("components_pages_InfraCalculator.updateTheCurrentBoxKeepTheOriginalPlanAnd")}</span>
-                </span>
-                <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="group flex min-h-20 w-full items-center gap-3 rounded-[var(--radius-md)] border border-border bg-background px-4 py-3 text-left outline-none transition-colors hover:border-foreground/40 hover:bg-muted/45 focus-visible:ring-2 focus-visible:ring-[#FFD800]"
-              onClick={openManualAction}
-              data-plan-action="manual"
-            >
-              <span className="grid size-10 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-muted text-foreground" aria-hidden="true"><PencilLine className="size-5" /></span>
-              <span className="min-w-0 flex-1">
-                <strong className="block text-sm font-semibold">{intl("components_pages_InfraCalculator.editTheCurrentPlanManually")}</strong>
-                <span className="mt-1 block text-xs leading-5 text-muted-foreground">{intl("components_pages_InfraCalculator.copyThePlanYouAreViewingAndContinueIn")}</span>
-              </span>
-              <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
+      {planActionsOpen && <Suspense fallback={null}><PlanActionsDialog hasBox={!!operbox} visibleVariantLabel={visibleVariantLabel} onOpenChange={setPlanActionsOpen} onProgression={openProgressionAction} onManual={openManualAction} /></Suspense>}
       <Suspense fallback={null}>
         <ShortcutGuideDialog open={shortcutGuideOpen} onOpenChange={setShortcutGuideOpen} />
         <Dialog open={cancelConfirmOpen} onOpenChange={setCancelConfirmOpen}>

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -57,6 +57,7 @@ import { planToRows, type RoomRow } from "@/schedule";
 import type { BaseBlueprint, MaaJson, MaaOperatorSlot, MaaRoom, OperBoxEntry } from "@/types";
 
 const ScrollArea = lazy(() => import("@/components/ui/scroll-area").then((module) => ({ default: module.ScrollArea })));
+const MaaImportDialog = lazy(() => import("@/components/MaaImportDialog").then(module => ({ default: module.MaaImportDialog })));
 const MANUAL_PICKER_PAGE_SIZE = 24;
 const ROOM_GROUP_TO_SKILL_PREFIX: Readonly<Record<RoomRow["group"], BuildingRoomPrefix>> = {
   control: "control",
@@ -769,46 +770,7 @@ export function ManualSchedulePage({
         </DialogContent>
       </Dialog>
 
-      <Dialog open={Boolean(maaImportPreview)} onOpenChange={(open) => { if (!open) setMaaImportPreview(null); }}>
-        <DialogContent className="max-w-[min(520px,calc(100vw-2rem))]">
-          <DialogHeader>
-            <DialogTitle>{intl("components_pages_ManualSchedulePage.importMaaScheduleQuestion")}</DialogTitle>
-            <DialogDescription>
-              {intl("components_pages_ManualSchedulePage.importMaaScheduleDescription")}
-            </DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-2 px-5 py-2 text-sm sm:px-7">
-            <p className="truncate"><span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.fileLabel")}</span>{maaImportPreview?.fileName}</p>
-            <p>
-              <span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.shiftsLabel")}</span>
-              <span className="font-number">{maaImportPreview?.importedShiftCount}</span>
-              {maaImportPreview && maaImportPreview.sourceShiftCount !== maaImportPreview.importedShiftCount ? (
-                <span className="ml-2 text-muted-foreground">
-                  {intl("components_pages_ManualSchedulePage.expandedFromPlans", { count: maaImportPreview.sourceShiftCount })}
-                </span>
-              ) : null}
-            </p>
-            <p>
-              <span className="text-muted-foreground">{intl("components_pages_ManualSchedulePage.assignmentsLabel")}</span>
-              <span className="font-number">{maaImportPreview?.importedAssignmentCount}</span>
-              <span className="text-muted-foreground"> / </span>
-              <span className="font-number">{maaImportPreview?.sourceAssignmentCount}</span>
-              {maaImportPreview && maaImportPreview.sourceAssignmentCount > maaImportPreview.importedAssignmentCount ? (
-                <span className="ml-2 text-amber-700">
-                  {intl("components_pages_ManualSchedulePage.unmappedAssignments", { count: maaImportPreview.sourceAssignmentCount - maaImportPreview.importedAssignmentCount })}
-                </span>
-              ) : null}
-            </p>
-            <p className="text-xs leading-5 text-muted-foreground">
-              {intl("components_pages_ManualSchedulePage.importMaaScheduleDetails")}
-            </p>
-          </div>
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => setMaaImportPreview(null)}>{intl("components_pages_ManualSchedulePage.cancel")}</Button>
-            <Button type="button" onClick={confirmMaaImport}><Upload />{intl("components_pages_ManualSchedulePage.replaceDraft")}</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      {maaImportPreview && <Suspense fallback={null}><MaaImportDialog maaImportPreview={maaImportPreview} confirmMaaImport={confirmMaaImport} onCancel={() => setMaaImportPreview(null)} /></Suspense>}
 
       <Dialog open={Boolean(pendingMove)} onOpenChange={(open) => { if (!open) setPendingMove(null); }}>
         <DialogContent className="max-w-[min(480px,calc(100vw-2rem))]">


### PR DESCRIPTION
合并 #257、#261 后的发布检查发现安全依赖告警、脚本体积超限，以及无人机编辑使计算器误用手动排班宽度规则、隐藏布局切换的问题。

- 升级 Next 16.3.4、sharp 0.35.4，更新 hono / js-yaml 锁文件到修复版本，审计零漏洞。
- 无人机设置不再触发手动排班的布局限制，保留计算器布局切换。
- 按需加载无人机选择、方案操作、MAA 导入确认、反馈和改配方确认弹窗，保持原功能，满足现有体积门槛。
- 同步培养文案和测试数量断言；补充无人机手动、自动、停用时的导出验证，确保不发起求解。

验证：npm run check 通过；生产构建及全部体积门槛通过（首页 1,287,308 / 1,293,000 字节）。相关 Chromium / WebKit 14 项中 13 项首次通过，双班次 Chromium 用例首次培养页加载超时，单独复测通过；WebKit 对应用例首次通过。完整 CI 在 develop 合并后执行。
