### PR TITLE
fix: lock manual slots above room capacity

### DIFF
--- a/messages/helpers/en/components.json
+++ b/messages/helpers/en/components.json
@@ -59,6 +59,7 @@
   "infrastructureSkillS": "Infrastructure skill S{index}: {name}, {unlockLabel}",
   "autoFill": "Auto-fill",
   "empty": "Empty",
+  "slotLocked": "Locked",
   "label2": ": ",
   "focusToViewInfrastructureSkills": ". Focus to view infrastructure skills",
   "edit": "EDIT",

--- a/messages/helpers/zh/components.json
+++ b/messages/helpers/zh/components.json
@@ -59,6 +59,7 @@
   "infrastructureSkillS": "基建技能 S{index}：{nameValue}，{unlockLabel}",
   "autoFill": "自动补位",
   "empty": "空置",
+  "slotLocked": "未解锁",
   "label2": "：",
   "focusToViewInfrastructureSkills": "，聚焦可查看基建技能",
   "edit": "可编辑",

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1196,7 +1196,7 @@ function OperatorSlotShell({
         </span>
       ) : editableHint ? (
         <span className="pointer-events-none absolute bottom-0.5 right-0.5 z-20 bg-black/72 px-1 py-0.5 text-[9px] font-medium leading-none tracking-wide text-[#FFD800]">
-          {unavailable ? "未解锁" : editableHint}
+          {editableHint}
         </span>
       ) : null}
     </div>
@@ -1371,7 +1371,8 @@ export function OperatorSlot({
   const professionLabelEnglish = slot ? operatorProfessionLabelEnglishForCode(slot.profession) : undefined;
   const enterX = shouldReduceMotion ? 0 : shiftDirection * 6;
   const exitX = shouldReduceMotion ? 0 : shiftDirection * -4;
-  const occupantLabel = unavailable ? "未解锁" : displayName ?? (autofill ? (intl("components.autoFill")) : (intl("components.empty")));
+  const unavailableLabel = intl("components.slotLocked");
+  const occupantLabel = unavailable ? unavailableLabel : displayName ?? (autofill ? (intl("components.autoFill")) : (intl("components.empty")));
   const occupantAriaLabel = displayPositionLabel
     ? `${displayPositionLabel}${intl("components.label2")}${occupantLabel}`
     : occupantLabel;
@@ -1393,7 +1394,7 @@ export function OperatorSlot({
       compactView={compactView}
       editableAppearance={!selectionMode}
       unavailable={unavailable}
-      editableHint={unavailable ? "未解锁" : onActivate && !selectionMode ? (intl("components.edit")) : undefined}
+      editableHint={unavailable ? unavailableLabel : onActivate && !selectionMode ? (intl("components.edit")) : undefined}
       frameClassName={frameClassName}
       frameContent={
         <AnimatePresence initial={false} mode="sync">

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   FileWarning,
   Loader2,
+  LockKeyhole,
   Play,
   Smile,
 } from "lucide-react";
@@ -1154,6 +1155,7 @@ function OperatorSlotShell({
   positionLabel,
   title,
   onActivate,
+  unavailable = false,
 }: {
   ariaLabel?: string;
   centerFrameInList: boolean;
@@ -1171,24 +1173,30 @@ function OperatorSlotShell({
   positionLabel?: string;
   title?: string;
   onActivate?: () => void;
+  unavailable?: boolean;
 }) {
   const frame = (
     <div
       className={cn(
         "relative aspect-square h-[var(--operator-slot-size)] min-w-0 shrink-0 overflow-hidden border-2 max-sm:border",
         frameClassName,
-        frameFocusable && "cursor-help outline-none transition-[border-color,box-shadow] hover:border-white/90 focus-visible:border-[#FFD501] focus-visible:ring-2 focus-visible:ring-[#FFD501]/70",
-        onActivate && editableAppearance && "border-[#FFD800] shadow-[0_0_0_1px_rgba(255,216,0,0.42),0_0_12px_rgba(255,216,0,0.2)]",
+        !unavailable && frameFocusable && "cursor-help outline-none transition-[border-color,box-shadow] hover:border-white/90 focus-visible:border-[#FFD501] focus-visible:ring-2 focus-visible:ring-[#FFD501]/70",
+        unavailable ? "border-[#666] bg-[#292929] opacity-70" : onActivate && editableAppearance && "border-[#FFD800] shadow-[0_0_0_1px_rgba(255,216,0,0.42),0_0_12px_rgba(255,216,0,0.2)]",
         centerFrameInList && "max-sm:h-auto max-sm:w-full sm:absolute sm:left-0 sm:top-1/2 sm:-translate-y-1/2",
       )}
       aria-label={ariaLabel}
-      role={frameFocusable ? "button" : undefined}
-      tabIndex={frameFocusable ? 0 : undefined}
+      role={!unavailable && frameFocusable ? "button" : undefined}
+      tabIndex={!unavailable && frameFocusable ? 0 : undefined}
     >
       {frameContent}
-      {editableHint ? (
+      {unavailable ? (
+        <span className="absolute inset-0 z-30 flex flex-col items-center justify-center gap-1 bg-black/55 text-xs text-white/80" data-operator-slot-lock-overlay>
+          <LockKeyhole className="size-4" aria-hidden="true" />
+          <span>{editableHint}</span>
+        </span>
+      ) : editableHint ? (
         <span className="pointer-events-none absolute bottom-0.5 right-0.5 z-20 bg-black/72 px-1 py-0.5 text-[9px] font-medium leading-none tracking-wide text-[#FFD800]">
-          {editableHint}
+          {unavailable ? "未解锁" : editableHint}
         </span>
       ) : null}
     </div>
@@ -1203,15 +1211,15 @@ function OperatorSlotShell({
           : "[--operator-slot-size:clamp(70px,7.3vw,80px)] max-sm:[--operator-slot-size:clamp(56px,16vw,76px)]",
         compactFactory && "min-[1800px]:[--operator-slot-size:70px]",
         centerFrameInList && "max-sm:w-full sm:relative sm:h-full sm:w-[var(--operator-slot-size)]",
-        onActivate && "cursor-pointer rounded-[4px] outline-none focus-visible:ring-2 focus-visible:ring-[#FFD800]",
-        onActivate && editableAppearance && "focus-visible:ring-offset-2 focus-visible:ring-offset-[#313131]",
+        !unavailable && onActivate && "cursor-pointer rounded-[4px] outline-none focus-visible:ring-2 focus-visible:ring-[#FFD800]",
+        !unavailable && onActivate && editableAppearance && "focus-visible:ring-offset-2 focus-visible:ring-offset-[#313131]",
       )}
       data-position={positionLabel || undefined}
       title={title}
-      role={onActivate ? "button" : undefined}
-      tabIndex={onActivate ? 0 : undefined}
-      onClick={onActivate}
-      onKeyDown={onActivate ? (event) => {
+      role={!unavailable && onActivate ? "button" : undefined}
+      tabIndex={!unavailable && onActivate ? 0 : undefined}
+      onClick={unavailable ? undefined : onActivate}
+      onKeyDown={!unavailable && onActivate ? (event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
           onActivate();
@@ -1320,6 +1328,7 @@ export function OperatorSlot({
   skillTooltipContextLabel,
   searchQuery = "",
   onActivate,
+  unavailable = false,
 }: {
   slot: RoomRow["operatorSlots"][number] | undefined;
   currentMorale?: number;
@@ -1348,6 +1357,7 @@ export function OperatorSlot({
   skillTooltipContextLabel?: string;
   searchQuery?: string;
   onActivate?: () => void;
+  unavailable?: boolean;
 }) {
   const intl = useTranslations();
   const shouldReduceMotion = useReducedMotion();
@@ -1361,7 +1371,7 @@ export function OperatorSlot({
   const professionLabelEnglish = slot ? operatorProfessionLabelEnglishForCode(slot.profession) : undefined;
   const enterX = shouldReduceMotion ? 0 : shiftDirection * 6;
   const exitX = shouldReduceMotion ? 0 : shiftDirection * -4;
-  const occupantLabel = displayName ?? (autofill ? (intl("components.autoFill")) : (intl("components.empty")));
+  const occupantLabel = unavailable ? "未解锁" : displayName ?? (autofill ? (intl("components.autoFill")) : (intl("components.empty")));
   const occupantAriaLabel = displayPositionLabel
     ? `${displayPositionLabel}${intl("components.label2")}${occupantLabel}`
     : occupantLabel;
@@ -1382,7 +1392,8 @@ export function OperatorSlot({
       compactFactory={compactFactory}
       compactView={compactView}
       editableAppearance={!selectionMode}
-      editableHint={onActivate && !selectionMode ? (intl("components.edit")) : undefined}
+      unavailable={unavailable}
+      editableHint={unavailable ? "未解锁" : onActivate && !selectionMode ? (intl("components.edit")) : undefined}
       frameClassName={frameClassName}
       frameContent={
         <AnimatePresence initial={false} mode="sync">
@@ -1955,6 +1966,7 @@ export function ScheduleBoard({
                             transitionDelay={Math.min(index, 2) * 0.02}
                             searchQuery={normalizedQuery}
                             positionLabel={positionLabel}
+                            unavailable={row.unavailableSlotIndices?.includes(index)}
                             onActivate={onSlotClick ? () => onSlotClick(row, index) : undefined}
                           />
                         ))}

--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -210,6 +210,7 @@ function CompactRoomCard({
       shiftDirection={shiftDirection}
       transitionDelay={Math.min(index, 2) * 0.02}
       positionLabel={positionLabel}
+      unavailable={row.unavailableSlotIndices?.includes(index)}
       onActivate={onSlotClick ? () => onSlotClick(row, index) : undefined}
     />
   ));

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -40,6 +40,7 @@ import {
   loadManualScheduleDraft,
   manualShiftTimeRanges,
   manualScheduleToMaa,
+  manualRoomCapacity,
   normalizeMaaScheduleForManualImport,
   parseMaaScheduleText,
   persistManualScheduleDraft,
@@ -304,10 +305,20 @@ export function ManualSchedulePage({
   const rows = useMemo(
     () => addOperatorPresentations(planToRows(activePlan, undefined, layout, activeTrainingRoomShift).map((row) => {
       const assignment = draft.shifts[activeShift]?.rooms[row.roomId];
+      const room = layout.rooms.find((candidate) => candidate.id === row.roomId);
+      const capacity = room ? manualRoomCapacity(room) : 0;
+      const visibleSlots = row.group === "control" ? 5 : row.group === "trading" || row.group === "manufacture" ? 3 : capacity;
       return {
         ...row,
         ...(row.positionSlots ? {} : {
-          slotAssignments: assignment?.operators.map((name) => name ? { name, label: name } : undefined),
+          slotAssignments: Array.from(
+            { length: visibleSlots },
+            (_, index) => {
+              const name = index < capacity ? assignment?.operators[index] : undefined;
+              return name ? { name, label: name } : undefined;
+            },
+          ),
+          unavailableSlotIndices: Array.from({ length: Math.max(0, visibleSlots - capacity) }, (_, index) => capacity + index),
         }),
         ...(row.group === "dormitory" ? { autofill: Boolean(assignment?.autofill) } : {}),
       };
@@ -360,6 +371,7 @@ export function ManualSchedulePage({
   }
 
   function openSlotPicker(row: RoomRow, slotIndex: number) {
+    if (row.unavailableSlotIndices?.includes(slotIndex)) return;
     setPickerScrolling(false);
     setPickerQuery("");
     setPickerRoomFilter(ROOM_GROUP_TO_SKILL_PREFIX[row.group]);

--- a/src/manual-schedule.test.ts
+++ b/src/manual-schedule.test.ts
@@ -12,6 +12,7 @@ import {
   manualScheduleDraftContentEqual,
   manualShiftTimeRanges,
   manualScheduleToMaa,
+  manualRoomCapacity,
   normalizeMaaScheduleForManualImport,
   parseMaaScheduleText,
   reconcileManualScheduleDraft,
@@ -49,6 +50,14 @@ test("manual draft defaults to independent 12/6/6 shifts and preserves filled sh
   const resized = resizeManualScheduleDraft(assigned, resizeManualShiftDurations([12, 6, 6], 4));
   assert.equal(resized.shifts[0]?.rooms.trade_1?.operators[0], "但书");
   assert.deepEqual(resized.shifts.map((shift) => shift.durationHours), [12, 6, 3, 3]);
+});
+
+test("manual room capacity follows control, trading and manufacturing room levels", () => {
+  assert.equal(manualRoomCapacity({ kind: "control_center", level: 2, id: "control" } as never), 2);
+  assert.equal(manualRoomCapacity({ kind: "control_center", level: 5, id: "control" } as never), 5);
+  assert.equal(manualRoomCapacity({ kind: "trade_post", level: 1, id: "trade_1" } as never), 1);
+  assert.equal(manualRoomCapacity({ kind: "factory", level: 2, id: "manu_1" } as never), 2);
+  assert.equal(manualRoomCapacity({ kind: "factory", level: 5, id: "manu_1" } as never), 3);
 });
 
 test("manual shift boundaries use minute precision, stay contiguous and cover one day", () => {

--- a/src/manual-schedule.ts
+++ b/src/manual-schedule.ts
@@ -226,8 +226,8 @@ function finitePositive(value: unknown, fallback: number): number {
 }
 
 export function manualRoomCapacity(room: BlueprintRoom): number {
-  if (room.kind === "control_center") return 5;
-  if (room.kind === "trade_post" || room.kind === "factory") return 3;
+  if (room.kind === "control_center") return Math.max(1, Math.min(5, room.level));
+  if (room.kind === "trade_post" || room.kind === "factory") return Math.max(1, Math.min(3, room.level));
   if (room.kind === "meeting_room" || room.kind === "training_room") return 2;
   if (room.kind === "dormitory") return Math.max(1, Math.min(5, room.dorm_beds ?? 5));
   return 1;
@@ -823,7 +823,7 @@ function maaProduct(room: BlueprintRoom): string | undefined {
 }
 
 function maaRoom(room: BlueprintRoom, assignment: ManualRoomAssignment | undefined): MaaRoom {
-  const operators = (assignment?.operators ?? []).filter(
+  const operators = (assignment?.operators ?? []).slice(0, manualRoomCapacity(room)).filter(
     (operator): operator is string => typeof operator === "string" && operator.length > 0,
   );
   const product = maaProduct(room);

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -17,6 +17,7 @@ export interface RoomRow {
   operatorSlots: RoomOperatorSlot[];
   /** Fixed-position slots used by editors; unlike operatorSlots, empty gaps are preserved. */
   slotAssignments?: Array<RoomOperatorSlot | undefined>;
+  unavailableSlotIndices?: number[];
   positionSlots?: RoomPositionSlot[];
   autofill: boolean;
   efficiency?: RoomEfficiency;


### PR DESCRIPTION
## 变更

- 控制中枢、贸易站、制造站的手动排班槽位按设施等级限制人数。
- 超出等级容量的槽位保留显示，并加灰色遮罩标记“未解锁”。
- 未解锁槽位不可点击、不可安排干员。
- MAA 导出同步截断到等级允许的干员数量。

## 验证

- 手动排班单元测试 19 项通过。
- ESLint 通过。
- 覆盖控制中枢、贸易站、制造站的等级容量边界。
- 未提交本地账号、密码或环境文件。