### PR TITLE
fix: 修复低级但书无人机优先级约束

### DIFF
--- a/src/server/drone-production.test.ts
+++ b/src/server/drone-production.test.ts
@@ -8,7 +8,41 @@ import {
   droneTradeOutputForShift,
   equivalentGoldForRotation,
   powerEfficiencyForShift,
+  tradeTargetPriority,
 } from "./drone-production.ts";
+
+test("drone trade targets follow the configured priority chain", () => {
+  const operators = (...names: string[]) => names;
+  assert.ok(tradeTargetPriority(1, operators("但书")) > tradeTargetPriority(2, operators("但书")));
+  assert.ok(tradeTargetPriority(2, operators("但书")) > tradeTargetPriority(3, operators("但书", "龙舌兰")));
+  assert.ok(tradeTargetPriority(3, operators("但书", "龙舌兰")) > tradeTargetPriority(3, operators("龙舌兰", "柏喙")));
+  assert.ok(tradeTargetPriority(3, operators("龙舌兰", "柏喙")) > tradeTargetPriority(3, operators("但书")));
+  assert.ok(tradeTargetPriority(3, operators("但书")) > tradeTargetPriority(1, operators("可露希尔")));
+  assert.equal(tradeTargetPriority(1, operators("可露希尔")), 100);
+});
+
+test("automatic allocation selects the highest-priority trade room", () => {
+  const layout = {
+    template: "153", drone_cap: 0, scenario: {}, rooms: [
+      { id: "trade_1", kind: "trade_post" as const, level: 3, product: { trade: { order: "gold" as const } } },
+      { id: "trade_2", kind: "trade_post" as const, level: 1, product: { trade: { order: "gold" as const } } },
+      { id: "power_1", kind: "power_plant" as const, level: 3 },
+    ],
+  };
+  const plan = { name: "A", rooms: {
+    trading: [
+      { product: "LMD", operators: ["但书", "龙舌兰"] },
+      { product: "LMD", operators: ["但书"] },
+    ],
+    power: [{ operators: ["雷蛇"] }],
+  } };
+  const shift = {
+    index: 0, duration_hours: 12, active_teams: [], resting_team: "", weighted_trade: 0, weighted_manu: 0, weighted_power: 0,
+    scores: { trade_score: 0, manu_prod_sum: 0, power_charge_sum: 0, room_lines: [{ room_id: "power_1", equivalent_efficiency: 0.2 }] },
+  };
+  const [allocation] = chooseDroneAllocations({ layout, plans: [plan], shifts: [shift], dailyProduction: { lmd: 0, pure_gold: 0 } });
+  assert.equal(allocation.target.roomId, "trade_2");
+});
 
 test("power efficiency includes one shared base, working-operator bonuses, and station efficiency", () => {
   assert.ok(Math.abs(powerEfficiencyForShift({

--- a/src/server/drone-production.test.ts
+++ b/src/server/drone-production.test.ts
@@ -14,7 +14,7 @@ import {
 test("drone trade targets follow the configured priority chain", () => {
   const operators = (...names: string[]) => names;
   assert.ok(tradeTargetPriority(1, operators("但书")) > tradeTargetPriority(2, operators("但书")));
-  assert.ok(tradeTargetPriority(2, operators("但书")) > tradeTargetPriority(3, operators("但书", "龙舌兰")));
+  assert.ok(tradeTargetPriority(2, operators("但书")) > tradeTargetPriority(3, operators("但书")));
   assert.ok(tradeTargetPriority(3, operators("但书", "龙舌兰")) > tradeTargetPriority(3, operators("龙舌兰", "柏喙")));
   assert.ok(tradeTargetPriority(3, operators("龙舌兰", "柏喙")) > tradeTargetPriority(3, operators("但书")));
   assert.ok(tradeTargetPriority(3, operators("但书")) > tradeTargetPriority(1, operators("可露希尔")));

--- a/src/server/drone-production.ts
+++ b/src/server/drone-production.ts
@@ -189,16 +189,27 @@ function tradeTargetForRoom(level: number, operators: MaaRoom["operators"]): Dro
   return { kind: "normal", level: normalizedLevel };
 }
 
+export function tradeTargetPriority(level: number, operators: MaaRoom["operators"]): number {
+  const names = Array.isArray(operators) ? operators.map((operator) => operatorName(operator)).filter(Boolean) : [];
+  const has = (name: string) => names.includes(name);
+  if (level === 1 && has("但书")) return 600;
+  if (level === 2 && has("但书")) return 500;
+  if (level === 3 && has("但书") && has("龙舌兰")) return 400;
+  if (level === 3 && has("龙舌兰") && has("柏喙")) return 300;
+  if (level === 3 && has("但书")) return 200;
+  if (has("可露希尔")) return 100;
+  return 0;
+}
+
 function bestTradeRoom(layout: BaseBlueprint, plan: MaaPlan): { target: DroneRoomTarget; profile: DroneTradeTarget } | null {
   const rooms = layout.rooms.filter((room) => room.kind === "trade_post");
-  const priorities: Record<DroneTradeTarget["kind"], number> = { dantshu: 4, tequila: 3, closure: 2, normal: 1 };
   return rooms.map((room, index) => {
     const maaRoom = plan.rooms.trading?.[index];
     const profile = tradeTargetForRoom(room.level, maaRoom?.operators ?? []);
     return {
       target: { room: "trading" as const, index: index + 1, roomId: room.id, product: "lmd" as const },
       profile,
-      priority: priorities[profile.kind],
+      priority: tradeTargetPriority(room.level, maaRoom?.operators ?? []),
       level: room.level,
     };
   }).sort((left, right) => right.priority - left.priority || right.level - left.level)[0] ?? null;


### PR DESCRIPTION
## 变更

修复低级但书无人机优先级规则，确保无人机分配时优先选择低等级贸易站的但书房间。

## 验证

- [x] PR base branch 为 develop
- [x] drone-production 测试通过
- [x] 未包含凭据或用户数据

## 许可

- [x] 本次改动为本项目代码贡献