### PR TITLE
fix(schedule): 发布发电站等待排班提示

### DIFF
--- a/src/components/CompactScheduleView.tsx
+++ b/src/components/CompactScheduleView.tsx
@@ -194,7 +194,7 @@ function CompactRoomCard({
       )}
     </div>
   ) : null;
-  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture" || (isPower && onClearRoom)) ? (
+  const emptyWorkstationState = !efficiency && (row.group === "trading" || row.group === "manufacture" || isPower) ? (
     <div className="font-technical text-xs tracking-[0.01em] text-white/38">
       {intl("components_CompactScheduleView.awaitingSchedule")}
     </div>


### PR DESCRIPTION
未生成排班时，发电站卡片现在与制造站、贸易站一样显示“等待排班”。复用现有空状态文案和样式，不再要求发电站具备手动清空操作。

验证：修改文件 ESLint 通过，18 项排班展示及效率单元测试通过；本地空排班页面用例通过。合并后继续由现有发布工作流执行完整检查和部署。
