### PR TITLE
feat: 技能查询支持英文干员名

### DIFF
--- a/src/building-rooms.test.ts
+++ b/src/building-rooms.test.ts
@@ -125,6 +125,15 @@ test("combines room and name-substring filters with AND and sorts by name", () =
   assert.ok(all.includes("阿米娅") && all.includes("阿能") && all.includes("能天使"));
 });
 
+test("supports English operator name queries only when English names are provided", () => {
+  const operators: OperatorWithSkills[] = [
+    { name: "阿米娅", buildingSkills: [{ id: "control_x" }] },
+  ];
+  const lookup: SkillRecordLookup = () => ({});
+  assert.deepEqual(filterOperators(operators, null, null, "Amiya", lookup), []);
+  assert.deepEqual(filterOperators(operators, null, null, "Amiya", lookup, { englishNames: { "阿米娅": "Amiya" } }).map((operator) => operator.name), ["阿米娅"]);
+});
+
 test("matches queries against skill names and plain-text descriptions", () => {
   const operators: OperatorWithSkills[] = [
     { name: "阿米娅", buildingSkills: [{ id: "control_x" }] },

--- a/src/building-rooms.ts
+++ b/src/building-rooms.ts
@@ -81,6 +81,7 @@ export type SkillRecordLookup = (skillId: string) => SkillRecord | undefined;
 export interface OperatorFilters {
   rarity?: number | null;
   profession?: number | null;
+  englishNames?: Readonly<Record<string, string>>;
 }
 
 export function operatorMatchesRoom(
@@ -116,10 +117,13 @@ export function operatorMatchesQuery(
   skillIds: readonly string[],
   query: string,
   skillLookup: SkillRecordLookup,
+  englishNames?: Readonly<Record<string, string>>,
 ): boolean {
   const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
   if (!normalizedQuery) return true;
   if (name.toLocaleLowerCase("zh-CN").includes(normalizedQuery)) return true;
+  const englishName = englishNames?.[name];
+  if (englishName?.toLocaleLowerCase("en-US").includes(normalizedQuery.toLocaleLowerCase("en-US"))) return true;
   return skillIds.some((id) => {
     const skill = skillLookup(id);
     if (!skill) return false;
@@ -148,7 +152,7 @@ export function filterOperators<T extends OperatorWithSkills>(
         &&
         operatorMatchesRoom(skillIds, room)
         && operatorMatchesTag(skillIds, room, tag, skillLookup)
-        && operatorMatchesQuery(operator.name, skillIds, query, skillLookup)
+        && operatorMatchesQuery(operator.name, skillIds, query, skillLookup, filters.englishNames)
       );
     })
     .sort((left, right) => {

--- a/src/components/pages/SkillQuery.tsx
+++ b/src/components/pages/SkillQuery.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { LoadMore } from "@/components/ui/load-more";
 import { BUILDING_SKILL_CATALOG, OPERATOR_CATALOG } from "@/operatorPortraits";
+import operatorEnglishNames from "@/generated/operator-english-names.json" with { type: "json" };
 import { indexSkillAnnotations } from "@/skill-annotations";
 import type { ApiResponse, SkillAnnotationListData } from "@/types";
 
@@ -23,6 +24,7 @@ export const SKILL_QUERY_PAGE_SIZE = 10;
 
 export function SkillQuery() {
   const intl = useTranslations();
+  const locale = useLocale();
 
   const filters = useTranslations("SkillFilters");
   const [rarity, setRarity] = useState("all");
@@ -60,9 +62,9 @@ export function SkillQuery() {
       selectedTag,
       query,
       (skillId) => BUILDING_SKILL_CATALOG[skillId],
-      { rarity: rarity === "all" ? null : Number(rarity), profession: profession === "all" ? null : Number(profession) },
+      { rarity: rarity === "all" ? null : Number(rarity), profession: profession === "all" ? null : Number(profession), englishNames: locale === "en" ? operatorEnglishNames : undefined },
     ),
-    [query, selectedRoom, selectedTag, rarity, profession],
+    [query, selectedRoom, selectedTag, rarity, profession, locale],
   );
   const visible = filtered.slice(0, visibleCount);
   const annotationIndex = useMemo(() => indexSkillAnnotations(annotations), [annotations]);


### PR DESCRIPTION
## 变更

- 英文界面下支持按英文干员名查询，例如 `Amiya`、`Exusiai`、`Dorothy`
- 中文界面继续使用中文干员名、技能名和技能描述查询
- 增加语言开关下的查询测试

## 验证

- eslint
- building-rooms tests（14 项通过）
- git diff --check