### PR TITLE
feat: 技能查询支持中文干员模糊搜索

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "next-intl": "^4.14.2",
         "overlayscrollbars": "^2.16.0",
         "pg": "^8.23.0",
+        "pinyin-pro": "^3.29.4",
         "qrcode.react": "4.2.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -7792,6 +7793,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pinyin-pro": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.29.4.tgz",
+      "integrity": "sha512-SPXpDT2cHEy+d26V1RXYMlVzXN42hotFAak1fzyWPi4o2dKXb61UqD4pzxDJHwk6gbv8vQ6EfErd+hYX0Qhzug==",
+      "license": "MIT"
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "next-intl": "^4.14.2",
     "overlayscrollbars": "^2.16.0",
     "pg": "^8.23.0",
+    "pinyin-pro": "^3.29.3",
+    "pinyin-pro": "^3.29.4",
     "qrcode.react": "4.2.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/src/building-rooms.test.ts
+++ b/src/building-rooms.test.ts
@@ -125,6 +125,17 @@ test("combines room and name-substring filters with AND and sorts by name", () =
   assert.ok(all.includes("阿米娅") && all.includes("阿能") && all.includes("能天使"));
 });
 
+test("supports Chinese operator-name fuzzy search with initials and full pinyin", () => {
+  const operators: OperatorWithSkills[] = [
+    { name: "阿米娅", buildingSkills: [{ id: "control_x" }] },
+    { name: "能天使", buildingSkills: [{ id: "manu_x" }] },
+  ];
+  const lookup: SkillRecordLookup = () => ({});
+  assert.deepEqual(filterOperators(operators, null, null, "amy", lookup).map((operator) => operator.name), ["阿米娅"]);
+  assert.deepEqual(filterOperators(operators, null, null, "amiya", lookup).map((operator) => operator.name), ["阿米娅"]);
+  assert.deepEqual(filterOperators(operators, null, null, "nts", lookup).map((operator) => operator.name), ["能天使"]);
+});
+
 test("matches queries against skill names and plain-text descriptions", () => {
   const operators: OperatorWithSkills[] = [
     { name: "阿米娅", buildingSkills: [{ id: "control_x" }] },

--- a/src/building-rooms.test.ts
+++ b/src/building-rooms.test.ts
@@ -136,6 +136,13 @@ test("supports Chinese operator-name fuzzy search with initials and full pinyin"
   assert.deepEqual(filterOperators(operators, null, null, "nts", lookup).map((operator) => operator.name), ["能天使"]);
 });
 
+test("keeps both pinyin readings for 仇白", () => {
+  const operators: OperatorWithSkills[] = [{ name: "仇白", buildingSkills: [{ id: "control_x" }] }];
+  const lookup: SkillRecordLookup = () => ({});
+  assert.deepEqual(filterOperators(operators, null, null, "choubai", lookup).map((operator) => operator.name), ["仇白"]);
+  assert.deepEqual(filterOperators(operators, null, null, "qiubai", lookup).map((operator) => operator.name), ["仇白"]);
+});
+
 test("matches queries against skill names and plain-text descriptions", () => {
   const operators: OperatorWithSkills[] = [
     { name: "阿米娅", buildingSkills: [{ id: "control_x" }] },

--- a/src/building-rooms.ts
+++ b/src/building-rooms.ts
@@ -110,6 +110,16 @@ export function operatorMatchesNameContains(name: string, query: string): boolea
   return name.toLocaleLowerCase("zh-CN").includes(normalizedQuery);
 }
 
+function operatorNameMatchesQuery(name: string, query: string): boolean {
+  const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
+  if (!normalizedQuery) return true;
+  if (name.toLocaleLowerCase("zh-CN").includes(normalizedQuery)) return true;
+  const initials = pinyin(name, { pattern: "first", toneType: "none", type: "array" }).join("").toLocaleLowerCase("en-US");
+  if (initials.includes(normalizedQuery)) return true;
+  const fullPinyin = pinyin(name, { toneType: "none", type: "array" }).join("").toLocaleLowerCase("en-US");
+  return fullPinyin.includes(normalizedQuery);
+}
+
 /** 搜索命中干员名称、技能名称或技能纯文本描述（任意一项命中即可）。 */
 export function operatorMatchesQuery(
   name: string,
@@ -119,7 +129,7 @@ export function operatorMatchesQuery(
 ): boolean {
   const normalizedQuery = query.trim().toLocaleLowerCase("zh-CN");
   if (!normalizedQuery) return true;
-  if (name.toLocaleLowerCase("zh-CN").includes(normalizedQuery)) return true;
+  if (operatorNameMatchesQuery(name, normalizedQuery)) return true;
   return skillIds.some((id) => {
     const skill = skillLookup(id);
     if (!skill) return false;
@@ -157,3 +167,4 @@ export function filterOperators<T extends OperatorWithSkills>(
       return (right.order ?? 0) - (left.order ?? 0) || left.name.localeCompare(right.name, "zh-CN");
     });
 }
+import { pinyin } from "pinyin-pro";

--- a/src/building-rooms.ts
+++ b/src/building-rooms.ts
@@ -1,3 +1,8 @@
+
+const OPERATOR_PINYIN_ALIASES: Readonly<Record<string, readonly string[]>> = {
+  "仇白": ["qiubai"],
+};
+
 // 基建技能房间标签：技能 id 第一个下划线之前就是房间前缀，
 // 例如 control_tra_spd_000 → control → 控制中枢。无依赖，可被页面/组件/测试直接复用。
 
@@ -117,7 +122,8 @@ function operatorNameMatchesQuery(name: string, query: string): boolean {
   const initials = pinyin(name, { pattern: "first", toneType: "none", type: "array" }).join("").toLocaleLowerCase("en-US");
   if (initials.includes(normalizedQuery)) return true;
   const fullPinyin = pinyin(name, { toneType: "none", type: "array" }).join("").toLocaleLowerCase("en-US");
-  return fullPinyin.includes(normalizedQuery);
+  return fullPinyin.includes(normalizedQuery)
+    || (OPERATOR_PINYIN_ALIASES[name] ?? []).some((alias) => alias.includes(normalizedQuery));
 }
 
 /** 搜索命中干员名称、技能名称或技能纯文本描述（任意一项命中即可）。 */


### PR DESCRIPTION
## 变更

- 干员名字支持中文模糊查询
- 支持拼音首字母，例如 `nts` 查找能天使
- 支持完整拼音，例如 `amiya` 查找阿米娅
- 技能名和技能描述继续使用普通包含搜索

## 验证

- eslint
- building-rooms tests（14 项通过）
- git diff --check