### PR TITLE
固定 MAA 导出中的干员顺序

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ import {
   type OnboardingPreference,
 } from "./onboarding";
 import { normalizeOperboxEntries } from "./operbox-normalization";
+import { prepareMaaForExport } from "./maa-safety";
 import { upgradeSimulationBoxSource } from "./upgrade-simulation";
 import {
   DEFAULT_MANUAL_SHIFT_DURATIONS,
@@ -1169,7 +1170,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
   async function handleDownloadMaa() {
     if (!result?.maa) return;
     const { downloadJson } = await import("./download");
-    downloadJson("arknights-infra-schedule-maa.json", result.maa);
+    downloadJson("arknights-infra-schedule-maa.json", prepareMaaForExport(result.maa));
   }
 
   function openManualScheduleDraft(draft: ManualScheduleDraft) {

--- a/src/components/pages/ManualSchedulePage.tsx
+++ b/src/components/pages/ManualSchedulePage.tsx
@@ -29,6 +29,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { downloadJson } from "@/download";
 import { localizedOperatorName, localizedRoomTitle } from "@/i18n/game-data";
 import { useGameCatalog } from "@/i18n/game-data-client";
+import { prepareMaaForExport } from "@/maa-safety";
 import {
   assignManualOperator,
   clearManualRoom,
@@ -505,7 +506,7 @@ export function ManualSchedulePage({
   }
 
   function exportMaa() {
-    downloadJson("arknights-infra-schedule-maa.json", maa);
+    downloadJson("arknights-infra-schedule-maa.json", prepareMaaForExport(maa));
   }
 
   async function prepareMaaImport(file: File) {

--- a/src/maa-safety.test.ts
+++ b/src/maa-safety.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { prepareMaaForExport } from "./maa-safety.ts";
+import type { MaaJson } from "./types.ts";
+
+test("prepares MAA export with sort enabled and preserves displayed operator order", () => {
+  const maa: MaaJson = {
+    title: "test",
+    plans: [{
+      name: "班次 1",
+      rooms: {
+        trading: [{
+          operators: ["古米", "银灰", "梅"],
+          sort: false,
+        }],
+      },
+    }],
+  };
+
+  const exported = prepareMaaForExport(maa);
+  const room = exported.plans[0]!.rooms.trading![0]!;
+
+  assert.equal(room.sort, true);
+  assert.deepEqual(room.operators, ["古米", "银灰", "梅"]);
+  assert.equal(maa.plans[0]!.rooms.trading![0]!.sort, false);
+});

--- a/src/maa-safety.ts
+++ b/src/maa-safety.ts
@@ -46,3 +46,25 @@ export function sanitizeMaaJson<T extends MaaJson>(maa: T): T {
 
   return sanitized;
 }
+
+/**
+ * Prepare a schedule for MAA export.
+ *
+ * MAA uses `sort: true` to respect the operator order in each room's
+ * `operators` array. The array already follows the order shown in the UI,
+ * so preserve it exactly while removing runtime-only fields.
+ */
+export function prepareMaaForExport<T extends MaaJson>(maa: T): T {
+  const exported = sanitizeMaaJson(maa);
+
+  for (const plan of exported.plans) {
+    for (const rooms of Object.values(plan.rooms)) {
+      if (!rooms) continue;
+      for (const room of rooms) {
+        room.sort = true;
+      }
+    }
+  }
+
+  return exported;
+}

--- a/src/manual-schedule.test.ts
+++ b/src/manual-schedule.test.ts
@@ -193,7 +193,7 @@ test("MAA export includes contiguous minute periods, per-shift Fiammetta targets
   assert.deepEqual(maa.plans[1]?.Fiammetta, { enable: false, target: "", order: "pre" });
   assert.equal(maa.plans[0]?.rooms.dormitory?.[0]?.autofill, true);
   assert.deepEqual(maa.plans[0]?.rooms.dormitory?.[0]?.operators, []);
-  assert.deepEqual(maa.plans[0]?.rooms.control?.[0], { operators: [], sort: false, skip: false, autofill: false });
+  assert.deepEqual(maa.plans[0]?.rooms.control?.[0], { operators: [], sort: true, skip: false, autofill: false });
   assert.equal(maa.plans[0]?.rooms.trading?.[0]?.product, "LMD");
   assert.equal(maa.plans[0]?.rooms.manufacture?.[0]?.product, "Battle Record");
   assert.equal("training" in (maa.plans[0]?.rooms ?? {}), false);

--- a/src/manual-schedule.ts
+++ b/src/manual-schedule.ts
@@ -829,7 +829,7 @@ function maaRoom(room: BlueprintRoom, assignment: ManualRoomAssignment | undefin
   const product = maaProduct(room);
   return {
     operators,
-    sort: false,
+    sort: true,
     skip: false,
     autofill: room.kind === "dormitory" ? assignment?.autofill ?? true : false,
     ...(product ? { product } : {}),


### PR DESCRIPTION
## 变更内容

- MAA 导出统一写入 `sort: true`。
- 保留前端当前展示的干员顺序，按数组顺序依次导出。
- 自动排班导出、手动排班导出统一生效。
- 增加导出顺序回归测试。

## 验证

- `node --test --experimental-strip-types src/maa-safety.test.ts src/manual-schedule.test.ts`
- `npx eslint src/maa-safety.ts src/maa-safety.test.ts src/manual-schedule.ts src/manual-schedule.test.ts src/App.tsx src/components/pages/ManualSchedulePage.tsx`