### PR TITLE
feat(settings): 统一设置页与账号页布局及下拉组件

### DIFF
--- a/e2e/user-settings.spec.ts
+++ b/e2e/user-settings.spec.ts
@@ -12,7 +12,8 @@ test("settings persist and control language, schedule controls and MAA export", 
   await page.getByRole("switch", { name: /^严格按照顺序入驻/ }).click();
   await page.getByRole("switch", { name: /^加载干员图片/ }).click();
   await page.getByRole("button", { name: "细致调整", exact: true }).click();
-  await page.locator("#schedule-view-control-detail").selectOption("select");
+  await page.getByRole("combobox", { name: "一图流和列表式控件", exact: true }).click();
+  await page.getByRole("option", { name: "下拉表单", exact: true }).click();
   await page.reload();
   await expect(page.getByRole("switch", { name: /^严格按照顺序入驻/ })).not.toBeChecked();
   await expect(page.getByRole("button", { name: "EN（关闭）", exact: true })).toBeDisabled();
@@ -25,6 +26,40 @@ test("settings persist and control language, schedule controls and MAA export", 
   const download = await pending;
   const exported = JSON.parse(await readFile((await download.path())!, "utf8"));
   expect(exported.plans.flatMap((plan: { rooms: Record<string, Array<{ sort: boolean }>> }) => Object.values(plan.rooms).flat()).every((room: { sort: boolean }) => room.sort === false)).toBe(true);
+});
+
+test("settings dropdowns preserve independent choices and fit narrow screens", async ({ page }) => {
+  await mockApis(page);
+  await page.goto("/settings");
+  await page.getByRole("button", { name: "细致调整", exact: true }).click();
+  const shifts = page.getByRole("combobox", { name: "多班制切换方式", exact: true });
+  await expect(shifts).toBeDisabled();
+  await page.getByRole("switch", { name: /^统一使用总设置/ }).click();
+  await shifts.click();
+  await shifts.press("ArrowDown");
+  await shifts.press("Enter");
+  await expect(shifts).toHaveValue("下拉表单");
+  await expect(page.getByRole("combobox", { name: "一图流和列表式控件", exact: true })).toHaveValue("按钮");
+  await page.getByRole("combobox", { name: "导出图片范围", exact: true }).click();
+  await page.getByRole("option", { name: "全班", exact: true }).click();
+  await page.getByRole("combobox", { name: "技能页加载方式", exact: true }).click();
+  await page.getByRole("option", { name: "每十条点击加载", exact: true }).click();
+  await page.reload();
+  await page.getByRole("button", { name: "细致调整", exact: true }).click();
+  await expect(shifts).toHaveValue("下拉表单");
+  await expect(page.getByRole("combobox", { name: "导出图片范围", exact: true })).toHaveValue("全班");
+  const pagination = page.getByRole("combobox", { name: "技能页加载方式", exact: true });
+  await expect(pagination).toHaveValue("每十条点击加载");
+  await page.setViewportSize({ width: 375, height: 812 });
+  await pagination.click();
+  await expect(page.getByRole("option", { name: "无限下滚", exact: true })).toBeVisible();
+  const popup = await page.locator('[data-slot="combobox-content"]').boundingBox();
+  expect(popup).not.toBeNull();
+  expect(popup!.x).toBeGreaterThanOrEqual(0);
+  expect(popup!.x + popup!.width).toBeLessThanOrEqual(375);
+  await pagination.press("Escape");
+  await expect(page.getByRole("listbox")).toHaveCount(0);
+  await expect(pagination).toHaveValue("每十条点击加载");
 });
 
 test("one-shift image export preserves the selected shift", async ({ page }) => {

--- a/src/components/pages/UserSettingsPage.tsx
+++ b/src/components/pages/UserSettingsPage.tsx
@@ -1,23 +1,62 @@
 "use client";
 
 import { useLocale } from "next-intl";
-import { RotateCcw, Settings2, SlidersHorizontal } from "lucide-react";
+import Link from "next/link";
+import { ArrowLeft, Eye, RotateCcw, Settings2, SlidersHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { InfraTechnicalCard, InfraTechnicalHeading } from "@/components/InfraTechnicalCard";
+import { StatusCenterHeader, StatusCenterPage } from "@/components/pages/StatusCenterShell";
+import { Combobox, ComboboxContent, ComboboxInput, ComboboxItem, ComboboxList } from "@/components/ui/combobox";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { DEFAULT_USER_SETTINGS, type UserSettings } from "@/user-settings";
+
+const SETTINGS_SWITCH_CLASS = "data-checked:bg-white data-unchecked:bg-white/20 dark:data-unchecked:bg-white/20 [&_[data-slot=switch-thumb]]:bg-white [&_[data-slot=switch-thumb][data-checked]]:bg-[#272a2b]";
 
 interface UserSettingsPageProps {
   settings: UserSettings;
   onSettingsChange: (settings: UserSettings) => void;
 }
 
+function SettingsDropdown<T extends string>({ id, label, value, options, disabled = false, onChange }: {
+  id: string;
+  label: string;
+  value: T;
+  options: Array<{ value: T; label: string }>;
+  disabled?: boolean;
+  onChange: (value: T) => void;
+}) {
+  const selected = options.find((option) => option.value === value) ?? null;
+  return (
+    <Combobox
+      items={options}
+      filteredItems={options}
+      value={selected}
+      inputValue={selected?.label ?? ""}
+      itemToStringValue={(option) => option.label}
+      isItemEqualToValue={(option, current) => option.value === current.value}
+      disabled={disabled}
+      onValueChange={(option) => { if (option) onChange(option.value); }}
+    >
+      <ComboboxInput id={id} aria-label={label} readOnly disabled={disabled} className="h-9 w-44 max-w-[55%] shrink-0 border-white/22 bg-white text-[#242424] shadow-none [&_input]:text-[#242424]" />
+      <ComboboxContent align="start">
+        <ComboboxList>
+          {(option) => <ComboboxItem key={option.value} value={option}>{option.label}</ComboboxItem>}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
 export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPageProps) {
   const en = useLocale() === "en";
   const [viewControlDetailsOpen, setViewControlDetailsOpen] = useState(!settings.linkShiftViewControl);
+  const viewControlOptions: Array<{ value: UserSettings["scheduleViewControl"]; label: string }> = [
+    { value: "tabs", label: en ? "Buttons" : "按钮" },
+    { value: "select", label: en ? "Dropdown" : "下拉表单" },
+  ];
   const resetViewControls = () => onSettingsChange({
     ...settings,
     scheduleViewControl: DEFAULT_USER_SETTINGS.scheduleViewControl,
@@ -25,36 +64,43 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
     shiftViewControl: DEFAULT_USER_SETTINGS.shiftViewControl,
   });
   return (
-    <div className="min-h-[calc(100svh-9rem)] py-5" data-user-settings-page>
-      <header className="mb-6 flex items-center gap-3 border-b border-border/70 pb-5">
-        <div className="flex size-11 items-center justify-center rounded-lg bg-primary/10 text-primary">
-          <Settings2 className="size-5" aria-hidden="true" />
-        </div>
-        <div>
-          <h1 className="font-heading text-2xl font-semibold">{en ? "Settings" : "设置"}</h1>
-          <p className="mt-1 text-sm text-muted-foreground">{en ? "Personalize scheduling behavior." : "调整排班和操作行为。"}</p>
-        </div>
-      </header>
-
-      <div className="grid max-w-3xl gap-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>{en ? "Manual scheduling" : "手动排班"}</CardTitle>
-            <CardDescription>
-              {en ? "Choose how operator conflicts are handled." : "选择干员冲突时的处理方式。"}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+    <StatusCenterPage data-user-settings-page>
+      <StatusCenterHeader
+        identity={(
+          <div className="flex min-w-0 items-center gap-4">
+            <div className="grid size-14 shrink-0 place-items-center rounded-xl bg-primary/10 text-primary">
+              <Settings2 className="size-7" aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-2xl font-semibold tracking-tight">{en ? "Settings" : "设置"}</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{en ? "Personalize scheduling and display. Changes are saved in this browser." : "调整排班与显示方式，修改自动保存在当前浏览器。"}</p>
+            </div>
+          </div>
+        )}
+        actions={(
+          <Button variant="outline" className="h-11 w-full sm:w-auto" render={<Link href="/" />}>
+            <ArrowLeft />{en ? "Back to calculator" : "返回基建计算器"}
+          </Button>
+        )}
+      />
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)]" data-settings-cards>
+        <InfraTechnicalCard group="control">
+          <section aria-labelledby="settings-scheduling-title">
+            <InfraTechnicalHeading icon={<SlidersHorizontal className="size-4" aria-hidden="true" />} titleId="settings-scheduling-title">
+              {en ? "Scheduling and export" : "排班与导出"}
+            </InfraTechnicalHeading>
+            <p className="mt-4 text-sm leading-6 text-white/64">{en ? "Configure operator order, view controls and image exports." : "设置干员入驻顺序、视图切换和图片导出。"}</p>
+            <div className="mt-5 grid gap-4">
+            <div className="flex items-center justify-between gap-6">
               <Label htmlFor="strict-maa-operator-order" className="grid min-w-0 gap-1">
                 <span>{en ? "Strict operator order" : "严格按照顺序入驻"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en
                     ? "Export operators in the same order shown in the schedule. Enabling this can make MAA take longer to fill rooms."
                     : "导出到 MAA 时，按前端排班中显示的顺序依次入驻；开启后 MAA 填写时间可能变长。"}
                 </span>
               </Label>
-              <Switch
+              <Switch className={SETTINGS_SWITCH_CLASS}
                 id="strict-maa-operator-order"
                 checked={settings.strictMaaOperatorOrder}
                 onCheckedChange={(checked) => onSettingsChange({
@@ -64,16 +110,16 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
                 aria-label={en ? "Strict operator order" : "严格按照顺序入驻"}
               />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="allow-replacement-operator-sort" className="grid min-w-0 gap-1">
                 <span>{en ? "Allow replacement operator sorting" : "替换排班允许调整干员顺序"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en
                     ? "Only allows MAA to adjust operator order inside the same facility when replacing a schedule. Off by default."
                     : "仅允许替换排班时在同一设施内调整干员顺序；默认关闭。"}
                 </span>
               </Label>
-              <Switch
+              <Switch className={SETTINGS_SWITCH_CLASS}
                 id="allow-replacement-operator-sort"
                 checked={settings.allowReplacementOperatorSort}
                 onCheckedChange={(checked) => onSettingsChange({
@@ -83,36 +129,36 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
                 aria-label={en ? "Allow replacement operator sorting" : "替换排班允许调整干员顺序"}
               />
             </div>
-            <div className="grid gap-3 border-t border-border/60 pt-4">
+            <div className="grid gap-3 border-t border-white/12 pt-4">
               <div className="flex items-center justify-between gap-6">
               <Label htmlFor="schedule-view-control" className="grid min-w-0 gap-1">
                 <span>{en ? "Schedule view control" : "排班视图切换方式"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en ? "Choose buttons or a dropdown for overview and list." : "选择“一图流 / 列表式”使用按钮还是下拉表单。"}
                 </span>
               </Label>
               <div className="flex shrink-0 items-center gap-2">
-                <Button type="button" variant="outline" size="icon" className="size-9" onClick={() => setViewControlDetailsOpen((open) => !open)} aria-label={en ? "Detailed controls" : "细致调整"} title={en ? "Detailed controls" : "细致调整"}>
+                <Button type="button" variant="outline" size="icon" className="size-9 border-white/22 bg-white/5 text-white hover:bg-white/10 hover:text-white" onClick={() => setViewControlDetailsOpen((open) => !open)} aria-label={en ? "Detailed controls" : "细致调整"} title={en ? "Detailed controls" : "细致调整"}>
                   <SlidersHorizontal />
                 </Button>
               </div>
               </div>
               {viewControlDetailsOpen ? (
-                <div className="grid gap-3 rounded-md border border-border/70 bg-muted/20 p-3">
+                <div className="grid gap-3 rounded-md border border-white/15 bg-white/5 p-3">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="text-sm font-medium">{en ? "Detailed controls" : "细致调整"}</div>
-                    <Button type="button" variant="ghost" size="sm" onClick={resetViewControls}>
+                    <Button type="button" variant="ghost" size="sm" className="text-white/80 hover:bg-white/10 hover:text-white" onClick={resetViewControls}>
                       <RotateCcw />{en ? "Restore defaults" : "恢复默认"}
                     </Button>
                   </div>
                   <div className="flex items-center justify-between gap-6">
                     <Label htmlFor="link-shift-view-control" className="grid min-w-0 gap-1">
                       <span>{en ? "Use one setting for all" : "统一使用总设置"}</span>
-                      <span className="font-normal text-sm text-muted-foreground">
+                      <span className="font-normal text-sm text-white/64">
                         {en ? "Disable this to tune overview/list and shift switching separately." : "关闭后可分别调整“一图流 / 列表式”和“多班制”。"}
                       </span>
                     </Label>
-                    <Switch
+                    <Switch className={SETTINGS_SWITCH_CLASS}
                       id="link-shift-view-control"
                       checked={settings.linkShiftViewControl}
                       onCheckedChange={(checked) => onSettingsChange({
@@ -127,136 +173,154 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
                     <Label htmlFor="schedule-view-control-detail" className="grid min-w-0 gap-1">
                       <span>{en ? "Overview / list" : "一图流 / 列表式"}</span>
                     </Label>
-                    <select
+                    <SettingsDropdown
                       id="schedule-view-control-detail"
                       value={settings.scheduleViewControl}
-                      onChange={(event) => {
-                        const control = event.target.value === "select" ? "select" : "tabs";
+                      options={viewControlOptions}
+                      onChange={(control) => {
                         onSettingsChange({
                           ...settings,
                           scheduleViewControl: control,
                           shiftViewControl: settings.linkShiftViewControl ? control : settings.shiftViewControl,
                         });
                       }}
-                      className="h-9 min-w-32 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      aria-label={en ? "Overview and list control" : "一图流和列表式控件"}
-                    >
-                      <option value="tabs">{en ? "Buttons" : "按钮"}</option>
-                      <option value="select">{en ? "Dropdown" : "下拉表单"}</option>
-                    </select>
+                      label={en ? "Overview and list control" : "一图流和列表式控件"}
+                    />
                   </div>
                   <div className="flex items-center justify-between gap-6">
                     <Label htmlFor="shift-view-control" className="grid min-w-0 gap-1">
                       <span>{en ? "Shift view control" : "多班制切换方式"}</span>
-                      <span className="font-normal text-sm text-muted-foreground">
+                      <span className="font-normal text-sm text-white/64">
                         {en ? "Choose buttons or a dropdown for switching between shifts." : "单独选择“第 1 班 / 第 2 班…”使用按钮还是下拉表单。"}
                       </span>
                     </Label>
-                    <select
+                    <SettingsDropdown
                       id="shift-view-control"
                       value={settings.linkShiftViewControl ? settings.scheduleViewControl : settings.shiftViewControl}
+                      options={viewControlOptions}
                       disabled={settings.linkShiftViewControl}
-                      onChange={(event) => onSettingsChange({
+                      onChange={(control) => onSettingsChange({
                         ...settings,
-                        shiftViewControl: event.target.value === "select" ? "select" : "tabs",
+                        shiftViewControl: control,
                       })}
-                      className="h-9 min-w-32 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
-                      aria-label={en ? "Shift view control" : "多班制切换方式"}
-                    >
-                      <option value="tabs">{en ? "Buttons" : "按钮"}</option>
-                      <option value="select">{en ? "Dropdown" : "下拉表单"}</option>
-                    </select>
+                      label={en ? "Shift view control" : "多班制切换方式"}
+                    />
                   </div>
                 </div>
               ) : null}
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="image-export-scope" className="grid min-w-0 gap-1">
                 <span>{en ? "Image export scope" : "导出图片范围"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en ? "Choose one shift or all shifts. All-shift export is currently under maintenance." : "选择导出一班或全班；全班导出目前维护中。"}
                 </span>
               </Label>
-              <select
+              <SettingsDropdown<UserSettings["imageExportScope"]>
                 id="image-export-scope"
                 value={settings.imageExportScope}
-                onChange={(event) => onSettingsChange({
+                options={[
+                  { value: "single", label: en ? "One shift" : "一班" },
+                  { value: "all", label: en ? "All shifts" : "全班" },
+                ]}
+                onChange={(scope) => onSettingsChange({
                   ...settings,
-                  imageExportScope: event.target.value === "all" ? "all" : "single",
+                  imageExportScope: scope,
                 })}
-                className="h-9 min-w-24 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                aria-label={en ? "Image export scope" : "导出图片范围"}
-              >
-                <option value="single">{en ? "One shift" : "一班"}</option>
-                <option value="all">{en ? "All shifts" : "全班"}</option>
-              </select>
+                label={en ? "Image export scope" : "导出图片范围"}
+              />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            </div>
+          </section>
+        </InfraTechnicalCard>
+        <InfraTechnicalCard group="manufacture">
+          <section aria-labelledby="settings-display-title">
+            <InfraTechnicalHeading icon={<Eye className="size-4" aria-hidden="true" />} titleId="settings-display-title">
+              {en ? "Display and loading" : "显示与加载"}
+            </InfraTechnicalHeading>
+            <p className="mt-4 text-sm leading-6 text-white/64">{en ? "Choose which actions, images and language resources to display." : "选择显示的操作入口、图片及语言资源。"}</p>
+            <div className="mt-5 grid gap-4">
+            <div className="flex items-center justify-between gap-6">
               <Label htmlFor="show-progression-recalculate" className="grid min-w-0 gap-1">
                 <span>{en ? "Show progression recalculation" : "显示修改练度并重算"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en ? "Show the button for simulating higher operator levels." : "控制“修改练度并重算”按钮是否显示。"}
                 </span>
               </Label>
-              <Switch
+              <Switch className={SETTINGS_SWITCH_CLASS}
                 id="show-progression-recalculate"
                 checked={settings.showProgressionRecalculate}
                 onCheckedChange={(checked) => onSettingsChange({ ...settings, showProgressionRecalculate: checked })}
                 aria-label={en ? "Show progression recalculation" : "显示修改练度并重算"}
               />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="show-manual-schedule-edit" className="grid min-w-0 gap-1">
                 <span>{en ? "Show current plan editor" : "显示基于当前方案编辑"}</span>
-                <span className="font-normal text-sm text-muted-foreground">
+                <span className="font-normal text-sm text-white/64">
                   {en ? "Show the button for opening the manual schedule editor." : "控制“基于当前方案编辑”按钮是否显示。"}
                 </span>
               </Label>
-              <Switch
+              <Switch className={SETTINGS_SWITCH_CLASS}
                 id="show-manual-schedule-edit"
                 checked={settings.showManualScheduleEdit}
                 onCheckedChange={(checked) => onSettingsChange({ ...settings, showManualScheduleEdit: checked })}
                 aria-label={en ? "Show current plan editor" : "显示基于当前方案编辑"}
               />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="load-english-resources" className="grid min-w-0 gap-1">
                 <span>{en ? "Load English resources" : "加载英文资源"}</span>
-                <span className="font-normal text-sm text-muted-foreground">{en ? "When off, English game data is not requested." : "关闭后不请求英文干员名、房间名和技能数据。"}</span>
+                <span className="font-normal text-sm text-white/64">{en ? "When off, English game data is not requested." : "关闭后不请求英文干员名、房间名和技能数据。"}</span>
               </Label>
-              <Switch id="load-english-resources" checked={settings.loadEnglishResources} onCheckedChange={(checked) => onSettingsChange({ ...settings, loadEnglishResources: checked })} aria-label={en ? "Load English resources" : "加载英文资源"} />
+              <Switch className={SETTINGS_SWITCH_CLASS} id="load-english-resources" checked={settings.loadEnglishResources} onCheckedChange={(checked) => onSettingsChange({ ...settings, loadEnglishResources: checked })} aria-label={en ? "Load English resources" : "加载英文资源"} />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="skill-pagination" className="grid min-w-0 gap-1">
                 <span>{en ? "Skill page loading" : "技能页加载方式"}</span>
-                <span className="font-normal text-sm text-muted-foreground">{en ? "Infinite scroll or click after ten results." : "无限下滚，或每显示十条后点击继续下滚。"}</span>
+                <span className="font-normal text-sm text-white/64">{en ? "Infinite scroll or click after ten results." : "无限下滚，或每显示十条后点击继续下滚。"}</span>
               </Label>
-              <select id="skill-pagination" value={settings.skillPagination} onChange={(event) => onSettingsChange({ ...settings, skillPagination: event.target.value === "manual" ? "manual" : "infinite" })} className="h-9 min-w-32 rounded-md border border-input bg-background px-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label={en ? "Skill page loading" : "技能页加载方式"}>
-                <option value="infinite">{en ? "Infinite scroll" : "无限下滚"}</option>
-                <option value="manual">{en ? "Click every ten" : "每十条点击加载"}</option>
-              </select>
+              <SettingsDropdown<UserSettings["skillPagination"]>
+                id="skill-pagination"
+                value={settings.skillPagination}
+                options={[
+                  { value: "infinite", label: en ? "Infinite scroll" : "无限下滚" },
+                  { value: "manual", label: en ? "Click every ten" : "每十条点击加载" },
+                ]}
+                onChange={(mode) => onSettingsChange({ ...settings, skillPagination: mode })}
+                label={en ? "Skill page loading" : "技能页加载方式"}
+              />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="show-feedback" className="grid min-w-0 gap-1">
                 <span>{en ? "Show feedback buttons" : "显示反馈按钮"}</span>
-                <span className="font-normal text-sm text-muted-foreground">{en ? "Show issue and performance feedback actions." : "控制排班结果中的问题反馈和性能反馈按钮。"}</span>
+                <span className="font-normal text-sm text-white/64">{en ? "Show issue and performance feedback actions." : "控制排班结果中的问题反馈和性能反馈按钮。"}</span>
               </Label>
-              <Switch id="show-feedback" checked={settings.showFeedback} onCheckedChange={(checked) => onSettingsChange({ ...settings, showFeedback: checked })} aria-label={en ? "Show feedback buttons" : "显示反馈按钮"} />
+              <Switch className={SETTINGS_SWITCH_CLASS} id="show-feedback" checked={settings.showFeedback} onCheckedChange={(checked) => onSettingsChange({ ...settings, showFeedback: checked })} aria-label={en ? "Show feedback buttons" : "显示反馈按钮"} />
             </div>
-            <div className="flex items-center justify-between gap-6 border-t border-border/60 pt-4">
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="show-images" className="grid min-w-0 gap-1">
                 <span>{en ? "Load operator images" : "加载干员图片"}</span>
-                <span className="font-normal text-sm text-muted-foreground">{en ? "When off, show names without loading portraits." : "关闭后只显示干员名字，不加载头像图片。"}</span>
+                <span className="font-normal text-sm text-white/64">{en ? "When off, show names without loading portraits." : "关闭后只显示干员名字，不加载头像图片。"}</span>
               </Label>
-              <Switch id="show-images" checked={settings.showImages} onCheckedChange={(checked) => onSettingsChange({ ...settings, showImages: checked })} aria-label={en ? "Load operator images" : "加载干员图片"} />
+              <Switch className={SETTINGS_SWITCH_CLASS} id="show-images" checked={settings.showImages} onCheckedChange={(checked) => onSettingsChange({ ...settings, showImages: checked })} aria-label={en ? "Load operator images" : "加载干员图片"} />
             </div>
-            <div className="border-t border-border/60 pt-4">
-              <div className="flex items-center justify-between gap-4">
+            </div>
+          </section>
+        </InfraTechnicalCard>
+      </div>
+      <InfraTechnicalCard group="processing">
+        <section aria-labelledby="settings-local-data-title">
+          <InfraTechnicalHeading icon={<Trash2 className="size-4" aria-hidden="true" />} titleId="settings-local-data-title">
+            {en ? "Local data" : "本地数据"}
+          </InfraTechnicalHeading>
+            <div className="mt-4">
+              <div className="flex flex-col items-start justify-between gap-5 sm:flex-row sm:items-end">
                 <div className="grid min-w-0 gap-1">
                   <span className="font-medium">{en ? "Clear local cache data" : "清除本地缓存数据"}</span>
-                  <span className="text-sm text-muted-foreground">{en ? "Clears schedules, drafts, BOX/layout data, settings, onboarding state, and browser cache. You may need to import and configure again." : "清除本地排班、草稿、BOX/布局数据、设置、引导状态和浏览器缓存；之后可能需要重新导入和配置。"}</span>
+                  <span className="text-sm text-white/64">{en ? "Clears schedules, drafts, BOX/layout data, settings, onboarding state, and browser cache. You may need to import and configure again." : "清除本地排班、草稿、BOX/布局数据、设置、引导状态和浏览器缓存；之后可能需要重新导入和配置。"}</span>
                 </div>
-                <Button type="button" variant="destructive" size="sm" onClick={() => {
+                <Button type="button" variant="destructive" size="dialog" className="w-full shrink-0 sm:w-auto" onClick={() => {
                   const message = en ? "This clears all local app data and browser cache entries. Continue?" : "将清除全部本地应用数据和浏览器缓存，之后可能需要重新导入和配置。继续吗？";
                   if (!window.confirm(message)) return;
                   window.localStorage.clear();
@@ -268,9 +332,8 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
                 </Button>
               </div>
             </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
+        </section>
+      </InfraTechnicalCard>
+    </StatusCenterPage>
   );
 }


### PR DESCRIPTION
设置页原先使用单张普通卡片和原生下拉菜单，与账号页及配置弹窗的样式不一致。现在复用账号页的 StatusCenter 页头和设施卡片，分为排班与导出、显示与加载、本地数据；桌面双列、窄屏单列，并调整深色卡片内的控件对比度。

四处下拉菜单统一使用现有 Combobox，保留选项、联动、禁用和本地保存行为。

验证：ESLint、TypeScript 和相关浏览器测试通过，覆盖设置保存、MAA 导出、独立班次选择、键盘操作及 375px 窄屏弹出菜单；已检查桌面和移动端截图。
