### PR TITLE
perf: 合并设置页共享分包以满足发布预算

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -99,7 +99,7 @@ const nextConfig: NextConfig = {
     cpus: 4,
     turbopackFileSystemCacheForDev: process.env.RIIC_DEV_DISK_CACHE !== "0",
     turbopackChunking: {
-      minChunkSize: 90_000,
+      minChunkSize: 130_000,
     },
   },
   typedRoutes: false,


### PR DESCRIPTION
设置页复用账号页与弹窗组件后，Turbopack 将首页脚本拆成 20 个，超过现有 18 个请求门禁。调整最小分包大小，使小脚本合并，保留页面独立加载和所有体积门禁。

与 develop CI 一致的本地构建通过：首页 16/18 个脚本，原始 JS 1,285,245/1,293,000 字节，文档 gzip 443,780/448,000 字节；所有路由预算通过。没有修改应用行为或放宽检查限制。
