### PR TITLE
release: 修复帮助页备案遮挡

### DIFF
--- a/e2e/help-back-to-top.spec.ts
+++ b/e2e/help-back-to-top.spec.ts
@@ -1,5 +1,22 @@
 import { expect, test } from "@playwright/test";
 
+test("help filing links stay clear of floating controls", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.goto("/help");
+  const filing = page.getByRole("link", { name: "沪公网安备31011502407364号" });
+  for (const width of [375, 768, 1440]) {
+    await page.setViewportSize({ width, height: 812 });
+    await filing.scrollIntoViewIfNeeded();
+    const filingBox = await filing.boundingBox();
+    const menuBox = await page.getByRole("button", { name: "帮助目录", exact: true }).boundingBox();
+    expect(filingBox).not.toBeNull();
+    expect(menuBox).not.toBeNull();
+    expect(filingBox!.x + filingBox!.width).toBeLessThanOrEqual(menuBox!.x - 8);
+    await filing.click({ trial: true, position: { x: filingBox!.width - 2, y: filingBox!.height / 2 } });
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  }
+});
+
 test("help pages provide an accessible back-to-top control", async ({ page }) => {
   await page.emulateMedia({ reducedMotion: "reduce" });
   await page.setViewportSize({ width: 375, height: 320 });

--- a/src/components/layout/InfoPageLayout.tsx
+++ b/src/components/layout/InfoPageLayout.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import { LanguageSwitch } from "@/i18n/client";
-import { cn } from "@/lib/utils";
 import { FilingLinks } from "./FilingLinks";
 
 /** Shared public-document shell: help and release notes don't load the calculator. */
@@ -38,7 +37,10 @@ export function InfoPageLayout({ title, href, contentId, children, floatingContr
       <div className="app-content-track flex-1 pb-8 sm:pb-10">
         <div id={contentId} className="min-w-0" tabIndex={-1}>{children}</div>
       </div>
-      <footer className={cn("app-content-track flex flex-wrap items-center gap-x-4 border-t border-border/80 py-5 text-xs text-muted-foreground", floatingControls && "pr-20 sm:pr-24")}>
+      <footer
+        className="app-content-track flex flex-wrap items-center gap-x-4 border-t border-border/80 py-5 text-xs text-muted-foreground"
+        style={floatingControls ? { paddingInlineEnd: "max(6rem, env(safe-area-inset-right))" } : undefined}
+      >
         <Link className="inline-flex min-h-11 items-center underline underline-offset-4 hover:text-foreground" href="/changelog">{t("changelog")}</Link>
         <Link className="inline-flex min-h-11 items-center underline underline-offset-4 hover:text-foreground" href="/terms">{t("terms")}</Link>
         <Link className="inline-flex min-h-11 items-center underline underline-offset-4 hover:text-foreground" href="/privacy">{t("privacy")}</Link>


### PR DESCRIPTION
修复帮助页窄屏底部的悬浮目录按钮遮挡公安备案号的问题。公共内容轨道的逻辑内边距覆盖了原有右侧预留空间；现明确设置页脚的逻辑右侧留白，让备案链接在空间不足时换行。

验证：Chromium 帮助页测试 2 项通过，覆盖 375、768、1440px 下备案链接避开悬浮控件、文字末端可点击、无横向溢出，以及原有回到顶部行为；相关 ESLint 通过。
