### PR TITLE
feat: 关于我们页面统一帮助页风格

### DIFF
--- a/e2e/about-page.spec.ts
+++ b/e2e/about-page.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+test("about uses the public help shell and keeps its links usable on small screens", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.goto("/about");
+  await expect(page.getByRole("heading", { level: 1, name: "关于我们" })).toBeVisible();
+  await expect(page.getByText("ABOUT US", { exact: true })).toHaveCount(0);
+  await expect(page.locator("#about-content article a[target='_blank']")).toHaveCount(5);
+  for (const link of await page.locator("#about-content article a[target='_blank']").all()) {
+    await expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  }
+  for (const width of [375, 768, 1440]) {
+    await page.setViewportSize({ width, height: 900 });
+    await expect(page.getByRole("heading", { name: "开发资料和数据来源" })).toBeVisible();
+    await expect(page.locator("footer [data-filing-links] a")).toHaveCount(2);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  }
+  await page.getByRole("button", { name: "EN", exact: true }).click();
+  await expect(page.getByRole("heading", { level: 1, name: "About", exact: true })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Development resources and data sources" })).toBeVisible();
+  await page.setViewportSize({ width: 375, height: 900 });
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true);
+  await page.reload();
+  await expect(page.getByRole("heading", { level: 1, name: "About", exact: true })).toBeVisible();
+  await page.getByRole("link", { name: "Back to Calculator", exact: true }).click();
+  await expect(page).toHaveURL(/\/$/);
+  expect(errors).toEqual([]);
+});

--- a/src/app/about/page-client.tsx
+++ b/src/app/about/page-client.tsx
@@ -2,10 +2,9 @@
 import { useTranslations, useLocale } from "next-intl";
 import { messageRecord } from "@/i18n/translate";
 
-import Link from "next/link";
 import { ArrowUpRight, Code2, Database, Github, HeartHandshake, Image as ImageIcon, MessageSquareText, UsersRound, type LucideIcon } from "lucide-react";
 
-import { LanguageSwitch } from "@/i18n/client";
+import { InfoPageLayout } from "@/components/layout/InfoPageLayout";
 
 type LinkCardItem = {
   title: string;
@@ -14,33 +13,35 @@ type LinkCardItem = {
   en: [string, string[]];
   href: string;
   icon: LucideIcon;
-  tone: string;
 };
 
 const sources: LinkCardItem[] = [
-  { title: "arknights-toolbox-data", zh: messageRecord("zh", "app_about_page_content").value as [string, string[]], en: messageRecord("en", "app_about_page_content").value as [string, string[]], href: "https://github.com/arkntools/arknights-toolbox-data", icon: Database, tone: "bg-sky-50 text-sky-700" },
-  { title: "ArknightsGameResource", zh: messageRecord("zh", "app_about_page_content2").value as [string, string[]], en: messageRecord("en", "app_about_page_content2").value as [string, string[]], href: "https://github.com/yuanyan3060/ArknightsGameResource", icon: ImageIcon, tone: "bg-indigo-50 text-indigo-700" },
-  { title: "", titleKey: "officialWebsite", zh: messageRecord("zh", "app_about_page_content3").value as [string, string[]], en: messageRecord("en", "app_about_page_content3").value as [string, string[]], href: "https://ak.hypergryph.com/", icon: Code2, tone: "bg-neutral-100 text-neutral-700" },
+  { title: "arknights-toolbox-data", zh: messageRecord("zh", "app_about_page_content").value as [string, string[]], en: messageRecord("en", "app_about_page_content").value as [string, string[]], href: "https://github.com/arkntools/arknights-toolbox-data", icon: Database },
+  { title: "ArknightsGameResource", zh: messageRecord("zh", "app_about_page_content2").value as [string, string[]], en: messageRecord("en", "app_about_page_content2").value as [string, string[]], href: "https://github.com/yuanyan3060/ArknightsGameResource", icon: ImageIcon },
+  { title: "", titleKey: "officialWebsite", zh: messageRecord("zh", "app_about_page_content3").value as [string, string[]], en: messageRecord("en", "app_about_page_content3").value as [string, string[]], href: "https://ak.hypergryph.com/", icon: Code2 },
 ];
 
 const contributionCards: LinkCardItem[] = [
-  { title: "RIIC-Web", zh: messageRecord("zh", "app_about_page_content4").value as [string, string[]], en: messageRecord("en", "app_about_page_content4").value as [string, string[]], href: "https://github.com/KnightCodeSquareMatrix/RIIC-Web", icon: Github, tone: "bg-neutral-100 text-neutral-700" },
-  { title: "", titleKey: "contribute", zh: messageRecord("zh", "app_about_page_content5").value as [string, string[]], en: messageRecord("en", "app_about_page_content5").value as [string, string[]], href: "https://github.com/KnightCodeSquareMatrix/RIIC-Web/issues", icon: MessageSquareText, tone: "bg-emerald-50 text-emerald-700" },
+  { title: "RIIC-Web", zh: messageRecord("zh", "app_about_page_content4").value as [string, string[]], en: messageRecord("en", "app_about_page_content4").value as [string, string[]], href: "https://github.com/KnightCodeSquareMatrix/RIIC-Web", icon: Github },
+  { title: "", titleKey: "contribute", zh: messageRecord("zh", "app_about_page_content5").value as [string, string[]], en: messageRecord("en", "app_about_page_content5").value as [string, string[]], href: "https://github.com/KnightCodeSquareMatrix/RIIC-Web/issues", icon: MessageSquareText },
 ];
 
-function LinkCard({ item }: { item: LinkCardItem }) {
+function ResourceLink({ item, featured = false }: { item: LinkCardItem; featured?: boolean }) {
   const t = useTranslations("app_about_page");
   const Icon = item.icon;
   const locale = useLocale();
   const en = locale === "en";
   const [description, tags] = en ? item.en : item.zh;
   return (
-    <a href={item.href} target="_blank" rel="noreferrer" className="group flex min-h-32 items-start gap-4 rounded-xl border border-neutral-200 bg-white p-4 shadow-[0_2px_8px_rgba(15,23,42,0.08)] transition duration-200 hover:-translate-y-0.5 hover:border-sky-200 hover:shadow-[0_7px_18px_rgba(15,23,42,0.11)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500">
-      <span className={`grid size-12 shrink-0 place-items-center rounded-full ${item.tone}`}><Icon className="size-6" aria-hidden="true" /></span>
+    <a href={item.href} target="_blank" rel="noopener noreferrer" className={featured
+      ? "group relative flex min-h-40 items-start gap-4 overflow-hidden bg-[#272A2B] p-5 text-white outline-none transition-[transform,box-shadow] hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-[#FFD501] motion-reduce:transform-none"
+      : "group flex items-start gap-3 px-2 py-5 outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring sm:gap-4 sm:px-3"}>
+      {featured && <span className={`absolute inset-x-0 top-0 h-1 ${item.titleKey ? "bg-[#22BBFF]" : "bg-[#FFD800]"}`} aria-hidden="true" />}
+      <Icon className={`mt-1 size-5 shrink-0 ${featured ? "text-white/64" : "text-muted-foreground"}`} aria-hidden="true" />
       <span className="min-w-0 flex-1">
-        <span className="flex items-start justify-between gap-3"><strong className="text-base font-semibold text-neutral-800">{item.titleKey ? t(item.titleKey) : item.title}</strong><ArrowUpRight className="size-4 shrink-0 text-neutral-300 transition-colors group-hover:text-sky-600" aria-hidden="true" /></span>
-        <span className="mt-1 block text-sm leading-6 text-neutral-500">{description}</span>
-        <span className="mt-3 flex flex-wrap gap-1.5">{tags.map((tag) => <span key={tag} className="rounded-md bg-sky-50 px-2 py-1 text-[11px] font-medium text-sky-600">{tag}</span>)}</span>
+        <span className="flex items-start justify-between gap-3"><strong className={`min-w-0 break-words ${featured ? "text-xl font-medium" : "text-sm font-semibold"}`}>{item.titleKey ? t(item.titleKey) : item.title}</strong><ArrowUpRight className="mt-1 size-4 shrink-0 opacity-60 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5 motion-reduce:transform-none" aria-hidden="true" /></span>
+        <span className={`mt-2 block text-sm leading-6 ${featured ? "text-white/64" : "text-muted-foreground"}`}>{description}</span>
+        <span className={`mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs ${featured ? (item.titleKey ? "text-[#22BBFF]" : "text-[#FFD800]") : "text-muted-foreground"}`}>{tags.map((tag) => <span key={tag}>{tag}</span>)}</span>
       </span>
     </a>
   );
@@ -50,33 +51,31 @@ export default function AboutPage() {
   const intl = useTranslations();
 
   return (
-    <main className="min-h-dvh bg-[#f7f7f7] px-4 py-8 text-neutral-800 sm:px-7 sm:py-12">
-      <div className="mx-auto max-w-5xl">
-        <div className="flex items-center justify-between gap-4"><Link className="inline-flex min-h-11 items-center text-sm text-neutral-500 underline underline-offset-4 hover:text-neutral-800" href="/">{intl("app_about_page.backToClosureInfrastructureTerminal")}</Link><LanguageSwitch /></div>
-        <section className="mt-5 rounded-2xl border border-neutral-200 bg-white px-5 py-7 shadow-sm sm:px-10 sm:py-10" aria-labelledby="about-title">
-          <header className="border-b border-neutral-100 pb-7">
-            <p className="text-xs font-semibold tracking-[0.16em] text-sky-600">ABOUT US</p>
-            <h1 id="about-title" className="mt-2 text-3xl font-semibold tracking-tight sm:text-4xl">{intl("app_about_page.about")}</h1>
-            <p className="mt-4 max-w-3xl text-sm leading-7 text-neutral-500 sm:text-base">{intl("app_about_page.closureInfrastructureTerminalIsAnUnofficialSchedulingAssistantFor")}</p>
+    <InfoPageLayout title={intl("app_about_page.about")} href="/about" contentId="about-content">
+        <article className="flex w-full flex-col gap-6 pt-5" aria-labelledby="about-title">
+          <header>
+            <div className="flex items-center gap-2.5">
+              <span className="h-7 w-1.5 shrink-0 bg-[#FFD501]" aria-hidden="true" />
+              <h1 id="about-title" className="text-[21px] font-medium leading-tight">{intl("app_about_page.about")}</h1>
+            </div>
+            <p className="mt-3 max-w-3xl text-sm leading-7 text-muted-foreground">{intl("app_about_page.closureInfrastructureTerminalIsAnUnofficialSchedulingAssistantFor")}</p>
           </header>
-          <section className="pt-8" aria-labelledby="source-title">
-            <h2 id="source-title" className="text-2xl font-semibold tracking-tight">{intl("app_about_page.developmentResourcesAndDataSources")}</h2>
-            <div className="mt-5 grid gap-3 md:grid-cols-2">{sources.map((item) => <LinkCard key={item.href} item={item} />)}</div>
+          <section aria-labelledby="contribution-title">
+            <h2 id="contribution-title" className="mb-3 flex items-center gap-2.5 text-sm font-medium"><span className="h-5 w-1 shrink-0 bg-[#FFD501]" aria-hidden="true" />{intl("app_about_page.developmentAndContributions")}</h2>
+            <div className="grid gap-3 md:grid-cols-2">{contributionCards.map((item) => <ResourceLink key={item.href} item={item} featured />)}</div>
           </section>
-          <section className="mt-10 border-t border-neutral-100 pt-8" aria-labelledby="contribution-title">
-            <h2 id="contribution-title" className="text-2xl font-semibold tracking-tight">{intl("app_about_page.developmentAndContributions")}</h2>
-            <div className="mt-5 grid gap-3 md:grid-cols-2">{contributionCards.map((item) => <LinkCard key={item.href} item={item} />)}</div>
+          <section aria-labelledby="source-title">
+            <h2 id="source-title" className="mb-3 flex items-center gap-2.5 text-sm font-medium"><span className="h-5 w-1 shrink-0 bg-[#22BBFF]" aria-hidden="true" />{intl("app_about_page.developmentResourcesAndDataSources")}</h2>
+            <ul className="divide-y divide-border border-y border-border">{sources.map((item) => <li key={item.href}><ResourceLink item={item} /></li>)}</ul>
           </section>
-          <section className="mt-10 border-t border-neutral-100 pt-8" aria-labelledby="support-title">
-            <h2 id="support-title" className="text-2xl font-semibold tracking-tight">{intl("app_about_page.contributorsAndSponsors")}</h2>
-            <div className="mt-5 grid gap-3 md:grid-cols-2">
-              <div className="flex min-h-32 items-start gap-4 rounded-xl border border-dashed border-neutral-200 bg-neutral-50/70 p-4"><span className="grid size-12 shrink-0 place-items-center rounded-full bg-violet-50 text-violet-600"><UsersRound className="size-6" aria-hidden="true" /></span><div><h3 className="font-semibold">{intl("app_about_page.contributors")}</h3><p className="mt-1 text-sm leading-6 text-neutral-500">{intl("app_about_page.reservedForContributorAvatarsNamesAndContributions")}</p><span className="mt-3 inline-block rounded-md bg-neutral-100 px-2 py-1 text-[11px] text-neutral-500">{intl("app_about_page.inProgress")}</span></div></div>
-              <div className="flex min-h-32 items-start gap-4 rounded-xl border border-dashed border-neutral-200 bg-neutral-50/70 p-4"><span className="grid size-12 shrink-0 place-items-center rounded-full bg-rose-50 text-rose-600"><HeartHandshake className="size-6" aria-hidden="true" /></span><div><h3 className="font-semibold">{intl("app_about_page.sponsors")}</h3><p className="mt-1 text-sm leading-6 text-neutral-500">{intl("app_about_page.reservedForSponsorNamesAvatarsAndPublicLinks")}</p><span className="mt-3 inline-block rounded-md bg-neutral-100 px-2 py-1 text-[11px] text-neutral-500">{intl("app_about_page.notOpenYet")}</span></div></div>
+          <section aria-labelledby="support-title">
+            <h2 id="support-title" className="mb-3 text-sm font-medium">{intl("app_about_page.contributorsAndSponsors")}</h2>
+            <div className="grid divide-y divide-border border-y border-border md:grid-cols-2 md:divide-x md:divide-y-0">
+              <div className="flex items-start gap-3 px-2 py-5 sm:px-3"><UsersRound className="mt-0.5 size-5 shrink-0 text-muted-foreground" aria-hidden="true" /><div className="min-w-0"><h3 className="text-sm font-semibold">{intl("app_about_page.contributors")}</h3><p className="mt-2 text-sm leading-6 text-muted-foreground">{intl("app_about_page.reservedForContributorAvatarsNamesAndContributions")}</p><span className="mt-3 block text-xs text-muted-foreground">{intl("app_about_page.inProgress")}</span></div></div>
+              <div className="flex items-start gap-3 px-2 py-5 sm:px-3"><HeartHandshake className="mt-0.5 size-5 shrink-0 text-muted-foreground" aria-hidden="true" /><div className="min-w-0"><h3 className="text-sm font-semibold">{intl("app_about_page.sponsors")}</h3><p className="mt-2 text-sm leading-6 text-muted-foreground">{intl("app_about_page.reservedForSponsorNamesAvatarsAndPublicLinks")}</p><span className="mt-3 block text-xs text-muted-foreground">{intl("app_about_page.notOpenYet")}</span></div></div>
             </div>
           </section>
-        </section>
-        <footer className="flex flex-wrap items-center justify-center gap-x-5 py-5 text-xs text-neutral-500"><Link className="inline-flex min-h-11 items-center underline underline-offset-4 hover:text-neutral-800" href="/terms">{intl("app_about_page.terms")}</Link><Link className="inline-flex min-h-11 items-center underline underline-offset-4 hover:text-neutral-800" href="/privacy">{intl("app_about_page.privacy")}</Link></footer>
-      </div>
-    </main>
+        </article>
+    </InfoPageLayout>
   );
 }


### PR DESCRIPTION
“关于我们”原先使用独立的圆角白卡布局，与帮助页的导航、内容宽度和信息层级不一致。现在复用 InfoPageLayout，统一顶部导航、语言切换、返回计算器入口及备案页脚。

项目和贡献入口改为帮助页同款深色卡片；数据来源改为分隔列表，贡献者及赞助者区域使用简洁分栏。保留原有说明和全部外部链接，移除 ABOUT US 英文装饰，补齐外部链接保护和减少动画偏好。

验证：相关 ESLint、TypeScript、国际化检查通过；Chromium 用例验证 375/768/1440px 无溢出、资源链接、备案页脚、中英文切换及持久化、返回计算器导航。桌面和手机截图已检查。
