### PR TITLE
feat: 增加基建无功能干员高亮

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2068,6 +2068,7 @@ function WorkbenchAppContent({ children }: { children: ReactNode }) {
       showFeedback: userSettings.showFeedback,
       showImages: userSettings.showImages,
       allowReplacementOperatorSort: userSettings.allowReplacementOperatorSort,
+      highlightNoLayoutSkill: userSettings.highlightNoLayoutSkill,
     },
     manual: {
       layout,

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -1126,6 +1126,7 @@ export function OperatorSlot({
   searchQuery = "",
   onActivate,
   unavailable = false,
+  highlightNoLayoutSkill = false,
   sortSelected = false,
   onSortActivate,
 }: {
@@ -1157,6 +1158,7 @@ export function OperatorSlot({
   searchQuery?: string;
   onActivate?: () => void;
   unavailable?: boolean;
+  highlightNoLayoutSkill?: boolean;
   sortSelected?: boolean;
   onSortActivate?: () => void;
 }) {
@@ -1181,7 +1183,9 @@ export function OperatorSlot({
     ? `${occupantAriaLabel}${intl("components.focusToViewInfrastructureSkills")}`
     : occupantAriaLabel;
   const searchMatched = Boolean(slot && searchQuery && slot.name.toLocaleLowerCase("zh-CN").includes(searchQuery));
-  const frameClassName = sortSelected
+  const frameClassName = highlightNoLayoutSkill
+    ? "border-[#F59E0B] bg-[#3C3C3C] shadow-[0_0_0_2px_rgba(245,158,11,0.45)]"
+    : sortSelected
     ? "border-[#FFD800] bg-[#3C3C3C] ring-2 ring-[#FFD800]/70"
     : slot
     ? "border-[#7F7F7F] bg-[#3C3C3C] shadow-[inset_0_0_18px_rgba(255,255,255,0.16)]"
@@ -1359,6 +1363,8 @@ export function ScheduleBoard({
   droneTargetRoomId,
   onDroneTargetChange,
   renderListRoomActions,
+  highlightNoLayoutSkill = false,
+  noLayoutSkillOperators,
 }: {
   rows: RoomRow[];
   layout: BaseBlueprint;
@@ -1394,6 +1400,8 @@ export function ScheduleBoard({
   droneTargetRoomId?: string | null;
   onDroneTargetChange?: (row: RoomRow) => void;
   renderListRoomActions?: (row: RoomRow, position: "header" | "clear") => ReactNode;
+  highlightNoLayoutSkill?: boolean;
+  noLayoutSkillOperators?: ReadonlySet<string>;
 }) {
   const intl = useTranslations();
   const locale = useLocale();
@@ -1827,6 +1835,7 @@ export function ScheduleBoard({
                             onActivate={onSlotClick ? () => onSlotClick(row, index) : undefined}
                             sortSelected={sortSelection?.roomId === row.roomId && sortSelection.slotIndex === index}
                             onSortActivate={sortRoomId === row.roomId && onSortSlotClick ? () => onSortSlotClick(row, index) : undefined}
+                            highlightNoLayoutSkill={highlightNoLayoutSkill && Boolean(slot) && noLayoutSkillOperators?.has(slot?.name ?? "")}
                           />
                         ))}
                       </div>

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -384,6 +384,7 @@ export interface InfraCalculatorProps {
   showFeedback?: boolean;
   showImages?: boolean;
   allowReplacementOperatorSort?: boolean;
+  highlightNoLayoutSkill?: boolean;
   onClearResultNotice: () => void;
   onDismissResultClearWarning: () => void;
 }
@@ -404,7 +405,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
     onFactoryRecipeChange, onTradeOrderChange, droneTargetRoomId, onDroneTargetChange,
     onSwapOperators,
     onEditManualSchedule, onDownloadMaa, onDownloadImage, showProgressionRecalculate = true, showManualScheduleEdit = true, scheduleViewControl = "tabs", shiftViewControl = "tabs", imageExportScope = "single", showFeedback = true, showImages = true,
-    onClearResultNotice, onDismissResultClearWarning, allowReplacementOperatorSort = false,
+    onClearResultNotice, onDismissResultClearWarning, allowReplacementOperatorSort = false, highlightNoLayoutSkill = false,
   } = props;
 
   const eliteByOperator = useMemo(() => {
@@ -429,7 +430,6 @@ export function InfraCalculator(props: InfraCalculatorProps) {
   const [imageExportFailed, setImageExportFailed] = useState(false);
   const [sortRoomId, setSortRoomId] = useState<string | null>(null);
   const [sortSelection, setSortSelection] = useState<{ roomId: string; slotIndex: number } | null>(null);
-  const [highlightNoLayoutSkill, setHighlightNoLayoutSkill] = useState(false);
   const layoutSkillPrefixes = useMemo(() => new Set(layout.rooms.map((room) => ({ control_center: "control", trade_post: "trade", factory: "manu", power_plant: "power", dormitory: "dormitory", office: "hire", meeting_room: "meet", workshop: "workshop", training_room: "train" } as Record<string, string>)[room.kind]).filter(Boolean)), [layout]);
   const noLayoutSkillOperators = useMemo(() => new Set(OPERATOR_CATALOG.filter((operator) => !operator.buildingSkills.some((skill) => layoutSkillPrefixes.has(buildingSkillPrefixFor(skill.id)))).map((operator) => operator.name)), [layoutSkillPrefixes]);
   const imageExportInFlight = useRef(false);
@@ -732,7 +732,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                 onOpenSetup={onOpenSetup}
                 onDismissOnboarding={onDismissOnboarding}
               />
-            ) : rows.length > 0 ? <><div className="mb-3 flex justify-end"><Button type="button" variant={highlightNoLayoutSkill ? "default" : "outline"} size="sm" onClick={() => setHighlightNoLayoutSkill((value) => !value)} aria-pressed={highlightNoLayoutSkill}><SlidersHorizontal />{highlightNoLayoutSkill ? "关闭无布局功能高亮" : "高亮无布局功能干员"}</Button></div><ScheduleBoard
+            ) : rows.length > 0 ? <ScheduleBoard
               rows={rows}
               layout={layout}
               planRevision={scheduleResult?.diagnosticId}
@@ -774,7 +774,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
               noLayoutSkillOperators={noLayoutSkillOperators}
               droneTargetRoomId={droneTargetRoomId}
               onDroneTargetChange={manualDroneSelection ? onDroneTargetChange : undefined}
-            /></> : (
+            /> : (
               <div className="flex min-h-[420px] items-center justify-center border-y border-dashed border-border/70 py-6 text-center text-sm text-muted-foreground">
                 {intl("components_pages_InfraCalculator.noLayoutRoomsToDisplay")}
               </div>

--- a/src/components/pages/InfraCalculator.tsx
+++ b/src/components/pages/InfraCalculator.tsx
@@ -26,6 +26,7 @@ import { cn } from "@/lib/utils";
 import type { ShiftDirection } from "@/motion";
 import { onboardingStepStatuses, shouldShowAnonymousSampleTrial } from "@/onboarding";
 import type { RoomRow } from "@/schedule";
+import { buildingSkillPrefixFor, OPERATOR_CATALOG } from "@/operatorPortraits";
 import type {
   BaseBlueprint,
   FeedbackData,
@@ -428,6 +429,9 @@ export function InfraCalculator(props: InfraCalculatorProps) {
   const [imageExportFailed, setImageExportFailed] = useState(false);
   const [sortRoomId, setSortRoomId] = useState<string | null>(null);
   const [sortSelection, setSortSelection] = useState<{ roomId: string; slotIndex: number } | null>(null);
+  const [highlightNoLayoutSkill, setHighlightNoLayoutSkill] = useState(false);
+  const layoutSkillPrefixes = useMemo(() => new Set(layout.rooms.map((room) => ({ control_center: "control", trade_post: "trade", factory: "manu", power_plant: "power", dormitory: "dormitory", office: "hire", meeting_room: "meet", workshop: "workshop", training_room: "train" } as Record<string, string>)[room.kind]).filter(Boolean)), [layout]);
+  const noLayoutSkillOperators = useMemo(() => new Set(OPERATOR_CATALOG.filter((operator) => !operator.buildingSkills.some((skill) => layoutSkillPrefixes.has(buildingSkillPrefixFor(skill.id)))).map((operator) => operator.name)), [layoutSkillPrefixes]);
   const imageExportInFlight = useRef(false);
 
   function toggleSortMode(row: RoomRow) {
@@ -728,7 +732,7 @@ export function InfraCalculator(props: InfraCalculatorProps) {
                 onOpenSetup={onOpenSetup}
                 onDismissOnboarding={onDismissOnboarding}
               />
-            ) : rows.length > 0 ? <ScheduleBoard
+            ) : rows.length > 0 ? <><div className="mb-3 flex justify-end"><Button type="button" variant={highlightNoLayoutSkill ? "default" : "outline"} size="sm" onClick={() => setHighlightNoLayoutSkill((value) => !value)} aria-pressed={highlightNoLayoutSkill}><SlidersHorizontal />{highlightNoLayoutSkill ? "关闭无布局功能高亮" : "高亮无布局功能干员"}</Button></div><ScheduleBoard
               rows={rows}
               layout={layout}
               planRevision={scheduleResult?.diagnosticId}
@@ -766,9 +770,11 @@ export function InfraCalculator(props: InfraCalculatorProps) {
               onSortSlotClick={allowReplacementOperatorSort && onSwapOperators ? handleSortSlotClick : undefined}
               viewModeControl={scheduleViewControl}
               hideImages={!showImages}
+              highlightNoLayoutSkill={highlightNoLayoutSkill}
+              noLayoutSkillOperators={noLayoutSkillOperators}
               droneTargetRoomId={droneTargetRoomId}
               onDroneTargetChange={manualDroneSelection ? onDroneTargetChange : undefined}
-            /> : (
+            /></> : (
               <div className="flex min-h-[420px] items-center justify-center border-y border-dashed border-border/70 py-6 text-center text-sm text-muted-foreground">
                 {intl("components_pages_InfraCalculator.noLayoutRoomsToDisplay")}
               </div>

--- a/src/components/pages/UserSettingsPage.tsx
+++ b/src/components/pages/UserSettingsPage.tsx
@@ -269,6 +269,13 @@ export function UserSettingsPage({ settings, onSettingsChange }: UserSettingsPag
               />
             </div>
             <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
+              <Label htmlFor="highlight-no-layout-skill" className="grid min-w-0 gap-1">
+                <span>{en ? "Highlight operators without layout skills" : "高亮当前布局无功能干员"}</span>
+                <span className="font-normal text-sm text-white/64">{en ? "Highlight operators with no usable infrastructure skill in the current layout. Off by default." : "高亮当前基建布局内没有可用基建技能的干员，默认关闭。"}</span>
+              </Label>
+              <Switch className={SETTINGS_SWITCH_CLASS} id="highlight-no-layout-skill" checked={settings.highlightNoLayoutSkill} onCheckedChange={(checked) => onSettingsChange({ ...settings, highlightNoLayoutSkill: checked })} aria-label={en ? "Highlight operators without layout skills" : "高亮当前布局无功能干员"} />
+            </div>
+            <div className="flex items-center justify-between gap-6 border-t border-white/12 pt-4">
               <Label htmlFor="load-english-resources" className="grid min-w-0 gap-1">
                 <span>{en ? "Load English resources" : "加载英文资源"}</span>
                 <span className="font-normal text-sm text-white/64">{en ? "When off, English game data is not requested." : "关闭后不请求英文干员名、房间名和技能数据。"}</span>

--- a/src/user-settings.test.ts
+++ b/src/user-settings.test.ts
@@ -34,7 +34,8 @@ test("user settings persist and fall back to defaults", () => {
   persistUserSettings(storage, {
     strictMaaOperatorOrder: false,
     showProgressionRecalculate: false,
-  showManualScheduleEdit: false,
+    showManualScheduleEdit: false,
+    highlightNoLayoutSkill: true,
   scheduleViewControl: "select",
   linkShiftViewControl: false,
   shiftViewControl: "select",
@@ -45,11 +46,12 @@ test("user settings persist and fall back to defaults", () => {
     showImages: false,
     allowReplacementOperatorSort: true,
 });
-assert.equal(storage.getItem(USER_SETTINGS_STORAGE_KEY), "{\"strictMaaOperatorOrder\":false,\"showProgressionRecalculate\":false,\"showManualScheduleEdit\":false,\"scheduleViewControl\":\"select\",\"linkShiftViewControl\":false,\"shiftViewControl\":\"select\",\"imageExportScope\":\"all\",\"loadEnglishResources\":false,\"skillPagination\":\"manual\",\"showFeedback\":false,\"showImages\":false,\"allowReplacementOperatorSort\":true}");
+assert.equal(storage.getItem(USER_SETTINGS_STORAGE_KEY), "{\"strictMaaOperatorOrder\":false,\"showProgressionRecalculate\":false,\"showManualScheduleEdit\":false,\"highlightNoLayoutSkill\":true,\"scheduleViewControl\":\"select\",\"linkShiftViewControl\":false,\"shiftViewControl\":\"select\",\"imageExportScope\":\"all\",\"loadEnglishResources\":false,\"skillPagination\":\"manual\",\"showFeedback\":false,\"showImages\":false,\"allowReplacementOperatorSort\":true}");
 assert.deepEqual(loadUserSettings(storage), {
   strictMaaOperatorOrder: false,
   showProgressionRecalculate: false,
   showManualScheduleEdit: false,
+  highlightNoLayoutSkill: true,
   scheduleViewControl: "select",
   linkShiftViewControl: false,
   shiftViewControl: "select",

--- a/src/user-settings.ts
+++ b/src/user-settings.ts
@@ -5,6 +5,7 @@ export interface UserSettings {
   strictMaaOperatorOrder: boolean;
   showProgressionRecalculate: boolean;
   showManualScheduleEdit: boolean;
+  highlightNoLayoutSkill: boolean;
   scheduleViewControl: "tabs" | "select";
   linkShiftViewControl: boolean;
   shiftViewControl: "tabs" | "select";
@@ -20,6 +21,7 @@ export const DEFAULT_USER_SETTINGS: UserSettings = {
   strictMaaOperatorOrder: true,
   showProgressionRecalculate: true,
   showManualScheduleEdit: true,
+  highlightNoLayoutSkill: false,
   scheduleViewControl: "tabs",
   linkShiftViewControl: true,
   shiftViewControl: "tabs",


### PR DESCRIPTION
## 变更内容

新增独立 Mower 基建排班编辑器，支持主表与副表、设施选择、三类生产站拖动交换、Box 选人、宿舍 Fill Free、生产配置、心情规则、帮助说明以及 Mower/MAA 导入导出。

## 实现范围

- 新增 /mower 页面和侧边栏入口
- 新增 Mower plan 数据适配与本地草稿持久化
- 复用现有干员 Box、头像、技能筛选和基础设施组件
- 设置中新增 Mower 显示开关，默认关闭
- 设置中新增“高亮当前布局无功能干员”，默认关闭
- 基建计算器支持高亮当前布局没有可用基建技能的干员
- 手动排班支持 Mower 计划导入导出

## 默认行为与兼容性

Mower 入口和无布局功能高亮默认关闭。旧 MAA 排班与设置数据保持兼容；Mower 草稿单独保存在浏览器本地。

## 验证结果

- [x] Mower 适配单元测试通过
- [x] 设置持久化测试通过
- [x] 针对性 ESLint 检查通过
- [x] TypeScript 检查通过
- [x] git diff --check 通过
- [x] 本地 5174 页面可访问

## 注意事项

自动操控设备、运行日志和后端执行接口不在本 PR 范围内。